### PR TITLE
redirect settings help icon

### DIFF
--- a/0001-use-64-bit-WebView-processes.patch
+++ b/0001-use-64-bit-WebView-processes.patch
@@ -1,7 +1,7 @@
-From acf4f6b173370304341ff48b2a6e3c5f5fc3a059 Mon Sep 17 00:00:00 2001
+From 4212e6110c35a42d5d830c345459666a9a26cf1a Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Thu, 26 Jan 2017 01:30:12 -0500
-Subject: [PATCH 01/46] use 64-bit WebView processes
+Subject: [PATCH 01/47] use 64-bit WebView processes
 
 ---
  android_webview/apk/java/AndroidManifest.xml | 1 -
@@ -20,5 +20,5 @@ index bca5a6bdcf82..1b321d04f5a7 100644
          {# This part is shared between stand-alone WebView and Monochrome #}
          {% macro common(manifest_package, webview_lib) %}
 -- 
-2.22.0
+2.21.0
 

--- a/0002-use-64-bit-Monochrome-processes.patch
+++ b/0002-use-64-bit-Monochrome-processes.patch
@@ -1,7 +1,7 @@
-From 0f51cd563e18ef36d8f05d7eb2850b1d74255b14 Mon Sep 17 00:00:00 2001
+From 5a946efebf80ceb9cfb006db7ad52dc6bfcedee6 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Wed, 1 May 2019 11:39:59 -0400
-Subject: [PATCH 02/46] use 64-bit Monochrome processes
+Subject: [PATCH 02/47] use 64-bit Monochrome processes
 
 ---
  chrome/android/BUILD.gn | 7 +++++++
@@ -26,5 +26,5 @@ index 17311184c478..cdb97d71d90c 100644
  
  if (public_android_sdk) {
 -- 
-2.22.0
+2.21.0
 

--- a/0003-switch-to-fstack-protector-strong.patch
+++ b/0003-switch-to-fstack-protector-strong.patch
@@ -1,7 +1,7 @@
-From fb051b0e3f4e549428a401eea7f3a542ae8b5fc7 Mon Sep 17 00:00:00 2001
+From bb2f806c9b9413de270b0d3e23161fadf5f71b39 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Wed, 26 Dec 2018 10:20:24 -0500
-Subject: [PATCH 03/46] switch to -fstack-protector-strong
+Subject: [PATCH 03/47] switch to -fstack-protector-strong
 
 ---
  build/config/compiler/BUILD.gn | 6 +-----
@@ -30,5 +30,5 @@ index a3f21b7ef850..d0679c35c1eb 100644
      }
  
 -- 
-2.22.0
+2.21.0
 

--- a/0004-enable-fwrapv-in-Clang-for-non-UBSan-builds.patch
+++ b/0004-enable-fwrapv-in-Clang-for-non-UBSan-builds.patch
@@ -1,7 +1,7 @@
-From 2082f54e6eb48fa65044f707fc72ca9c74ac072c Mon Sep 17 00:00:00 2001
+From a6171a7bbe16a17c660fbb78c8f5b3eaee6137ad Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Thu, 22 Dec 2016 07:15:34 -0500
-Subject: [PATCH 04/46] enable -fwrapv in Clang for non-UBSan builds
+Subject: [PATCH 04/47] enable -fwrapv in Clang for non-UBSan builds
 
 ---
  build/config/compiler/BUILD.gn | 4 ++++
@@ -23,5 +23,5 @@ index d0679c35c1eb..00cff1a45a98 100644
      if (fatal_linker_warnings && !(is_chromeos && current_cpu == "arm") &&
          !(is_android && use_order_profiling) && !is_mac && !is_ios &&
 -- 
-2.22.0
+2.21.0
 

--- a/0005-Vanadium-branding.patch
+++ b/0005-Vanadium-branding.patch
@@ -1,7 +1,7 @@
-From 81438b32344c637a8f7ca931900660c193c3beb1 Mon Sep 17 00:00:00 2001
+From c925f4e0b40a6d4415f5c5f7963dcd64a2f25f98 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Sun, 6 Aug 2017 12:45:14 -0400
-Subject: [PATCH 05/46] Vanadium branding
+Subject: [PATCH 05/47] Vanadium branding
 
 Current incantation of the recolor command:
 
@@ -105,7 +105,7 @@ new file mode 100644
 index 0000000000000000000000000000000000000000..d9d6661c938b2907e30da3ae87cdb2894db5592d
 GIT binary patch
 literal 11327
-zc-jF!EWp!=P)<h;3K|Lk000e1NJLTq006@P006@X1ONa4m3D0*00002VoOIv0RM-N
+zcmV-FEWp!=P)<h;3K|Lk000e1NJLTq006@P006@X1ONa4m3D0*00002VoOIv0RM-N
 z%)bBtEBHx7K~#9!?VWj)99MnsKlfJkKKmk#mXTyhSd#Y*%Ra`5ZCUog#tV)yF&KC+
 z<|GDU90K9Jge8O+2<PDNut@^%ybwqX4mOD~#x|Rm=jGuAZ?Y}P+NBwdW}lwvwYsb7
 zzCWs$s-B*i?&)QO$#0HE)79N|Z~eaax7^?T-QN}0Q9VgAq==9~B1y1@DNLZ1EKwAS
@@ -326,14 +326,14 @@ zJ0a3!Go$*HoHB+u);$m(um^Pmpo6HZ%F^*i{~yS0JYSiOkN*Gw002ovPDHLkV1iRV
 Bx8MK(
 
 literal 0
-Hc-jL100001
+HcmV?d00001
 
 diff --git a/chrome/android/java/res_vanadium/drawable-hdpi/product_logo_name.png b/chrome/android/java/res_vanadium/drawable-hdpi/product_logo_name.png
 new file mode 100644
 index 0000000000000000000000000000000000000000..8678cbbb730de9c3ff9d3dba7d928d60f28bd550
 GIT binary patch
 literal 1998
-zc-jHZ2Qm1GP)<h;3K|Lk000e1NJLTq005f+001Be1ONa4uVuoq00002VoOIv0RM-N
+zcmV;<2Qm1GP)<h;3K|Lk000e1NJLTq005f+001Be1ONa4uVuoq00002VoOIv0RM-N
 z%)bBt2Zu>SK~!ko<=J0sWOWq>@Xx*Tue$}h(?xgL^$(e{1YKD$ttiGof~^Vx9)MOu
 zG$zJ$V+<<#(2`(G2$D7sv-n`r`s9OR+7Oj!jP4K>9x$+jvMdlpCd<G5<L-9a?Y7g-
 zOlN%PbUM?eP`V|f@STVG{k!LP&i9^kf9KpA+yX)cp|aCLam8fei-l{8d&(cGTp%zN
@@ -374,14 +374,14 @@ zza1|{8eS^B9}!%))KF3pS28cMJ#j<i+Hm*uwq56aHaKx+;rQJ1`Nz)uvHbcbt!9+#
 gs)YxeZ9!A;U++Vmx7pctfdBvi07*qoM6N<$g5_ZC5&!@I
 
 literal 0
-Hc-jL100001
+HcmV?d00001
 
 diff --git a/chrome/android/java/res_vanadium/drawable-mdpi/fre_product_logo.png b/chrome/android/java/res_vanadium/drawable-mdpi/fre_product_logo.png
 new file mode 100644
 index 0000000000000000000000000000000000000000..40b88b5225ddff2fb47116a99a38999218e744ec
 GIT binary patch
 literal 6794
-zc-jGq8g=D~P)<h;3K|Lk000e1NJLTq004pj004pr1ONa4APU%a00002VoOIv0RM-N
+zcmV;58g=D~P)<h;3K|Lk000e1NJLTq004pj004pr1ONa4APU%a00002VoOIv0RM-N
 z%)bBt8be7$K~#9!)tz~iB*lH_KM{G<)z|bjJ@>)D%!mO-Fw7-DAPmTokc7~a^mM>3
 zZzcS8pLT_9R@Sb(&)T)*U3n#2eztCw(_%quSrW30g+~aD#AO%`F)++9!yMhycU9M2
 zm6esTe`IDI-BsOnwFSR?U7eMc85!}--xa_3MWpxuOOYgpLdU@%#5jW(oWUeO8V!Yp
@@ -514,14 +514,14 @@ zhj>D$5MmkU-7e!>Q2kdIXfIhW74NXI16-hOVT5&Tll`hE8(I@M7MRpEgsm*{#hgm!
 s;^t9aPfn=Q!52i_!lZI+YPsnD1F3svQs!l<l>h($07*qoM6N<$g1%n2wg3PC
 
 literal 0
-Hc-jL100001
+HcmV?d00001
 
 diff --git a/chrome/android/java/res_vanadium/drawable-mdpi/product_logo_name.png b/chrome/android/java/res_vanadium/drawable-mdpi/product_logo_name.png
 new file mode 100644
 index 0000000000000000000000000000000000000000..5f92063170520afa34dd48fa6610ea122439e916
 GIT binary patch
 literal 1200
-zc-jH51W)^kP)<h;3K|Lk000e1NJLTq003tI000#T1ONa4@uE1m00002VoOIv0RM-N
+zcmV;h1W)^kP)<h;3K|Lk000e1NJLTq003tI000#T1ONa4@uE1m00002VoOIv0RM-N
 z%)bBt1Zhb`K~z}7&DURyTy+%(@Xx(>_FsX@O}84i3U(VMgzx}UVwc9o;1FXpBtoWy
 z2j6rWUf_X*Ex|`ac1+~Kw;kh?hR6=+gBnd1V-!O{cS$sAG|)-^n3k4yW}(~d?#%4H
 zJk0Ig(t_M=8p?UO_x{fBob&yjbAEqr@Ss2<(bv_zXSLeh+uv!6mFS39qGs}1Psy+Z
@@ -547,14 +547,14 @@ z^+sAqN|1`A|9R&d!QRnoG_`We?y>N~$>SGZU49|`b6{BT;s2taFnJGY>5Ee&#m%|^
 O0000<MNUMnLSTZ4d0|-q
 
 literal 0
-Hc-jL100001
+HcmV?d00001
 
 diff --git a/chrome/android/java/res_vanadium/drawable-xhdpi/fre_product_logo.png b/chrome/android/java/res_vanadium/drawable-xhdpi/fre_product_logo.png
 new file mode 100644
 index 0000000000000000000000000000000000000000..07ecccb90a3786c3c3d7ac33a3f8cb2d2ee555b2
 GIT binary patch
 literal 16100
-zc-jHvJ{!S_P)<h;3K|Lk000e1NJLTq009I5009ID1ONa4WC4PK00002VoOIv0RM-N
+zcmV<AJ{!S_P)<h;3K|Lk000e1NJLTq009I5009ID1ONa4WC4PK00002VoOIv0RM-N
 z%)bBtKAlNKK~#9!?Y()N9A|y!|9+mT>T52|jP6^OWZ9N1VOvH9-zHeb#!fgw4%lQv
 z$ijkcSV%%nLjpgJCFC%egaq>2WV4%1AUFXM8<TL^1|O0SNyfU5(Tp@#&(+g+RXzJh
 zbx&7!Rrhqy^fjzM^HOW3y6UOt_&(q3`99xAyqU#AATUW`(?ymf-K5CSOD`ws#wNu|
@@ -866,14 +866,14 @@ zHcQ#BHdrh4<*AJ_B6{r&$*>;S8h$!F714vru|u<1B12pyR4S0QllFOiQcu_e_IP%D
 q!#O!IXc-t}kqB(e_H@WD3jY_Ejr#a36nZuQ0000<MNUMnLSTZIDYe}I
 
 literal 0
-Hc-jL100001
+HcmV?d00001
 
 diff --git a/chrome/android/java/res_vanadium/drawable-xhdpi/product_logo_name.png b/chrome/android/java/res_vanadium/drawable-xhdpi/product_logo_name.png
 new file mode 100644
 index 0000000000000000000000000000000000000000..ee268c83d97f8d6b73eac0dbe25a204dcc91d4da
 GIT binary patch
 literal 2609
-zc-jFm3eNS3P)<h;3K|Lk000e1NJLTq007Pa001fo1ONa4QNyg;00002VoOIv0RM-N
+zcmV-13eNS3P)<h;3K|Lk000e1NJLTq007Pa001fo1ONa4QNyg;00002VoOIv0RM-N
 z%)bBt3F=8iK~#9!?VEp$9Az2DKl9G)>|MKe?OY3KEzmHhZ7oJh_b?bl5q6Cl$`8$6
 zVyeMtyrsqjL?Wkupu|7C13_#I&?Eea{E9vN5hVoEGmQ!{$}OUR0>T#Bv=rLj-0j}p
 z?#}Mc_{YxP?flr@59Y4e+;@|^n`hsd?>o=)KF|BS&-<SA1?mt~siI;sg@r%{tPPb<
@@ -926,14 +926,14 @@ zR{4SA1I10^GC3}7F0I#ApB+75niI9R&DV<0m-ZK5R*5d?U#*rgcSy_XegEQref)de
 TPbPHy00000NkvXXu0mjf*Ld(I
 
 literal 0
-Hc-jL100001
+HcmV?d00001
 
 diff --git a/chrome/android/java/res_vanadium/drawable-xxhdpi/fre_product_logo.png b/chrome/android/java/res_vanadium/drawable-xxhdpi/fre_product_logo.png
 new file mode 100644
 index 0000000000000000000000000000000000000000..4f300d7f849b005ba63163d63a643f3aeb737aea
 GIT binary patch
 literal 26693
-zc-jCpK+3;~P)<h;3K|Lk000e1NJLTq00D*o00D*w1ONa4)rszI00002VoOIv0RM-N
+zcmV)WK(4=uP)<h;3K|Lk000e1NJLTq00D*o00D*w1ONa4)rszI00002VoOIv0RM-N
 z%)bBtXZ}e<K~#9!?Y(!LBu9Ps|E}tuxOs2)a#YSbC6rMH1Ok&yFg9R#z!)AIunpLL
 z%wufxke!VaVEiK*3?>O1Bmol20R<$TPP(+WySF*bPV7*>KYC`TXQroTW_M<HW_CaQ
 zy4&5E>h9|5`qVenx4tD_$?8A=kjBJDrvsA(Bz>49u+a!}I!}@z!wwdh;UrRoh%-qC
@@ -1249,7 +1249,7 @@ zdcKKqUq4ciB!{qTmJ6-Wr*uL*_0Tg2KpGerq@K0fPBJ*qNO3#8zT<uz$-B{8IEHn3
 z5G2ug55gx)5<nM6+b~wufriD%p(7mSsG}z7$fu09GoisrTOZ*OCh77ir8C53+`>W=
 zkzqAfmrLe(DVH+jn;lOl#X&6e8Z#xe261c>!<(Mk&NjB?#DU0|Pqs$oYlT2#m^;{1
 zK?R!U{p?|;N#x^dybFzK_VRna>lZ-L&9j^!*y2l}ydlV7{<7cbp@$x1m@r|YaDTh3
-zcPoBe8^Jv+(B;#`0T3wf*90>}crP?X+R4?Rf+UIHeT13ued0h?E@(BTlWdKlRiKF9
+zcPoBe8^Jv+(B;#`1T#c<FEmBk$<?5OB#GdCgqiVu;y_j|Xf>vj0rV#e*ldlVRiKF9
 zzd)QAF{Fisg^lsB*(9T4{U12UP(|6GGsHFgDzj_+8dobLmCYQl<C+R8l1(=UnIKeS
 z{=C+pg0lxv`oY}h?#>J}7UE&M3C6_6;YUo+U*RQ9^M1}{x^BBzHZL@$Igj@-U7=i*
 zMSh7u)-+JI3Kc*jsgl3QkS0w!_ly!XY&^QwRcjOkL5}l%)#Lk`1Pd5^jQ$FN%#Fip
@@ -1449,14 +1449,14 @@ zmdO6dLevV2PCKFk1e8tyg&_<~Vak+T6mgOyRl46yrqzfT&dhB~rQ@;TuHku8A=pF*
 gCy1=|1GgRie-#m>m)v0)5&!@I07*qoM6N<$f-sBn4*&oF
 
 literal 0
-Hc-jL100001
+HcmV?d00001
 
 diff --git a/chrome/android/java/res_vanadium/drawable-xxhdpi/product_logo_name.png b/chrome/android/java/res_vanadium/drawable-xxhdpi/product_logo_name.png
 new file mode 100644
 index 0000000000000000000000000000000000000000..fc327262fd9479d15200e5ebca3f5335a1ce12c4
 GIT binary patch
 literal 4270
-zc-jH35K-@mP)<h;3K|Lk000e1NJLTq00A`s002J-1ONa4EBcpR00002VoOIv0RM-N
+zcmV;f5K-@mP)<h;3K|Lk000e1NJLTq00A`s002J-1ONa4EBcpR00002VoOIv0RM-N
 z%)bBt5NAn5K~#9!?VVe28`pWqe`j}b;Y}oD-6h)*Bwyq{=mJ@mRC}5zU^<Q`Gqz+Z
 zeTeH!(@;q|(_}iGkvxslNj>RMO&_Z1q%mnH(^#G+rXu^L^(CS+aZ^=^B}kQ%Sh6F*
 zvUQ^rkst|@xGb>S2P_r~VlR*kg0O`@W(W{x&+fOoe|+aV-{q{>jujFrDn4X#q|wQs
@@ -1541,14 +1541,14 @@ z*2`;HlJ4qiTN*q=E}fs&#<Ev(?_^F){hCug1Ockg5ozLPfoK}+P1Fbf4>8lX6)B~&
 QLI3~&07*qoM6N<$f)Jt_fB*mh
 
 literal 0
-Hc-jL100001
+HcmV?d00001
 
 diff --git a/chrome/android/java/res_vanadium/drawable-xxxhdpi/fre_product_logo.png b/chrome/android/java/res_vanadium/drawable-xxxhdpi/fre_product_logo.png
 new file mode 100644
 index 0000000000000000000000000000000000000000..52abcdfc19c13770971730c8bd4d8267a633ac22
 GIT binary patch
 literal 39011
-zc-jC^K(D`vP)<h;3K|Lk000e1NJLTq00IaA00IaI1ONa4q4nPA00002VoOIv0RM-N
+zcmV)xK$E|TP)<h;3K|Lk000e1NJLTq00IaA00IaI1ONa4q4nPA00002VoOIv0RM-N
 z%)bBtfB;EEK~#9!?45U<Bu9Dozg686H{RY}4!S!@r;~KbIR}u)29a!IW57g%jcpvk
 z*v7^YkWF#`1I9MI7>j5yK}Z5cKmiFPp?tcy;WqD1?ojU^J+qT~W_o64cEa{=KGN+>
 zcXd})S3UjYN4%U)f<TbQL}8<$6GAeJKr%ppX#$u?G&IiV3C4(GBH78~gpi!VA)*ZN
@@ -1864,8 +1864,8 @@ zAtnhgKOCs$P3V5aDezV6u~v$0uvy^wynth#$$`xf0p8CnqrUc_F4zn*#b5GChFJ2r
 z5hb(i=REEqMHn5c!e*%UTlq2X-i@Ux&b;~)*1AtUB%suzu^jo8u(a1K;J{=qAA117
 z!d2dV!`cB!f;4BKm+9y$SJ-pk0t(y1o7z1i&Jz9n36_gjL?sA@`8W?U($2}F`^bTV
 z^*q4G8L4AsDl%NlAW4$cryp=XCOmKGVtYX)jYXxF-uwru!(BsBK0`UJ2P|A3BeDFE
-zIs2oD-DjQFsTzblrrE-d0)GVe?1;5;Ce}w1@(@6b=d!PkgkKf_P(ZK0JNPkQAX1Y2
-z)rS{2RiwYbee9^i+Az-!&Lu+z1Kopup!8T}iM?7oQTE-texSSu)rnT+D|xwRPGr^q
+zIs2oD-DjQFsTzblrrE-d0)GVe?1;5;Ce}w1@(@6b=d!PkgkKgr_%UA~Qj+}DhZi_i
+zq`$y@?5M-qFwYLoB|`=P(m*Z01Kopup!8T}iM?7oQTE-texSSu)rnT+D|xwRPGr^q
 z`z$M*w=~KW&L>Us;`GKAKG~)~Vz9s&L|t5z>Vtp^9`EkwI?z~Rh~FcD>5+l8Sx1}?
 zVbJG`3k~+WAA=8)tRsnx%@UU}LNaTnZj>J=wL>V^mhRuZ^8;>%L~kO3C~N8M%tG>J
 zYzkl0znn2?c~vXqS%%i>{DG6baFD%D{YlEziPbrW{PZ~RW^pJyKhBHT$FxTkmqIeg
@@ -2181,10 +2181,10 @@ zNnf2<2ZGFV7&#Sq5%Z!T1<mSWRjmw#kO+8If0gm=neZqf49^qbZ}*j=R=9KSn<z@G
 zn)^McHOPA^sDi&u5(K#pjhLToy$*y};u&O8e^us?f!Vg1)8lQqts>(H3O~?ZpZV_@
 zMhPtE{r9o@a93U_SF><=;`KaiOfp=|8F8xs02mNSL_t)@9;S%-$<jO{M3Mu<xaf5!
 z-X6znqawCtY1penWNDyH=!?M(v5(C%+R<JKy$m;Z<=nSYfkBm!j$*;VNtQOkb4ZaS
-z?ehm75hTqs81((-@J*wvbGYX=VO3)p0mBzO=nCPyI~0n*$AjxL@0;;S!YZM1cI8q%
-zfsHB>2nzEmmb);6MFxY**vc63wl3>#LJ*5*h%xx*)<0!XB-+}Wjv(UVFZ9nRne#2y
-ztANVy_tM|hvca+Nh${Ji;W3jqTe*w{;w`C6+=~ccbAWk5pHqL?2_kbx5Cn_J>xRD;
-zV-Bq|I<zKHsS-owY>LIdTVx1uEkPFiQm!7M0|%I9*H=bg-x=}09kTzV6?l#OVUjtY
+z?ehm75hTqs81((-@J*wvbGYX=VO3)p3gNsv6pFydgX=TzoAF7)Dxq?A<x)L?jVcld
+z3iB$KyD)=A27}Ak${6vsF6(YW5Q}GsG5F`!KV?uP+S;3rAmZXL^v@@m^DWk^fXeUp
+z(%;px!Ljg&D*1omF_So3xr_zkEvZc0iwIzIfO$fnQ-9eBB6CL&1dGV)hQAhL4y`jf
+zv?fuh5<}%|ip9TMWC(CAK^FW{t{$NS2bcjR7ux7%*H=bg-x=}09kTzV6?l#OVUjtY
 z(OfkYyCYTdGH^RytVYcJ>X;kPWuBx9Z{edH8j?dy(|7mo*VtAk@CO}35EOP&T&Ld|
 zXBOEho$5K1O8)Mag~H>i2H%iBYLXzrbAXtiJJAy~bPh6&cBi`DN_R>QF}>Y%Dd&PA
 zu;cox)E)7?lHs;TIIIO!^OJYe5#)a_hhuKMlwC}b@Xd`LprLb!DMC-CUZoOxR(Tsh
@@ -2301,14 +2301,14 @@ z_ovCc>JVL~6Nel*qf8EkA(UZKq##1!Qp6RmDdR~WZ@xb2TgT;pb#Gjxe1+ay)NW^0
 f`ch_Jq&DIIbfZ@m$+<~>00000NkvXXu0mjf!$8AO
 
 literal 0
-Hc-jL100001
+HcmV?d00001
 
 diff --git a/chrome/android/java/res_vanadium/drawable-xxxhdpi/product_logo_name.png b/chrome/android/java/res_vanadium/drawable-xxxhdpi/product_logo_name.png
 new file mode 100644
 index 0000000000000000000000000000000000000000..5f16990a7eb67c441bfc62d50a4e92f95c0f4f22
 GIT binary patch
 literal 5925
-zc-jFa7ux8FP)<h;3K|Lk000e1NJLTq00Eo;002}71ONa49E3^V00002VoOIv0RM-N
+zcmV+=7ux8FP)<h;3K|Lk000e1NJLTq00Eo;002}71ONa49E3^V00002VoOIv0RM-N
 z%)bBt7T!rjK~#9!?VW3I99NZqzuVpO(9<5-ma!dTYwU!O1cx9c1V|NBN`~dR6d=Qr
 z;9Wu?k?a=B0u`Gjfm)z~9jXYhOTeO*uml3JYO~8D0oK~=BfOGWu#f~N!5-W3Te4>)
 zjYgVh_x_lkQTI&G^c`g+&6xhCT<%dn=AQ0*`kZ_3x#x;^P>w=|ETAD!nMOe;4fx2R
@@ -2425,14 +2425,14 @@ zntO)Bsb@2f>)9Xy)CEPqd3ZD)!gH8BJZeXNYNm&WN0I*rsl^JT&aD`J00000NkvXX
 Hu0mjf>GD|)
 
 literal 0
-Hc-jL100001
+HcmV?d00001
 
 diff --git a/chrome/android/java/res_vanadium/mipmap-hdpi/app_icon.png b/chrome/android/java/res_vanadium/mipmap-hdpi/app_icon.png
 new file mode 100644
 index 0000000000000000000000000000000000000000..9533ce927dbb3f4d3849d9a2c062ff31850ae454
 GIT binary patch
 literal 2578
-zc-jFH3hniYP)<h;3K|Lk000e1NJLTq002k;002k`1ONa4|Kxkj00002VoOIv0RM-N
+zcmV+t3hniYP)<h;3K|Lk000e1NJLTq002k;002k`1ONa4|Kxkj00002VoOIv0RM-N
 z%)bBt3Cl@DK~!ko&6;g&9K{*Oe>1yxw$JbO8P_4Po#2Ed#34XHNoYhVQYlDKP@zf@
 zQc+t$^PyEskqT=10YutL<)xL{(l30d1VJe&MXDf_hLlDD6d<%Nae@tbabi31OJdIN
 zcelIK4?BCeciy|(%Zu9QboTA+?#yrg^UO0dI}873CN6Rw>VE|!0D;tB_gDcA3Wb9@
@@ -2484,14 +2484,14 @@ zXXB@sW|~>%NnwTFPc9S4yIy9tcp`dZ$9=x*cD58r()wd%HYdv}pnUV*K$DqAt8PAy
 o?sU%izlC<8Z|MbZHC}-I7X>G&nZLZnpa1{>07*qoM6N<$f{)wb@Bjb+
 
 literal 0
-Hc-jL100001
+HcmV?d00001
 
 diff --git a/chrome/android/java/res_vanadium/mipmap-hdpi/app_shortcut_icon.png b/chrome/android/java/res_vanadium/mipmap-hdpi/app_shortcut_icon.png
 new file mode 100644
 index 0000000000000000000000000000000000000000..b054450f1534f806b8b28213b33778e75c450725
 GIT binary patch
 literal 2574
-zc-jFD3i0)cP)<h;3K|Lk000e1NJLTq002k;002k`1ONa4|Kxkj00002VoOIv0RM-N
+zcmV+p3i0)cP)<h;3K|Lk000e1NJLTq002k;002k`1ONa4|Kxkj00002VoOIv0RM-N
 z%)bBt3CBr9K~!ko&6;^^9Mu`XfA7uguD!lC_PS1-!*(tL*pNUdN+2abRSqc#R6!}C
 z1qrp3KPpiQYAPrK)F9MC)k+AYs>dH(IRMd0B|r(ZB&j$|m6XIzq6Fe3Hu%V4d$YE8
 zXXf>fdAmEip4r1m)PAcy=FOY;{pNe$eDC-c{?A05<u=s+3P=C~i9jIru>u?v3I{b)
@@ -2543,14 +2543,14 @@ zWRetC+4<xOfim?aW;T@*Axuc;4IC`eq?jVDU+y1ID%#<iS;{$+naiXqGASO%Gw9Fo
 kUub9gFFpTM;~B_*0oNUsuT)Zgn*aa+07*qoM6N<$f)V!8^8f$<
 
 literal 0
-Hc-jL100001
+HcmV?d00001
 
 diff --git a/chrome/android/java/res_vanadium/mipmap-hdpi/app_single_page_icon.png b/chrome/android/java/res_vanadium/mipmap-hdpi/app_single_page_icon.png
 new file mode 100644
 index 0000000000000000000000000000000000000000..c544d46ce870ad2efc9984da57d853df5f28c3e4
 GIT binary patch
 literal 1496
-zc-jHj1t<E6P)<h;3K|Lk000e1NJLTq002k;002k`1ONa4|Kxkj00002VoOIv0RM-N
+zcmV;}1t<E6P)<h;3K|Lk000e1NJLTq002k;002k`1ONa4|Kxkj00002VoOIv0RM-N
 z%)bBt1(8WaK~!ko?b`2e6LlQG@%P=W?K))Z24hoTs|p6?$Lh2BfG~M5;$Pr1Wj^x}
 z{sW36K3pQk7!uKpghWvzBqkV8%rM|G!+wOx07D$pzyfq^D_w8x*53Kx?%Hd6cfD(`
 z3nqS>w9DOn?_T}>xX<T%9sFPZV@0sraU-UFob9vTrvM^~<B3DpIk;!RH_(k}ZZZ?G
@@ -2581,14 +2581,14 @@ zb9Vz0S$6R(3Mwlk<(uP|zFE1&9p;Jypy25m-peMs=@i;G#UkAzy<H3QPvlf;W_s}!
 yNoJTUbk%x+03vLpg;t=E9BZr*C&^Md2H;<$gf3O<DB$=20000<MNUMnLSTXr)4V<a
 
 literal 0
-Hc-jL100001
+HcmV?d00001
 
 diff --git a/chrome/android/java/res_vanadium/mipmap-mdpi/app_icon.png b/chrome/android/java/res_vanadium/mipmap-mdpi/app_icon.png
 new file mode 100644
 index 0000000000000000000000000000000000000000..5c340f7a0936223c14d858784e18e38443264df5
 GIT binary patch
 literal 1532
-zc-jH{1q1qtP)<h;3K|Lk000e1NJLTq001xm001xu1ONa4{R=S+00002VoOIv0RM-N
+zcmV<Y1q1qtP)<h;3K|Lk000e1NJLTq001xm001xu1ONa4{R=S+00002VoOIv0RM-N
 z%)bBt1+_^;K~z}7wU}LO6jc<*fAhK9FSj4Gl@^fFmXCf&_%0<7pdv9*FyTp!k%UB(
 zB1RJR!53qA-~}{B5jF7z2vK}6qQ*dCNDwS7U<+0QrBIr*wA609Eo^tUyEEg%%<SjP
 zwqQIrnPl#q^Z(y_&bjxVJMce?FiS17nfeA`SnWR(2#82ki_~VRNmwpc;R9nrzZ>h+
@@ -2620,14 +2620,14 @@ zm1+;i!}o^%y8HLd?$8i^0)&aWZc4NGS7FwHIpmUy2MLG~A;c6RqC~U(MwktOtz}*V
 i?5f^Os2P5PnDQ@s4<gB_=JK-u0000<MNUMnLSTa0>e?Ux
 
 literal 0
-Hc-jL100001
+HcmV?d00001
 
 diff --git a/chrome/android/java/res_vanadium/mipmap-mdpi/app_shortcut_icon.png b/chrome/android/java/res_vanadium/mipmap-mdpi/app_shortcut_icon.png
 new file mode 100644
 index 0000000000000000000000000000000000000000..8723f01f61d163b947af43af0c871695ed25ee6a
 GIT binary patch
 literal 1534
-zc-jH}1p)erP)<h;3K|Lk000e1NJLTq001xm001xu1ONa4{R=S+00002VoOIv0RM-N
+zcmV<a1p)erP)<h;3K|Lk000e1NJLTq001xm001xu1ONa4{R=S+00002VoOIv0RM-N
 z%)bBt1-D5=K~z}7wU}9KR8<(qf9Gy9okFLDLWP3Tg~gVtY*J7NNWhp7jKL)amniWC
 z2*yNt@Ie!NASNs-1PGB3aUp^)LP!)f1~h5dAp)`#DN-m@pbN~_nR|~9_uiSgGk4m8
 z@w>^)+_U`t=X~F}=X`hIe>Tz2R`zALmw<Gx|12O7Xf>mPjWmjhREbiM9cBy1<iTXq
@@ -2659,14 +2659,14 @@ zvaW21dAB2et?hKnnRBONZQP=hI7xqaUjlZ$y$ci(B7}hkq(~4WN{l4Q-u_1DkAU0C
 kebcbBdV4`xeI`u6zY8!J8&ZgeVgLXD07*qoM6N<$f-H)~aR2}S
 
 literal 0
-Hc-jL100001
+HcmV?d00001
 
 diff --git a/chrome/android/java/res_vanadium/mipmap-mdpi/app_single_page_icon.png b/chrome/android/java/res_vanadium/mipmap-mdpi/app_single_page_icon.png
 new file mode 100644
 index 0000000000000000000000000000000000000000..2ef668f35442a8681129f3db24c6fed504d61ae4
 GIT binary patch
 literal 1206
-zc-jHB1WEgeP)<h;3K|Lk000e1NJLTq001xm001xu1ONa4{R=S+00002VoOIv0RM-N
+zcmV;n1WEgeP)<h;3K|Lk000e1NJLTq001xm001xu1ONa4{R=S+00002VoOIv0RM-N
 z%)bBt1aC=1K~z}7)s|amTtyhie>3OI*-M&DlQt=(ZPKKrTErVsP(iB{eW(a(B2=qr
 zrTA8T$+I`a7HI|XLBt39V5Fo~RPaGjOG~8?YM@}129uQZlBBV1ZkyfgIcLU)J>6ta
 zb~l^Ty!g%2&VKX%4gdM(I|Kjs5aEdfZ|rz`W_2}7En2_t+WT#8S%AY&Jar`798NL_
@@ -2692,14 +2692,14 @@ z`4MAz0~f`Crd?apPTtB&j}wQ>e3|OqR`bB7hf<qU+=t8bTz_xh>7irvlg?-T2X2kH
 Ud&;davH$=807*qoM6N<$g0vVglK=n!
 
 literal 0
-Hc-jL100001
+HcmV?d00001
 
 diff --git a/chrome/android/java/res_vanadium/mipmap-xhdpi/app_icon.png b/chrome/android/java/res_vanadium/mipmap-xhdpi/app_icon.png
 new file mode 100644
 index 0000000000000000000000000000000000000000..2110d524c9c403b80301dd34709d4f6fcc430f28
 GIT binary patch
 literal 3727
-zc-jGv4sh{_P)<h;3K|Lk000e1NJLTq003YB003YJ1ONa4NRhv@00002VoOIv0RM-N
+zcmV;A4sh{_P)<h;3K|Lk000e1NJLTq003YB003YJ1ONa4NRhv@00002VoOIv0RM-N
 z%)bBt4oFEvK~#9!?VM?BT-SBSe{Y!?awu{rky<E9q83w|B}<lV$yH+4ixMM+<2Y^|
 zApX!GY10O^fueDP26ciKU4p_6)EGe>%L$UY1q@{Y?80_qYqjHgk+Nu`EZGz#$|NO{
 z5*KkB&b)c=_QShx8@`!&Z%Ety&@+(c&0FsM|Ia<=-gD2pm+=4c@rv@Hl~`P|DEj_C
@@ -2773,14 +2773,14 @@ z9k%K%AG1#Yxqn*%9UWbMYjPp9L%?(fLrhE;_#FIcjJeuX<!lB}<Wj@nvNy-CEq8V~
 tXMdbzt~W?J>%)T!-Glpw=5&Y9{{mHf#%w_K>9PO-002ovPDHLkV1nv5AYT9g
 
 literal 0
-Hc-jL100001
+HcmV?d00001
 
 diff --git a/chrome/android/java/res_vanadium/mipmap-xhdpi/app_shortcut_icon.png b/chrome/android/java/res_vanadium/mipmap-xhdpi/app_shortcut_icon.png
 new file mode 100644
 index 0000000000000000000000000000000000000000..dce04b58684dd6c7ee265ddf332facaf9d4073e9
 GIT binary patch
 literal 3664
-zc-jF_4zKZvP)<h;3K|Lk000e1NJLTq003YB003YJ1ONa4NRhv@00002VoOIv0RM-N
+zcmV-W4zKZvP)<h;3K|Lk000e1NJLTq003YB003YJ1ONa4NRhv@00002VoOIv0RM-N
 z%)bBt4hcy_K~#9!?VNd#99MnEKd-xIW@m4$q&=k7v9edPBnw@(1oDA|%@LO&#)UBz
 zl2o8b{ve@J_8-KQ9qg(EFiAy<330F?6fPXa2tpC;U?dDeaj+v|qcgT-tye2)SI25E
 z?KL|y-Tm@MzdmNRXQpR%WaSTjU8<e#cYVLV_j~XC-X-|0Tw4)WEyw(vW!~TacLW3=
@@ -2853,14 +2853,14 @@ zdH=Tr1_p-utE+?1E&<CO46(30;8pmqF{*W|%D;jUT;B07eYjnd<+buEolUFu1xf#?
 ie=zsl`$JVdRQG?1!InhXyR7v90000<MNUMnLSTaK4EbIF
 
 literal 0
-Hc-jL100001
+HcmV?d00001
 
 diff --git a/chrome/android/java/res_vanadium/mipmap-xhdpi/app_single_page_icon.png b/chrome/android/java/res_vanadium/mipmap-xhdpi/app_single_page_icon.png
 new file mode 100644
 index 0000000000000000000000000000000000000000..a0a80433631765f9bd91707fffb16cffe7160a95
 GIT binary patch
 literal 2639
-zc-jF^3b6HwP)<h;3K|Lk000e1NJLTq003YB003YJ1ONa4NRhv@00002VoOIv0RM-N
+zcmV-V3b6HwP)<h;3K|Lk000e1NJLTq003YB003YJ1ONa4NRhv@00002VoOIv0RM-N
 z%)bBt3J6I=K~#9!?VEXQ9Mu`XfA7t)-nAW{I0=q%oTN}eI76V9L^;$WC<Roh6jeRd
 zmi|+<DkZ9D)gm<kK|u)70}1u7LPbi7qN-4pMh#a{A);y$jwGgd?f8z*wb#e)%zOP~
 zXHT#9w8yT>H?n5eGyCTIz4yIuzVDki@PT|F|KB2tpYqTZH~utoBUYhv6aX^ysjx`Y
@@ -2913,14 +2913,14 @@ z>F6ur*vMv@X{p`OzN_g&bz5Xzh>x;>gX2z&4E3CO>p%Z?hMD9XgGBN*v9<sJ7Hzb$
 xfm(tDkkqtonVp;KM-pR!IcAt*l<DPu{$JS7*jWIpcGUm?002ovPDHLkV1jo9>>B_8
 
 literal 0
-Hc-jL100001
+HcmV?d00001
 
 diff --git a/chrome/android/java/res_vanadium/mipmap-xxhdpi/app_icon.png b/chrome/android/java/res_vanadium/mipmap-xxhdpi/app_icon.png
 new file mode 100644
 index 0000000000000000000000000000000000000000..f4894e5b5b5047708bad46853f06c3bd68e54aa0
 GIT binary patch
 literal 6160
-zc-jFF81LtaP)<h;3K|Lk000e1NJLTq0058x0058(1ONa4O;0K_00002VoOIv0RM-N
+zcmV+r81LtaP)<h;3K|Lk000e1NJLTq0058x0058(1ONa4O;0K_00002VoOIv0RM-N
 z%)bBt7s*LPK~#9!?VWj$9MyTif89OTUfN4qUAvM%Vzo#}kw8e`00IoMAyC-Zv11cE
 z#ARa2c9khRNmU%jE?jneRKQ1U2OQsb0CQs(64)FD34sBFBqRhvNGt6n?Xv9LGu@p(
 z`g%RnJ<~JOqr>HIYIgg4{oZfB?|b)a_>25S{vu5j=_Gi*exgUPS<jU0zmn^?14Vaj
@@ -3041,14 +3041,14 @@ ze;qSGZcNx~(z;hnFCCERG|Xu(gX37CIo5#0=as%T&i%$B5IZ^CZx(=KhUWMH@_Mq@
 iy8!i)|Hl}MBmWOUsYCM~E)RwP0000<MNUMnLSTZfrRkLb
 
 literal 0
-Hc-jL100001
+HcmV?d00001
 
 diff --git a/chrome/android/java/res_vanadium/mipmap-xxhdpi/app_shortcut_icon.png b/chrome/android/java/res_vanadium/mipmap-xxhdpi/app_shortcut_icon.png
 new file mode 100644
 index 0000000000000000000000000000000000000000..ddde3d59f00d5eb17564a8214ad9cdcffa38a299
 GIT binary patch
 literal 6046
-zc-jG;7h&j$P)<h;3K|Lk000e1NJLTq0058x0058(1ONa4O;0K_00002VoOIv0RM-N
+zcmV;P7h&j$P)<h;3K|Lk000e1NJLTq0058x0058(1ONa4O;0K_00002VoOIv0RM-N
 z%)bBt7gtF{K~#9!?VWj)TveICe{ZR!_a&VUounJGbs9nffg}(V64^#n#2FDs85vv{
 zopGC^cpM$^3>;>hGc%%&3JT~jxE|RD)G@3IgCrn<glvRBmJZ!XC+Q?zUF%!skGI`d
 z>#M3)oy6l;C!KoRefR$A`@Z|#`|iCD{v>~rKS={cIsxu)9`6}!)IBBlujJeBK{0*b
@@ -3167,14 +3167,14 @@ zV!CK#q7I3sCI;VAG`@7|0Ezd@e}SC;jYZ&J8rI(@JH^YuPBoxnca{qFhz~g^_%@~T
 Y|1QPj5%LR(VE_OC07*qoM6N<$f_t{1X8-^I
 
 literal 0
-Hc-jL100001
+HcmV?d00001
 
 diff --git a/chrome/android/java/res_vanadium/mipmap-xxhdpi/app_single_page_icon.png b/chrome/android/java/res_vanadium/mipmap-xxhdpi/app_single_page_icon.png
 new file mode 100644
 index 0000000000000000000000000000000000000000..a18ac214a3cbcd93fd5722bdc4da33de245e68bf
 GIT binary patch
 literal 3485
-zc-jG-4Px?%P)<h;3K|Lk000e1NJLTq0058x0058(1ONa4O;0K_00002VoOIv0RM-N
+zcmV;O4Px?%P)<h;3K|Lk000e1NJLTq0058x0058(1ONa4O;0K_00002VoOIv0RM-N
 z%)bBt4OU4+K~#9!?VVd}9Mv6%znxusv+LNqu^kL)LYxaC2~=@_(pC`3B`AqXD<Pyl
 zqME)IDe&5tC{k5beQ1COS`pd+53SO2DHR}62uU%}HW$Lpae&;M*h%cHowZ}H?cJT3
 zKFnojc4u~Xc4u~H?fgdZ&gIOUbH4n~WzKEjrf%w{ZtA9Ps!<iF<fgB><y|}~b=M`t
@@ -3244,14 +3244,14 @@ zgb5-t4~Wb$j|ikmGVW|ei-iG5Q8TSXi4+uUY37+F#f@U6m7V?%zd0TLfLr+m00000
 LNkvXXu0mjf=__DT
 
 literal 0
-Hc-jL100001
+HcmV?d00001
 
 diff --git a/chrome/android/java/res_vanadium/mipmap-xxxhdpi/app_icon.png b/chrome/android/java/res_vanadium/mipmap-xxxhdpi/app_icon.png
 new file mode 100644
 index 0000000000000000000000000000000000000000..1e02f37a1a940619f19cb73eb3605e14e8b0cfef
 GIT binary patch
 literal 9104
-zc-jGwBX8V^P)<h;3K|Lk000e1NJLTq006)M006)U1ONa4_|>G000002VoOIv0RM-N
+zcmV;BBX8V^P)<h;3K|Lk000e1NJLTq006)M006)U1ONa4_|>G000002VoOIv0RM-N
 z%)bBtBS}d_K~#9!?VWd&9MzrgKNY%rva)7I5-1QPB!UbAga|emY{2&6*v9dAkKb7z
 zN1ns_t?_y9t@rKPn>hB`hPAy8Zygq6!ai)+0}j{(BQi(`fk8+JWsPP=(nu3JR(O9@
 zPTf`ARXqdCZ_b3O>AH36`@O$#e>W7oA#cbV@`k)2|5Zhp?h0g7SADuG8&~A%u0UN8
@@ -3429,14 +3429,14 @@ z&TnT3ZAJm_ecYKSLdb8y_m^AzAbV#p&N$%xk2#Y?sB;t)z0T1Ll>ZM}!uj~k+35iQ
 O0000<MNUMnLSTY_yT{`I
 
 literal 0
-Hc-jL100001
+HcmV?d00001
 
 diff --git a/chrome/android/java/res_vanadium/mipmap-xxxhdpi/app_shortcut_icon.png b/chrome/android/java/res_vanadium/mipmap-xxxhdpi/app_shortcut_icon.png
 new file mode 100644
 index 0000000000000000000000000000000000000000..462b433a801f6fcea98599426cb227a3849dccd0
 GIT binary patch
 literal 8910
-zc-jHZA~D^GP)<h;3K|Lk000e1NJLTq006)M006)U1ONa4_|>G000002VoOIv0RM-N
+zcmV;<A~D^GP)<h;3K|Lk000e1NJLTq006)M006)U1ONa4_|>G000002VoOIv0RM-N
 z%)bBtB8N#tK~#9!?VWkN9aWX@zg2aHd+v~%fh0HcL=r+6LP&%Jh$12ZMOsDM0bl!h
 zDk6NaZTs1_KJAZ<s2}X6ecIAW<In;R@W~{Kq9C9UkRb^K2r(oiWWJemhcnjj{-}94
 z=Tz0HI`=}e&gTwQr)t-(-*4}=)?RypH|0%vQ{I#}<-e;4Bb|Yi@~Vw=X2VKmq%+V^
@@ -3610,14 +3610,14 @@ zXcEEoJ9rftXX!V^9j|uw-*{Iq7*#U*2=M02`B(7#=M*o<n(O?i1K#_ZqgjLoM}E;7
 c9F0Qx|B}Q+Z=dlMDF6Tf07*qoM6N<$f|_$^VgLXD
 
 literal 0
-Hc-jL100001
+HcmV?d00001
 
 diff --git a/chrome/android/java/res_vanadium/mipmap-xxxhdpi/app_single_page_icon.png b/chrome/android/java/res_vanadium/mipmap-xxxhdpi/app_single_page_icon.png
 new file mode 100644
 index 0000000000000000000000000000000000000000..ee550d2496b8ee610665e0973b6c1009bdec18bb
 GIT binary patch
 literal 6162
-zc-jFH813hYP)<h;3K|Lk000e1NJLTq006)M006)U1ONa4_|>G000002VoOIv0RM-N
+zcmV+t813hYP)<h;3K|Lk000e1NJLTq006)M006)U1ONa4_|>G000002VoOIv0RM-N
 z%)bBt7t2XRK~#9!?VWj$99MnEKd+~!XJ$|BuJ(|1uCQfn3uANmEDMNbT$DrEMTH|V
 zMJiOPph75;0*XKKN0P!fBos~+kUx?lIHnLbm>AnQK#Z_ui^CwxGD2(J(ysQ@&fatM
 z@$yIa+&$O!%+73UzFQhi_sqP0{r$f8d%ySI@4bc=T4<q#7FuYbg%(<9;ZlRBRYDJ5
@@ -3738,7 +3738,7 @@ z4=n*~D0DMGYE(<3jW9uiIZ-V(EMl0%i4%8ROr2S#S@mO;TLNUD(nALwgmP#XXsB2P
 kGn<knmRQIH8Lkfh4<#z;WpdrDCIA2c07*qoM6N<$g5lVO)Bpeg
 
 literal 0
-Hc-jL100001
+HcmV?d00001
 
 diff --git a/chrome/android/java/res_vanadium/values/channel_constants.xml b/chrome/android/java/res_vanadium/values/channel_constants.xml
 new file mode 100644
@@ -3755,5 +3755,5 @@ index 000000000000..934572cd12f2
 +    <string name="search_widget_title" translatable="false">Vanadium search</string>
 +</resources>
 -- 
-2.22.0
+2.21.0
 

--- a/0007-remove-Help-feedback-menu-entry.patch
+++ b/0007-remove-Help-feedback-menu-entry.patch
@@ -1,7 +1,7 @@
-From 44e309f954c85f475fa728601185acac953811da Mon Sep 17 00:00:00 2001
+From c2820dfa585b85ad3337f867e52ece95eb6dd376 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Sat, 6 Jul 2019 05:56:45 -0400
-Subject: [PATCH 07/46] remove Help & feedback menu entry
+Subject: [PATCH 07/47] remove Help & feedback menu entry
 
 ---
  chrome/android/java/res/menu/main_menu.xml               | 2 --
@@ -71,5 +71,5 @@ index f1e3635e8da5..b32aca969154 100644
                  || id == R.id.open_history_menu_id) {
              return true;
 -- 
-2.22.0
+2.21.0
 

--- a/0008-hide-passwords.google.com-link-when-not-supported.patch
+++ b/0008-hide-passwords.google.com-link-when-not-supported.patch
@@ -1,7 +1,7 @@
-From 19a2917f68a8059e953b07f02cfd993972e4778e Mon Sep 17 00:00:00 2001
+From f1dbe084a2c3e52ee3f5e0e5bfae3851f5379f5e Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Sun, 13 Aug 2017 19:33:04 -0400
-Subject: [PATCH 08/46] hide passwords.google.com link when not supported
+Subject: [PATCH 08/47] hide passwords.google.com link when not supported
 
 ---
  .../preferences/password/SavePasswordsPreferences.java        | 4 ++++
@@ -30,5 +30,5 @@ index abdba9d881ff..94ca5503b45b 100644
              return; // Don't add the Manage Account link if it's present.
          }
 -- 
-2.22.0
+2.21.0
 

--- a/0009-disable-first-run-welcome-page.patch
+++ b/0009-disable-first-run-welcome-page.patch
@@ -1,7 +1,7 @@
-From e46e7abfa1c06eb2d2aedbaed03b78580e23d5b4 Mon Sep 17 00:00:00 2001
+From 8d7674c8aa87058d4abf21f5a3707edfb59ddabf Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Thu, 24 Nov 2016 08:19:03 -0500
-Subject: [PATCH 09/46] disable first run welcome page
+Subject: [PATCH 09/47] disable first run welcome page
 
 ---
  .../chromium/chrome/browser/firstrun/FirstRunActivity.java    | 4 ++--
@@ -30,5 +30,5 @@ index b30ae516b6ce..a414a354067a 100644
                      mResultSignInAccountName = mFreProperties.getString(
                              AccountFirstRunFragment.FORCE_SIGNIN_ACCOUNT_TO);
 -- 
-2.22.0
+2.21.0
 

--- a/0010-disable-seed-based-field-trials.patch
+++ b/0010-disable-seed-based-field-trials.patch
@@ -1,7 +1,7 @@
-From e35efad246162eac36410d83a3563f75023798a9 Mon Sep 17 00:00:00 2001
+From b3816624aa9b76eda9152c51cc2f24469e9f82a7 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Tue, 25 Dec 2018 16:19:51 -0500
-Subject: [PATCH 10/46] disable seed-based field trials
+Subject: [PATCH 10/47] disable seed-based field trials
 
 ---
  components/variations/service/variations_field_trial_creator.cc | 2 ++
@@ -23,5 +23,5 @@ index 7c6a2a7e7335..418a35f8abe7 100644
  
    platform_field_trials->SetupFeatureControllingFieldTrials(used_seed,
 -- 
-2.22.0
+2.21.0
 

--- a/0011-disable-navigation-error-correction-by-default.patch
+++ b/0011-disable-navigation-error-correction-by-default.patch
@@ -1,7 +1,7 @@
-From f5184408ea46dfb65927f90cf23666376dd7e7f7 Mon Sep 17 00:00:00 2001
+From 5ff8b13bc63fb8509f50a612c5c804754891e118 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Wed, 23 Nov 2016 08:29:58 -0500
-Subject: [PATCH 11/46] disable navigation error correction by default
+Subject: [PATCH 11/47] disable navigation error correction by default
 
 ---
  chrome/browser/ui/navigation_correction_tab_observer.cc | 2 +-
@@ -21,5 +21,5 @@ index 40256d42872f..6d802c92bcaf 100644
  }
  
 -- 
-2.22.0
+2.21.0
 

--- a/0012-disable-contextual-search-by-default.patch
+++ b/0012-disable-contextual-search-by-default.patch
@@ -1,7 +1,7 @@
-From 3dec95f03adc055977e830f191f5579061537291 Mon Sep 17 00:00:00 2001
+From d12b48fbffbc78cd04bb61a3adf7901c0ae5aebe Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Wed, 23 Nov 2016 09:26:51 -0500
-Subject: [PATCH 12/46] disable contextual search by default
+Subject: [PATCH 12/47] disable contextual search by default
 
 ---
  chrome/browser/profiles/profile.cc | 2 +-
@@ -21,5 +21,5 @@ index 71d736c9eaf3..d3b1c8de2984 100644
  #endif  // defined(OS_ANDROID)
    registry->RegisterBooleanPref(prefs::kSessionExitedCleanly, true);
 -- 
-2.22.0
+2.21.0
 

--- a/0013-disable-network-prediction-by-default.patch
+++ b/0013-disable-network-prediction-by-default.patch
@@ -1,7 +1,7 @@
-From 7f43fba11add6094cffbc629511b42577baa6295 Mon Sep 17 00:00:00 2001
+From a328886cf6c0695d8a10b79b640939e9ac601c5e Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Wed, 23 Nov 2016 08:31:44 -0500
-Subject: [PATCH 13/46] disable network prediction by default
+Subject: [PATCH 13/47] disable network prediction by default
 
 ---
  chrome/browser/net/prediction_options.h | 2 +-
@@ -21,5 +21,5 @@ index 651248390f50..4c55a198b4fe 100644
  
  enum class NetworkPredictionStatus {
 -- 
-2.22.0
+2.21.0
 

--- a/0014-disable-metrics-by-default.patch
+++ b/0014-disable-metrics-by-default.patch
@@ -1,7 +1,7 @@
-From 47ca01b365f91d1a9e2917b2d50caececfd67a27 Mon Sep 17 00:00:00 2001
+From dbfbb5b90b012451ed30e219fd26035a7b92dafe Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Thu, 24 Nov 2016 11:41:00 -0500
-Subject: [PATCH 14/46] disable metrics by default
+Subject: [PATCH 14/47] disable metrics by default
 
 ---
  .../chromium/chrome/browser/firstrun/FirstRunActivityBase.java  | 2 +-
@@ -21,5 +21,5 @@ index 9c69e1071c79..70ef53e01211 100644
      private boolean mNativeInitialized;
  
 -- 
-2.22.0
+2.21.0
 

--- a/0015-disable-hyperlink-auditing-by-default.patch
+++ b/0015-disable-hyperlink-auditing-by-default.patch
@@ -1,7 +1,7 @@
-From b9e0ebd130cf92c4d20d28ca79c7d2f2f855f01d Mon Sep 17 00:00:00 2001
+From b8ad8fade08a7205f9b1bc6240197560e2e44dd6 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Sat, 26 Nov 2016 14:57:22 -0500
-Subject: [PATCH 15/46] disable hyperlink auditing by default
+Subject: [PATCH 15/47] disable hyperlink auditing by default
 
 ---
  chrome/browser/chrome_content_browser_client.cc | 2 +-
@@ -21,5 +21,5 @@ index 9ec73c5bb8fc..4c3f610b65b6 100644
    // Register user prefs for mapping SitePerProcess and IsolateOrigins in
    // user policy in addition to the same named ones in Local State (which are
 -- 
-2.22.0
+2.21.0
 

--- a/0016-disable-showing-popular-sites-by-default.patch
+++ b/0016-disable-showing-popular-sites-by-default.patch
@@ -1,7 +1,7 @@
-From 5edc02b0800403c8c86301c9a1ffe579ddf97c61 Mon Sep 17 00:00:00 2001
+From aae902400aca30ab334fe455213fb57ea1d03d53 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Tue, 6 Mar 2018 00:27:41 -0500
-Subject: [PATCH 16/46] disable showing popular sites by default
+Subject: [PATCH 16/47] disable showing popular sites by default
 
 ---
  components/ntp_tiles/features.cc | 4 ++--
@@ -28,5 +28,5 @@ index 0ea51f0746e0..5fe7b5bbdfd4 100644
  const base::Feature kDefaultSearchShortcut{"DefaultSearchShortcut",
                                             base::FEATURE_DISABLED_BY_DEFAULT};
 -- 
-2.22.0
+2.21.0
 

--- a/0017-disable-article-suggestions-feature-by-default.patch
+++ b/0017-disable-article-suggestions-feature-by-default.patch
@@ -1,7 +1,7 @@
-From 25d8e0120eeef3e1cb1bc7b9849da18e3713d290 Mon Sep 17 00:00:00 2001
+From f270d021a357a3782274a8151792eb28f553270b Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Thu, 8 Mar 2018 22:43:12 -0500
-Subject: [PATCH 17/46] disable article suggestions feature by default
+Subject: [PATCH 17/47] disable article suggestions feature by default
 
 ---
  components/ntp_snippets/features.cc | 2 +-
@@ -21,5 +21,5 @@ index fe045330ec25..99d2c10bf874 100644
  const base::Feature kRemoteSuggestionsEmulateM58FetchingSchedule{
      "RemoteSuggestionsEmulateM58FetchingSchedule",
 -- 
-2.22.0
+2.21.0
 

--- a/0018-disable-prefetching-suggested-pages-by-default.patch
+++ b/0018-disable-prefetching-suggested-pages-by-default.patch
@@ -1,7 +1,7 @@
-From 00b2d57bfd0095220efad460e1f898622c894afd Mon Sep 17 00:00:00 2001
+From 5eff44af4793a0075d36e9a520552072e0eedcb3 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Fri, 12 Jul 2019 04:10:21 -0400
-Subject: [PATCH 18/46] disable prefetching suggested pages by default
+Subject: [PATCH 18/47] disable prefetching suggested pages by default
 
 ---
  components/offline_pages/core/offline_page_feature.cc | 2 +-
@@ -21,5 +21,5 @@ index b6c93de8591d..f636030659a7 100644
  const base::Feature kOfflinePagesCTV2Feature{"OfflinePagesCTV2",
                                               base::FEATURE_DISABLED_BY_DEFAULT};
 -- 
-2.22.0
+2.21.0
 

--- a/0019-disable-sensors-access-by-default.patch
+++ b/0019-disable-sensors-access-by-default.patch
@@ -1,7 +1,7 @@
-From 90e189275e932fefd82b5075ca99001d087f9ef3 Mon Sep 17 00:00:00 2001
+From 01c6c6279d4fb5019ba6211a2f7ac07420dc0672 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Sun, 16 Jun 2019 15:57:29 -0400
-Subject: [PATCH 19/46] disable sensors access by default
+Subject: [PATCH 19/47] disable sensors access by default
 
 ---
  .../content_settings/core/browser/content_settings_registry.cc  | 2 +-
@@ -21,5 +21,5 @@ index 4df204998912..d67b2dc6908f 100644
             ValidSettings(CONTENT_SETTING_ALLOW, CONTENT_SETTING_BLOCK),
             WebsiteSettingsInfo::SINGLE_ORIGIN_ONLY_SCOPE,
 -- 
-2.22.0
+2.21.0
 

--- a/0020-disable-third-party-cookies-by-default.patch
+++ b/0020-disable-third-party-cookies-by-default.patch
@@ -1,7 +1,7 @@
-From e2556f529846418cafbc9b65366cb02cb53b7a75 Mon Sep 17 00:00:00 2001
+From e070f97ebf0b587479122b1211ed8b9ea87853ef Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Sun, 16 Jun 2019 16:01:31 -0400
-Subject: [PATCH 20/46] disable third party cookies by default
+Subject: [PATCH 20/47] disable third party cookies by default
 
 ---
  components/content_settings/core/browser/cookie_settings.cc | 2 +-
@@ -21,5 +21,5 @@ index 47430eec6e88..99f944a0dabd 100644
  }
  
 -- 
-2.22.0
+2.21.0
 

--- a/0021-disable-background-sync-by-default.patch
+++ b/0021-disable-background-sync-by-default.patch
@@ -1,7 +1,7 @@
-From 96d2b84a98d4714630404e1d42cd6692258a602b Mon Sep 17 00:00:00 2001
+From 7a6bc9cd974baca8cfd0361c6b189d5d1618ac5a Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Sun, 16 Jun 2019 21:57:26 -0400
-Subject: [PATCH 21/46] disable background sync by default
+Subject: [PATCH 21/47] disable background sync by default
 
 ---
  .../content_settings/core/browser/content_settings_registry.cc  | 2 +-
@@ -21,5 +21,5 @@ index d67b2dc6908f..682461999279 100644
             ValidSettings(CONTENT_SETTING_ALLOW, CONTENT_SETTING_BLOCK),
             WebsiteSettingsInfo::SINGLE_ORIGIN_ONLY_SCOPE,
 -- 
-2.22.0
+2.21.0
 

--- a/0022-disable-payment-support-by-default.patch
+++ b/0022-disable-payment-support-by-default.patch
@@ -1,7 +1,7 @@
-From b33cde476db92b49e0b6e1a2587f12f353e78f40 Mon Sep 17 00:00:00 2001
+From 1eb66245c84a800a8dcfff2fe026a3b8fbb2a4be Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Tue, 18 Jun 2019 22:28:53 -0400
-Subject: [PATCH 22/46] disable payment support by default
+Subject: [PATCH 22/47] disable payment support by default
 
 ---
  components/payments/core/payment_prefs.cc | 2 +-
@@ -21,5 +21,5 @@ index 9590d9494ed1..787ff68af12a 100644
  }
  
 -- 
-2.22.0
+2.21.0
 

--- a/0023-disable-media-router-media-remoting-by-default.patch
+++ b/0023-disable-media-router-media-remoting-by-default.patch
@@ -1,7 +1,7 @@
-From 45ef7ce89ffcbed4d1ee82c7e3e14af788d9d33a Mon Sep 17 00:00:00 2001
+From 87b31f6888149ef4c921ec4c4431aae9f819bc30 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Thu, 4 Jul 2019 18:11:27 -0400
-Subject: [PATCH 23/46] disable media router media remoting by default
+Subject: [PATCH 23/47] disable media router media remoting by default
 
 ---
  chrome/browser/profiles/profile.cc | 2 +-
@@ -21,5 +21,5 @@ index d3b1c8de2984..f0f0e4d4b5b5 100644
  
    registry->RegisterDictionaryPref(prefs::kWebShareVisitedTargets);
 -- 
-2.22.0
+2.21.0
 

--- a/0024-disable-media-router-by-default.patch
+++ b/0024-disable-media-router-by-default.patch
@@ -1,7 +1,7 @@
-From 995bcae12113e4942b98c4655ee6961f6cf213a1 Mon Sep 17 00:00:00 2001
+From 6e618781f3311cab67f08fa5462cc15e52fa7e3a Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Thu, 4 Jul 2019 19:08:52 -0400
-Subject: [PATCH 24/46] disable media router by default
+Subject: [PATCH 24/47] disable media router by default
 
 ---
  .../media/router/media_router_feature.cc      | 19 +++++++++----------
@@ -59,5 +59,5 @@ index 71619ca3d527..062569a76016 100644
    registry->RegisterBooleanPref(
        prefs::kOobeMarketingOptInScreenFinished, false,
 -- 
-2.22.0
+2.21.0
 

--- a/0025-disable-offering-translations-by-default.patch
+++ b/0025-disable-offering-translations-by-default.patch
@@ -1,7 +1,7 @@
-From 3fe12a8849622c6e6635b24b403c8b0bb2a2dae9 Mon Sep 17 00:00:00 2001
+From 73501f181ac53c4f04c78f9fb5916c9b56a910ab Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Fri, 12 Jul 2019 03:58:01 -0400
-Subject: [PATCH 25/46] disable offering translations by default
+Subject: [PATCH 25/47] disable offering translations by default
 
 ---
  chrome/browser/ui/browser_ui_prefs.cc | 2 +-
@@ -21,5 +21,5 @@ index e011650b48a6..8d942c6765fa 100644
    registry->RegisterStringPref(prefs::kCloudPrintEmail, std::string());
    registry->RegisterBooleanPref(prefs::kCloudPrintProxyEnabled, true);
 -- 
-2.22.0
+2.21.0
 

--- a/0026-disable-browser-sign-in-feature-by-default.patch
+++ b/0026-disable-browser-sign-in-feature-by-default.patch
@@ -1,7 +1,7 @@
-From 8f8bb12fe40cf0998dd33fcf68ddb155605f0b2e Mon Sep 17 00:00:00 2001
+From 0c12833492cac2129bb79f2c9304160c2427f328 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Fri, 12 Jul 2019 04:23:18 -0400
-Subject: [PATCH 26/46] disable browser sign in feature by default
+Subject: [PATCH 26/47] disable browser sign in feature by default
 
 ---
  components/signin/core/browser/signin_manager_base.cc | 2 +-
@@ -21,5 +21,5 @@ index 37ee80721d59..436daa169af6 100644
                                base::Time().ToInternalValue());
    registry->RegisterBooleanPref(prefs::kSignedInWithCredentialProvider, false);
 -- 
-2.22.0
+2.21.0
 

--- a/0027-disable-safe-browsing-reporting-opt-in-by-default.patch
+++ b/0027-disable-safe-browsing-reporting-opt-in-by-default.patch
@@ -1,7 +1,7 @@
-From 906643ad9eaa5fc0fa78b9029704fc29094577e8 Mon Sep 17 00:00:00 2001
+From 4534abf0eb3dba37d29161e70d1ae621ae152e31 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Fri, 12 Jul 2019 05:22:11 -0400
-Subject: [PATCH 27/46] disable safe browsing reporting opt-in by default
+Subject: [PATCH 27/47] disable safe browsing reporting opt-in by default
 
 ---
  components/safe_browsing/common/safe_browsing_prefs.cc | 2 +-
@@ -21,5 +21,5 @@ index e224e09bbcbc..8a45791a72ee 100644
        prefs::kSafeBrowsingEnabled, true,
        user_prefs::PrefRegistrySyncable::SYNCABLE_PREF);
 -- 
-2.22.0
+2.21.0
 

--- a/0028-enable-dubious-Do-Not-Track-feature-by-default.patch
+++ b/0028-enable-dubious-Do-Not-Track-feature-by-default.patch
@@ -1,7 +1,7 @@
-From 427f417f394e4cbadcc1ba1b7979bbe7c480e5ba Mon Sep 17 00:00:00 2001
+From 38f30d6996cd9c465ba63dc3aae2046efb00e2dd Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Tue, 1 Aug 2017 11:16:11 -0400
-Subject: [PATCH 28/46] enable dubious Do Not Track feature by default
+Subject: [PATCH 28/47] enable dubious Do Not Track feature by default
 
 ---
  chrome/browser/ui/browser_ui_prefs.cc | 2 +-
@@ -21,5 +21,5 @@ index 8d942c6765fa..4b9e252184e0 100644
  #if !defined(OS_CHROMEOS) && !defined(OS_ANDROID)
    registry->RegisterBooleanPref(prefs::kPrintPreviewUseSystemDefaultPrinter,
 -- 
-2.22.0
+2.21.0
 

--- a/0029-mark-non-secure-origins-as-non-secure-by-default.patch
+++ b/0029-mark-non-secure-origins-as-non-secure-by-default.patch
@@ -1,7 +1,7 @@
-From 33c17e576efb95b436bfe17228a90109abb3f0a3 Mon Sep 17 00:00:00 2001
+From a7e33f9449cba1aa9e334a3010c0f13e6ca2016b Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Fri, 20 Oct 2017 21:20:50 -0400
-Subject: [PATCH 29/46] mark non-secure origins as non-secure by default
+Subject: [PATCH 29/47] mark non-secure origins as non-secure by default
 
 ---
  components/security_state/core/security_state.cc | 8 +++-----
@@ -30,5 +30,5 @@ index b402dc745d2f..06b2c870262d 100644
  
  std::string GetHistogramSuffixForSecurityLevel(
 -- 
-2.22.0
+2.21.0
 

--- a/0030-enable-strict-site-isolation-by-default-on-Android.patch
+++ b/0030-enable-strict-site-isolation-by-default-on-Android.patch
@@ -1,7 +1,7 @@
-From 1b2278da100b89781ea13ccd81e2781231471da9 Mon Sep 17 00:00:00 2001
+From bbeef1aae15b5cc51ce9f772602ef1aeb96e1864 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Thu, 2 May 2019 07:15:32 -0400
-Subject: [PATCH 30/46] enable strict site isolation by default on Android
+Subject: [PATCH 30/47] enable strict site isolation by default on Android
 
 ---
  chrome/browser/about_flags.cc    | 14 --------------
@@ -52,5 +52,5 @@ index 86b61edb4a5a..66ae0278410b 100644
  
  // Controls a mode for dynamically process-isolating sites where the user has
 -- 
-2.22.0
+2.21.0
 

--- a/0031-disable-search-engine-permissions-by-default.patch
+++ b/0031-disable-search-engine-permissions-by-default.patch
@@ -1,7 +1,7 @@
-From 7b3ec6a92827dacf709b6398cdbddf34bcf7fec1 Mon Sep 17 00:00:00 2001
+From b05768f60bfcfff67424353eb90873a647e38e91 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Tue, 1 Aug 2017 20:29:56 -0400
-Subject: [PATCH 31/46] disable search engine permissions by default
+Subject: [PATCH 31/47] disable search engine permissions by default
 
 Disable the geolocation and notification permissions for the default
 search engine by default.
@@ -63,5 +63,5 @@ index f55019c639f2..69c98e105903 100644
  
      // Update the content setting with the auto-grants for the DSE.
 -- 
-2.22.0
+2.21.0
 

--- a/0032-stub-out-the-battery-status-API.patch
+++ b/0032-stub-out-the-battery-status-API.patch
@@ -1,7 +1,7 @@
-From da2caa587c99e524f531836d8c0aa6162488c038 Mon Sep 17 00:00:00 2001
+From 2f3d0495327226e65c9cd1d1e4e17d6b3951b670 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Mon, 17 Jun 2019 11:29:21 -0400
-Subject: [PATCH 32/46] stub out the battery status API
+Subject: [PATCH 32/47] stub out the battery status API
 
 Pretend that the device is always plugged in and fully charged.
 ---
@@ -63,5 +63,5 @@ index 25c3e426682c..34b21b674c1a 100644
  
  void BatteryManager::RegisterWithDispatcher() {
 -- 
-2.22.0
+2.21.0
 

--- a/0033-always-use-local-new-tab-page.patch
+++ b/0033-always-use-local-new-tab-page.patch
@@ -1,7 +1,7 @@
-From 646b52339aba86bd1aca9d044a5f97193fb576a6 Mon Sep 17 00:00:00 2001
+From ab714ef54ff502ef799da21b0d8620189a9058eb Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Mon, 17 Jun 2019 13:14:22 -0400
-Subject: [PATCH 33/46] always use local new tab page
+Subject: [PATCH 33/47] always use local new tab page
 
 ---
  chrome/browser/search/search.cc | 2 +-
@@ -21,5 +21,5 @@ index 7828c416ff5b..1c7114def5b4 100644
  
  // Used to look up the URL to use for the New Tab page. Also tracks how we
 -- 
-2.22.0
+2.21.0
 

--- a/0034-disable-search-provider-logo.patch
+++ b/0034-disable-search-provider-logo.patch
@@ -1,7 +1,7 @@
-From 816d274ba89ac6419e80f04d86b15966eb6f4c55 Mon Sep 17 00:00:00 2001
+From de1cb8645396c233cee73a55e95a860d55763734 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Mon, 17 Jun 2019 12:03:52 -0400
-Subject: [PATCH 34/46] disable search provider logo
+Subject: [PATCH 34/47] disable search provider logo
 
 ---
  .../template_url_service_android.cc           | 23 +------------------
@@ -42,5 +42,5 @@ index df23c7b1ed5b..6662ccfa4df7 100644
  
  jboolean
 -- 
-2.22.0
+2.21.0
 

--- a/0035-stop-ignoring-download-location-prompt-setting.patch
+++ b/0035-stop-ignoring-download-location-prompt-setting.patch
@@ -1,7 +1,7 @@
-From ed53f42695688826e2de1ff2cfa1d1db0a922ee3 Mon Sep 17 00:00:00 2001
+From 34ca74f4348aeb1594b87106464f25098ccd4f42 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Fri, 28 Jun 2019 16:56:37 -0400
-Subject: [PATCH 35/46] stop ignoring download location prompt setting
+Subject: [PATCH 35/47] stop ignoring download location prompt setting
 
 ---
  .../download/DownloadLocationDialogBridge.java     | 14 --------------
@@ -33,5 +33,5 @@ index 64823b27d948..251558b0565f 100644
          if (mDialogModel != null) return;
  
 -- 
-2.22.0
+2.21.0
 

--- a/0036-show-download-prompt-again-by-default.patch
+++ b/0036-show-download-prompt-again-by-default.patch
@@ -1,7 +1,7 @@
-From 00cab7f5abd11ea97008bc437db0fe0cad0bffa1 Mon Sep 17 00:00:00 2001
+From 78b74409d9a4b528a8cd90e1edd41ba83f46e3e8 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Fri, 28 Jun 2019 17:48:49 -0400
-Subject: [PATCH 36/46] show download prompt again by default
+Subject: [PATCH 36/47] show download prompt again by default
 
 ---
  .../chrome/browser/download/DownloadLocationCustomView.java   | 4 ----
@@ -23,5 +23,5 @@ index f25930b612d1..9311a63f3092 100644
  
          mFileName.setText(suggestedPath.getName());
 -- 
-2.22.0
+2.21.0
 

--- a/0037-rename-Sync-and-Google-services-Services.patch
+++ b/0037-rename-Sync-and-Google-services-Services.patch
@@ -1,7 +1,7 @@
-From 2d3eea3162e1d167002bb6f20efcb2cedfd0e341 Mon Sep 17 00:00:00 2001
+From bebcc59cc91005b5b10d032505024ab3cf67d787 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Fri, 2 Aug 2019 23:28:06 -0400
-Subject: [PATCH 37/46] rename Sync and Google services -> Services
+Subject: [PATCH 37/47] rename Sync and Google services -> Services
 
 ---
  chrome/android/java/strings/android_chrome_strings.grd | 6 +++---
@@ -34,5 +34,5 @@ index a9a597f4c44e..5b653f5f4c84 100644
        <message name="IDS_USAGE_AND_CRASH_REPORTS_TITLE" desc="Title for a preference that enables sending usage statistics and crash reports.">
          Help improve Vanadium's features and performance
 -- 
-2.22.0
+2.21.0
 

--- a/0038-remove-data-reduction-preference.patch
+++ b/0038-remove-data-reduction-preference.patch
@@ -1,7 +1,7 @@
-From 5f92651d9bcafc90c35ee72540fc8a8a3b5a486a Mon Sep 17 00:00:00 2001
+From ae3f9e3416dfcb1c39add2e3ae52de2095d94216 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Fri, 2 Aug 2019 22:06:31 -0400
-Subject: [PATCH 38/46] remove data reduction preference
+Subject: [PATCH 38/47] remove data reduction preference
 
 ---
  chrome/android/java/res/xml/main_preferences.xml       | 10 +++++-----
@@ -56,5 +56,5 @@ index 1e030309f420..f0ce671e91c6 100644
  
      private Preference addPreferenceIfAbsent(String key) {
 -- 
-2.22.0
+2.21.0
 

--- a/0039-remove-translate-offer-preference.patch
+++ b/0039-remove-translate-offer-preference.patch
@@ -1,7 +1,7 @@
-From bbf818cc6bad912627651ef3488471aafb936e6f Mon Sep 17 00:00:00 2001
+From ceab1a994c312db45d51c7e50327aee41663025d Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Fri, 2 Aug 2019 21:11:17 -0400
-Subject: [PATCH 39/46] remove translate offer preference
+Subject: [PATCH 39/47] remove translate offer preference
 
 ---
  .../java/res/xml/languages_preferences.xml    |  8 ++---
@@ -93,5 +93,5 @@ index 5b653f5f4c84..da8d6273e9a8 100644
          Offer to translate
        </message>
 -- 
-2.22.0
+2.21.0
 

--- a/0040-remove-sync-preferences.patch
+++ b/0040-remove-sync-preferences.patch
@@ -1,7 +1,7 @@
-From 4e70abfac098ecb504528fbd52c3e4a57fea8b9d Mon Sep 17 00:00:00 2001
+From cf339d347cc2e3e52b5ad20719b6747b5fff99f5 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Fri, 2 Aug 2019 21:12:28 -0400
-Subject: [PATCH 40/46] remove sync preferences
+Subject: [PATCH 40/47] remove sync preferences
 
 ---
  .../res/xml/sync_and_services_preferences.xml |  50 ++++-----
@@ -266,5 +266,5 @@ index da8d6273e9a8..e183e182f5e7 100644
          Manage sync
        </message>
 -- 
-2.22.0
+2.21.0
 

--- a/0041-remove-navigation-error-preference.patch
+++ b/0041-remove-navigation-error-preference.patch
@@ -1,7 +1,7 @@
-From 6892646260a97ddb0ab1ea850f503361c0450fa9 Mon Sep 17 00:00:00 2001
+From 56f6f85fa0623da4946e7193f229627de8342956 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Fri, 2 Aug 2019 23:46:41 -0400
-Subject: [PATCH 41/46] remove navigation error preference
+Subject: [PATCH 41/47] remove navigation error preference
 
 ---
  .../res/xml/sync_and_services_preferences.xml | 10 ++++-----
@@ -122,5 +122,5 @@ index e183e182f5e7..61cacbc762e3 100644
          Make searches and browsing better
        </message>
 -- 
-2.22.0
+2.21.0
 

--- a/0042-remove-safe-browsing-reporting-preference.patch
+++ b/0042-remove-safe-browsing-reporting-preference.patch
@@ -1,7 +1,7 @@
-From 9c8ebe9523c4d083e097ec03fb61db7fb8ea31b8 Mon Sep 17 00:00:00 2001
+From 8b725bbc8be7fd28132f9462b5b949849b40cbd6 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Fri, 2 Aug 2019 23:48:41 -0400
-Subject: [PATCH 42/46] remove safe browsing reporting preference
+Subject: [PATCH 42/47] remove safe browsing reporting preference
 
 ---
  .../res/xml/sync_and_services_preferences.xml | 10 +++----
@@ -104,5 +104,5 @@ index c1d356115acd..8a8a002904df 100644
                  return mPrefServiceBridge.isSafeBrowsingManaged();
              }
 -- 
-2.22.0
+2.21.0
 

--- a/0043-remove-usage-and-crash-reports-preference.patch
+++ b/0043-remove-usage-and-crash-reports-preference.patch
@@ -1,7 +1,7 @@
-From db51b02992b889af3f900ddb8b22b4a2af52d407 Mon Sep 17 00:00:00 2001
+From be96be7b0aebe508b1237338517c5e3dcaf54831 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Fri, 2 Aug 2019 23:49:13 -0400
-Subject: [PATCH 43/46] remove usage and crash reports preference
+Subject: [PATCH 43/47] remove usage and crash reports preference
 
 ---
  .../res/xml/sync_and_services_preferences.xml | 10 +++----
@@ -126,5 +126,5 @@ index 61cacbc762e3..2917928333ef 100644
          Cancel sync?
        </message>
 -- 
-2.22.0
+2.21.0
 

--- a/0044-remove-url-keyed-anonymized-data-preference.patch
+++ b/0044-remove-url-keyed-anonymized-data-preference.patch
@@ -1,7 +1,7 @@
-From 1e1b9d3e7938b7bcc2cc585dce0e07f8676c3beb Mon Sep 17 00:00:00 2001
+From d147f9d4b442af83965f3dc4b78aae1bdac5628c Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Fri, 2 Aug 2019 23:50:03 -0400
-Subject: [PATCH 44/46] remove url keyed anonymized data preference
+Subject: [PATCH 44/47] remove url keyed anonymized data preference
 
 ---
  .../res/xml/sync_and_services_preferences.xml | 10 +++----
@@ -128,5 +128,5 @@ index 2917928333ef..36078900647a 100644
          For more settings that relate to privacy, security, and data collection, see <ph name="BEGIN_LINK">&lt;link&gt;</ph>Services<ph name="END_LINK">&lt;/link&gt;</ph>
        </message>
 -- 
-2.22.0
+2.21.0
 

--- a/0045-disable-contextual-search-by-default.patch
+++ b/0045-disable-contextual-search-by-default.patch
@@ -1,7 +1,7 @@
-From 74dc47b5c767721941879fb656efe0ff2c15e361 Mon Sep 17 00:00:00 2001
+From c44ea5ef7f56b9afa4620e2f001bd2d12a191940 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Sat, 3 Aug 2019 00:28:49 -0400
-Subject: [PATCH 45/46] disable contextual search by default
+Subject: [PATCH 45/47] disable contextual search by default
 
 ---
  .../browser/contextualsearch/ContextualSearchFieldTrial.java    | 2 +-
@@ -21,5 +21,5 @@ index d1c3b35adece..2e758da20f31 100644
  
      /**
 -- 
-2.22.0
+2.21.0
 

--- a/0046-remove-redundant-services-preference-category.patch
+++ b/0046-remove-redundant-services-preference-category.patch
@@ -1,7 +1,7 @@
-From 8db033603a3c7290bee0bb9fe225d8a62f596498 Mon Sep 17 00:00:00 2001
+From 6088211225edc0e325bdebcc2cc53248296b90e2 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Sat, 3 Aug 2019 00:34:43 -0400
-Subject: [PATCH 46/46] remove redundant services preference category
+Subject: [PATCH 46/47] remove redundant services preference category
 
 ---
  .../java/res/xml/sync_and_services_preferences.xml        | 8 ++++----
@@ -79,5 +79,5 @@ index 36078900647a..eab3ffda3e3d 100644
          Autocomplete searches and URLs
        </message>
 -- 
-2.22.0
+2.21.0
 

--- a/0047-redirect-settings-help-icon.patch
+++ b/0047-redirect-settings-help-icon.patch
@@ -1,0 +1,25 @@
+From 8bb80fa9d9f34fe3ef6923ef71a90d888b8ae5d6 Mon Sep 17 00:00:00 2001
+From: Zoraver Kang <zkang@wpi.edu>
+Date: Fri, 16 Aug 2019 02:03:45 -0400
+Subject: [PATCH 47/47] redirect settings help icon
+
+---
+ .../src/org/chromium/chrome/browser/help/HelpAndFeedback.java   | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/chrome/android/java/src/org/chromium/chrome/browser/help/HelpAndFeedback.java b/chrome/android/java/src/org/chromium/chrome/browser/help/HelpAndFeedback.java
+index 50673d6f529a..a879ddc36bef 100644
+--- a/chrome/android/java/src/org/chromium/chrome/browser/help/HelpAndFeedback.java
++++ b/chrome/android/java/src/org/chromium/chrome/browser/help/HelpAndFeedback.java
+@@ -29,7 +29,7 @@ import javax.annotation.Nonnull;
+  */
+ public class HelpAndFeedback {
+     protected static final String FALLBACK_SUPPORT_URL =
+-            "https://support.google.com/chrome/topic/6069782";
++            "https://grapheneos.org/usage#web-browsing";
+     private static final String TAG = "cr_HelpAndFeedback";
+ 
+     private static HelpAndFeedback sInstance;
+-- 
+2.21.0
+


### PR DESCRIPTION
Addresses #29. The pressing the help icon in the settings now opens https://grapheneos.org/usage#web-browsing instead of https://support.google.com/chrome/topic/6069782. I have built and tested this change in the emulator, and it works as intended.