### PR TITLE
Apply Chromium's built-in adblocker (subresource filter) to every page

### DIFF
--- a/0001-use-64-bit-WebView-processes.patch
+++ b/0001-use-64-bit-WebView-processes.patch
@@ -1,7 +1,7 @@
-From b9c68f83fc00a7e43fe3dd6f0a567cad7cbffe5a Mon Sep 17 00:00:00 2001
+From 82995fcff47fd8acafa875b29ff35b09bf336a14 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Thu, 26 Jan 2017 01:30:12 -0500
-Subject: [PATCH 01/47] use 64-bit WebView processes
+Subject: [PATCH 01/50] use 64-bit WebView processes
 
 ---
  android_webview/apk/java/AndroidManifest.xml | 1 -
@@ -20,5 +20,5 @@ index ba6498dc35d6..b4b102ecf832 100644
          {# This part is shared between stand-alone WebView and Monochrome #}
          {% macro common(manifest_package, webview_lib) %}
 -- 
-2.23.0
+2.21.0
 

--- a/0002-switch-to-fstack-protector-strong.patch
+++ b/0002-switch-to-fstack-protector-strong.patch
@@ -1,7 +1,7 @@
-From 9bd8df61e8f3d88d698fad2acb2692de0ebc01e3 Mon Sep 17 00:00:00 2001
+From e9cee4d1d5d03a5a97a22eb24f24782f570a7b95 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Wed, 26 Dec 2018 10:20:24 -0500
-Subject: [PATCH 02/47] switch to -fstack-protector-strong
+Subject: [PATCH 02/50] switch to -fstack-protector-strong
 
 ---
  build/config/compiler/BUILD.gn | 6 +-----
@@ -30,5 +30,5 @@ index 66f3b325be58..e1baadcdd048 100644
      }
  
 -- 
-2.23.0
+2.21.0
 

--- a/0003-enable-fwrapv-in-Clang-for-non-UBSan-builds.patch
+++ b/0003-enable-fwrapv-in-Clang-for-non-UBSan-builds.patch
@@ -1,7 +1,7 @@
-From be873a30c25dd554806a4cd5f9b0e245c0eb4c4f Mon Sep 17 00:00:00 2001
+From 06d3abe15af8db44eafa4b175ddf465e01a3f6ba Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Thu, 22 Dec 2016 07:15:34 -0500
-Subject: [PATCH 03/47] enable -fwrapv in Clang for non-UBSan builds
+Subject: [PATCH 03/50] enable -fwrapv in Clang for non-UBSan builds
 
 ---
  build/config/compiler/BUILD.gn | 4 ++++
@@ -23,5 +23,5 @@ index e1baadcdd048..33be26cec70b 100644
      if (fatal_linker_warnings && !(is_chromeos && current_cpu == "arm") &&
          !(is_android && use_order_profiling) && !is_mac && !is_ios &&
 -- 
-2.23.0
+2.21.0
 

--- a/0004-Vanadium-branding.patch
+++ b/0004-Vanadium-branding.patch
@@ -1,7 +1,7 @@
-From 833dff68d5d5fe244f55279b2c12c1e477dca71a Mon Sep 17 00:00:00 2001
+From 8da877d2305b7e59bbdcd7d0188c35f390db7613 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Sun, 6 Aug 2017 12:45:14 -0400
-Subject: [PATCH 04/47] Vanadium branding
+Subject: [PATCH 04/50] Vanadium branding
 
 Current incantation of the recolor command:
 
@@ -105,7 +105,7 @@ new file mode 100644
 index 0000000000000000000000000000000000000000..d9d6661c938b2907e30da3ae87cdb2894db5592d
 GIT binary patch
 literal 11327
-zc-jF!EWp!=P)<h;3K|Lk000e1NJLTq006@P006@X1ONa4m3D0*00002VoOIv0RM-N
+zcmV-FEWp!=P)<h;3K|Lk000e1NJLTq006@P006@X1ONa4m3D0*00002VoOIv0RM-N
 z%)bBtEBHx7K~#9!?VWj)99MnsKlfJkKKmk#mXTyhSd#Y*%Ra`5ZCUog#tV)yF&KC+
 z<|GDU90K9Jge8O+2<PDNut@^%ybwqX4mOD~#x|Rm=jGuAZ?Y}P+NBwdW}lwvwYsb7
 zzCWs$s-B*i?&)QO$#0HE)79N|Z~eaax7^?T-QN}0Q9VgAq==9~B1y1@DNLZ1EKwAS
@@ -326,14 +326,14 @@ zJ0a3!Go$*HoHB+u);$m(um^Pmpo6HZ%F^*i{~yS0JYSiOkN*Gw002ovPDHLkV1iRV
 Bx8MK(
 
 literal 0
-Hc-jL100001
+HcmV?d00001
 
 diff --git a/chrome/android/java/res_vanadium/drawable-hdpi/product_logo_name.png b/chrome/android/java/res_vanadium/drawable-hdpi/product_logo_name.png
 new file mode 100644
 index 0000000000000000000000000000000000000000..8678cbbb730de9c3ff9d3dba7d928d60f28bd550
 GIT binary patch
 literal 1998
-zc-jHZ2Qm1GP)<h;3K|Lk000e1NJLTq005f+001Be1ONa4uVuoq00002VoOIv0RM-N
+zcmV;<2Qm1GP)<h;3K|Lk000e1NJLTq005f+001Be1ONa4uVuoq00002VoOIv0RM-N
 z%)bBt2Zu>SK~!ko<=J0sWOWq>@Xx*Tue$}h(?xgL^$(e{1YKD$ttiGof~^Vx9)MOu
 zG$zJ$V+<<#(2`(G2$D7sv-n`r`s9OR+7Oj!jP4K>9x$+jvMdlpCd<G5<L-9a?Y7g-
 zOlN%PbUM?eP`V|f@STVG{k!LP&i9^kf9KpA+yX)cp|aCLam8fei-l{8d&(cGTp%zN
@@ -374,14 +374,14 @@ zza1|{8eS^B9}!%))KF3pS28cMJ#j<i+Hm*uwq56aHaKx+;rQJ1`Nz)uvHbcbt!9+#
 gs)YxeZ9!A;U++Vmx7pctfdBvi07*qoM6N<$g5_ZC5&!@I
 
 literal 0
-Hc-jL100001
+HcmV?d00001
 
 diff --git a/chrome/android/java/res_vanadium/drawable-mdpi/fre_product_logo.png b/chrome/android/java/res_vanadium/drawable-mdpi/fre_product_logo.png
 new file mode 100644
 index 0000000000000000000000000000000000000000..40b88b5225ddff2fb47116a99a38999218e744ec
 GIT binary patch
 literal 6794
-zc-jGq8g=D~P)<h;3K|Lk000e1NJLTq004pj004pr1ONa4APU%a00002VoOIv0RM-N
+zcmV;58g=D~P)<h;3K|Lk000e1NJLTq004pj004pr1ONa4APU%a00002VoOIv0RM-N
 z%)bBt8be7$K~#9!)tz~iB*lH_KM{G<)z|bjJ@>)D%!mO-Fw7-DAPmTokc7~a^mM>3
 zZzcS8pLT_9R@Sb(&)T)*U3n#2eztCw(_%quSrW30g+~aD#AO%`F)++9!yMhycU9M2
 zm6esTe`IDI-BsOnwFSR?U7eMc85!}--xa_3MWpxuOOYgpLdU@%#5jW(oWUeO8V!Yp
@@ -514,14 +514,14 @@ zhj>D$5MmkU-7e!>Q2kdIXfIhW74NXI16-hOVT5&Tll`hE8(I@M7MRpEgsm*{#hgm!
 s;^t9aPfn=Q!52i_!lZI+YPsnD1F3svQs!l<l>h($07*qoM6N<$g1%n2wg3PC
 
 literal 0
-Hc-jL100001
+HcmV?d00001
 
 diff --git a/chrome/android/java/res_vanadium/drawable-mdpi/product_logo_name.png b/chrome/android/java/res_vanadium/drawable-mdpi/product_logo_name.png
 new file mode 100644
 index 0000000000000000000000000000000000000000..5f92063170520afa34dd48fa6610ea122439e916
 GIT binary patch
 literal 1200
-zc-jH51W)^kP)<h;3K|Lk000e1NJLTq003tI000#T1ONa4@uE1m00002VoOIv0RM-N
+zcmV;h1W)^kP)<h;3K|Lk000e1NJLTq003tI000#T1ONa4@uE1m00002VoOIv0RM-N
 z%)bBt1Zhb`K~z}7&DURyTy+%(@Xx(>_FsX@O}84i3U(VMgzx}UVwc9o;1FXpBtoWy
 z2j6rWUf_X*Ex|`ac1+~Kw;kh?hR6=+gBnd1V-!O{cS$sAG|)-^n3k4yW}(~d?#%4H
 zJk0Ig(t_M=8p?UO_x{fBob&yjbAEqr@Ss2<(bv_zXSLeh+uv!6mFS39qGs}1Psy+Z
@@ -547,14 +547,14 @@ z^+sAqN|1`A|9R&d!QRnoG_`We?y>N~$>SGZU49|`b6{BT;s2taFnJGY>5Ee&#m%|^
 O0000<MNUMnLSTZ4d0|-q
 
 literal 0
-Hc-jL100001
+HcmV?d00001
 
 diff --git a/chrome/android/java/res_vanadium/drawable-xhdpi/fre_product_logo.png b/chrome/android/java/res_vanadium/drawable-xhdpi/fre_product_logo.png
 new file mode 100644
 index 0000000000000000000000000000000000000000..07ecccb90a3786c3c3d7ac33a3f8cb2d2ee555b2
 GIT binary patch
 literal 16100
-zc-jHvJ{!S_P)<h;3K|Lk000e1NJLTq009I5009ID1ONa4WC4PK00002VoOIv0RM-N
+zcmV<AJ{!S_P)<h;3K|Lk000e1NJLTq009I5009ID1ONa4WC4PK00002VoOIv0RM-N
 z%)bBtKAlNKK~#9!?Y()N9A|y!|9+mT>T52|jP6^OWZ9N1VOvH9-zHeb#!fgw4%lQv
 z$ijkcSV%%nLjpgJCFC%egaq>2WV4%1AUFXM8<TL^1|O0SNyfU5(Tp@#&(+g+RXzJh
 zbx&7!Rrhqy^fjzM^HOW3y6UOt_&(q3`99xAyqU#AATUW`(?ymf-K5CSOD`ws#wNu|
@@ -866,14 +866,14 @@ zHcQ#BHdrh4<*AJ_B6{r&$*>;S8h$!F714vru|u<1B12pyR4S0QllFOiQcu_e_IP%D
 q!#O!IXc-t}kqB(e_H@WD3jY_Ejr#a36nZuQ0000<MNUMnLSTZIDYe}I
 
 literal 0
-Hc-jL100001
+HcmV?d00001
 
 diff --git a/chrome/android/java/res_vanadium/drawable-xhdpi/product_logo_name.png b/chrome/android/java/res_vanadium/drawable-xhdpi/product_logo_name.png
 new file mode 100644
 index 0000000000000000000000000000000000000000..ee268c83d97f8d6b73eac0dbe25a204dcc91d4da
 GIT binary patch
 literal 2609
-zc-jFm3eNS3P)<h;3K|Lk000e1NJLTq007Pa001fo1ONa4QNyg;00002VoOIv0RM-N
+zcmV-13eNS3P)<h;3K|Lk000e1NJLTq007Pa001fo1ONa4QNyg;00002VoOIv0RM-N
 z%)bBt3F=8iK~#9!?VEp$9Az2DKl9G)>|MKe?OY3KEzmHhZ7oJh_b?bl5q6Cl$`8$6
 zVyeMtyrsqjL?Wkupu|7C13_#I&?Eea{E9vN5hVoEGmQ!{$}OUR0>T#Bv=rLj-0j}p
 z?#}Mc_{YxP?flr@59Y4e+;@|^n`hsd?>o=)KF|BS&-<SA1?mt~siI;sg@r%{tPPb<
@@ -926,14 +926,14 @@ zR{4SA1I10^GC3}7F0I#ApB+75niI9R&DV<0m-ZK5R*5d?U#*rgcSy_XegEQref)de
 TPbPHy00000NkvXXu0mjf*Ld(I
 
 literal 0
-Hc-jL100001
+HcmV?d00001
 
 diff --git a/chrome/android/java/res_vanadium/drawable-xxhdpi/fre_product_logo.png b/chrome/android/java/res_vanadium/drawable-xxhdpi/fre_product_logo.png
 new file mode 100644
 index 0000000000000000000000000000000000000000..4f300d7f849b005ba63163d63a643f3aeb737aea
 GIT binary patch
 literal 26693
-zc-jCpK+3;~P)<h;3K|Lk000e1NJLTq00D*o00D*w1ONa4)rszI00002VoOIv0RM-N
+zcmV)WK(4=uP)<h;3K|Lk000e1NJLTq00D*o00D*w1ONa4)rszI00002VoOIv0RM-N
 z%)bBtXZ}e<K~#9!?Y(!LBu9Ps|E}tuxOs2)a#YSbC6rMH1Ok&yFg9R#z!)AIunpLL
 z%wufxke!VaVEiK*3?>O1Bmol20R<$TPP(+WySF*bPV7*>KYC`TXQroTW_M<HW_CaQ
 zy4&5E>h9|5`qVenx4tD_$?8A=kjBJDrvsA(Bz>49u+a!}I!}@z!wwdh;UrRoh%-qC
@@ -1249,7 +1249,7 @@ zdcKKqUq4ciB!{qTmJ6-Wr*uL*_0Tg2KpGerq@K0fPBJ*qNO3#8zT<uz$-B{8IEHn3
 z5G2ug55gx)5<nM6+b~wufriD%p(7mSsG}z7$fu09GoisrTOZ*OCh77ir8C53+`>W=
 zkzqAfmrLe(DVH+jn;lOl#X&6e8Z#xe261c>!<(Mk&NjB?#DU0|Pqs$oYlT2#m^;{1
 zK?R!U{p?|;N#x^dybFzK_VRna>lZ-L&9j^!*y2l}ydlV7{<7cbp@$x1m@r|YaDTh3
-zcPoBe8^Jv+(B;#`0T3wf*90>}crP?X+R4?Rf+UIHeT13ued0h?E@(BTlWdKlRiKF9
+zcPoBe8^Jv+(B;#`1T#c<FEmBk$<?5OB#GdCgqiVu;y_j|Xf>vj0rV#e*ldlVRiKF9
 zzd)QAF{Fisg^lsB*(9T4{U12UP(|6GGsHFgDzj_+8dobLmCYQl<C+R8l1(=UnIKeS
 z{=C+pg0lxv`oY}h?#>J}7UE&M3C6_6;YUo+U*RQ9^M1}{x^BBzHZL@$Igj@-U7=i*
 zMSh7u)-+JI3Kc*jsgl3QkS0w!_ly!XY&^QwRcjOkL5}l%)#Lk`1Pd5^jQ$FN%#Fip
@@ -1449,14 +1449,14 @@ zmdO6dLevV2PCKFk1e8tyg&_<~Vak+T6mgOyRl46yrqzfT&dhB~rQ@;TuHku8A=pF*
 gCy1=|1GgRie-#m>m)v0)5&!@I07*qoM6N<$f-sBn4*&oF
 
 literal 0
-Hc-jL100001
+HcmV?d00001
 
 diff --git a/chrome/android/java/res_vanadium/drawable-xxhdpi/product_logo_name.png b/chrome/android/java/res_vanadium/drawable-xxhdpi/product_logo_name.png
 new file mode 100644
 index 0000000000000000000000000000000000000000..fc327262fd9479d15200e5ebca3f5335a1ce12c4
 GIT binary patch
 literal 4270
-zc-jH35K-@mP)<h;3K|Lk000e1NJLTq00A`s002J-1ONa4EBcpR00002VoOIv0RM-N
+zcmV;f5K-@mP)<h;3K|Lk000e1NJLTq00A`s002J-1ONa4EBcpR00002VoOIv0RM-N
 z%)bBt5NAn5K~#9!?VVe28`pWqe`j}b;Y}oD-6h)*Bwyq{=mJ@mRC}5zU^<Q`Gqz+Z
 zeTeH!(@;q|(_}iGkvxslNj>RMO&_Z1q%mnH(^#G+rXu^L^(CS+aZ^=^B}kQ%Sh6F*
 zvUQ^rkst|@xGb>S2P_r~VlR*kg0O`@W(W{x&+fOoe|+aV-{q{>jujFrDn4X#q|wQs
@@ -1541,14 +1541,14 @@ z*2`;HlJ4qiTN*q=E}fs&#<Ev(?_^F){hCug1Ockg5ozLPfoK}+P1Fbf4>8lX6)B~&
 QLI3~&07*qoM6N<$f)Jt_fB*mh
 
 literal 0
-Hc-jL100001
+HcmV?d00001
 
 diff --git a/chrome/android/java/res_vanadium/drawable-xxxhdpi/fre_product_logo.png b/chrome/android/java/res_vanadium/drawable-xxxhdpi/fre_product_logo.png
 new file mode 100644
 index 0000000000000000000000000000000000000000..52abcdfc19c13770971730c8bd4d8267a633ac22
 GIT binary patch
 literal 39011
-zc-jC^K(D`vP)<h;3K|Lk000e1NJLTq00IaA00IaI1ONa4q4nPA00002VoOIv0RM-N
+zcmV)xK$E|TP)<h;3K|Lk000e1NJLTq00IaA00IaI1ONa4q4nPA00002VoOIv0RM-N
 z%)bBtfB;EEK~#9!?45U<Bu9Dozg686H{RY}4!S!@r;~KbIR}u)29a!IW57g%jcpvk
 z*v7^YkWF#`1I9MI7>j5yK}Z5cKmiFPp?tcy;WqD1?ojU^J+qT~W_o64cEa{=KGN+>
 zcXd})S3UjYN4%U)f<TbQL}8<$6GAeJKr%ppX#$u?G&IiV3C4(GBH78~gpi!VA)*ZN
@@ -1864,8 +1864,8 @@ zAtnhgKOCs$P3V5aDezV6u~v$0uvy^wynth#$$`xf0p8CnqrUc_F4zn*#b5GChFJ2r
 z5hb(i=REEqMHn5c!e*%UTlq2X-i@Ux&b;~)*1AtUB%suzu^jo8u(a1K;J{=qAA117
 z!d2dV!`cB!f;4BKm+9y$SJ-pk0t(y1o7z1i&Jz9n36_gjL?sA@`8W?U($2}F`^bTV
 z^*q4G8L4AsDl%NlAW4$cryp=XCOmKGVtYX)jYXxF-uwru!(BsBK0`UJ2P|A3BeDFE
-zIs2oD-DjQFsTzblrrE-d0)GVe?1;5;Ce}w1@(@6b=d!PkgkKf_P(ZK0JNPkQAX1Y2
-z)rS{2RiwYbee9^i+Az-!&Lu+z1Kopup!8T}iM?7oQTE-texSSu)rnT+D|xwRPGr^q
+zIs2oD-DjQFsTzblrrE-d0)GVe?1;5;Ce}w1@(@6b=d!PkgkKgr_%UA~Qj+}DhZi_i
+zq`$y@?5M-qFwYLoB|`=P(m*Z01Kopup!8T}iM?7oQTE-texSSu)rnT+D|xwRPGr^q
 z`z$M*w=~KW&L>Us;`GKAKG~)~Vz9s&L|t5z>Vtp^9`EkwI?z~Rh~FcD>5+l8Sx1}?
 zVbJG`3k~+WAA=8)tRsnx%@UU}LNaTnZj>J=wL>V^mhRuZ^8;>%L~kO3C~N8M%tG>J
 zYzkl0znn2?c~vXqS%%i>{DG6baFD%D{YlEziPbrW{PZ~RW^pJyKhBHT$FxTkmqIeg
@@ -2181,10 +2181,10 @@ zNnf2<2ZGFV7&#Sq5%Z!T1<mSWRjmw#kO+8If0gm=neZqf49^qbZ}*j=R=9KSn<z@G
 zn)^McHOPA^sDi&u5(K#pjhLToy$*y};u&O8e^us?f!Vg1)8lQqts>(H3O~?ZpZV_@
 zMhPtE{r9o@a93U_SF><=;`KaiOfp=|8F8xs02mNSL_t)@9;S%-$<jO{M3Mu<xaf5!
 z-X6znqawCtY1penWNDyH=!?M(v5(C%+R<JKy$m;Z<=nSYfkBm!j$*;VNtQOkb4ZaS
-z?ehm75hTqs81((-@J*wvbGYX=VO3)p0mBzO=nCPyI~0n*$AjxL@0;;S!YZM1cI8q%
-zfsHB>2nzEmmb);6MFxY**vc63wl3>#LJ*5*h%xx*)<0!XB-+}Wjv(UVFZ9nRne#2y
-ztANVy_tM|hvca+Nh${Ji;W3jqTe*w{;w`C6+=~ccbAWk5pHqL?2_kbx5Cn_J>xRD;
-zV-Bq|I<zKHsS-owY>LIdTVx1uEkPFiQm!7M0|%I9*H=bg-x=}09kTzV6?l#OVUjtY
+z?ehm75hTqs81((-@J*wvbGYX=VO3)p3gNsv6pFydgX=TzoAF7)Dxq?A<x)L?jVcld
+z3iB$KyD)=A27}Ak${6vsF6(YW5Q}GsG5F`!KV?uP+S;3rAmZXL^v@@m^DWk^fXeUp
+z(%;px!Ljg&D*1omF_So3xr_zkEvZc0iwIzIfO$fnQ-9eBB6CL&1dGV)hQAhL4y`jf
+zv?fuh5<}%|ip9TMWC(CAK^FW{t{$NS2bcjR7ux7%*H=bg-x=}09kTzV6?l#OVUjtY
 z(OfkYyCYTdGH^RytVYcJ>X;kPWuBx9Z{edH8j?dy(|7mo*VtAk@CO}35EOP&T&Ld|
 zXBOEho$5K1O8)Mag~H>i2H%iBYLXzrbAXtiJJAy~bPh6&cBi`DN_R>QF}>Y%Dd&PA
 zu;cox)E)7?lHs;TIIIO!^OJYe5#)a_hhuKMlwC}b@Xd`LprLb!DMC-CUZoOxR(Tsh
@@ -2301,14 +2301,14 @@ z_ovCc>JVL~6Nel*qf8EkA(UZKq##1!Qp6RmDdR~WZ@xb2TgT;pb#Gjxe1+ay)NW^0
 f`ch_Jq&DIIbfZ@m$+<~>00000NkvXXu0mjf!$8AO
 
 literal 0
-Hc-jL100001
+HcmV?d00001
 
 diff --git a/chrome/android/java/res_vanadium/drawable-xxxhdpi/product_logo_name.png b/chrome/android/java/res_vanadium/drawable-xxxhdpi/product_logo_name.png
 new file mode 100644
 index 0000000000000000000000000000000000000000..5f16990a7eb67c441bfc62d50a4e92f95c0f4f22
 GIT binary patch
 literal 5925
-zc-jFa7ux8FP)<h;3K|Lk000e1NJLTq00Eo;002}71ONa49E3^V00002VoOIv0RM-N
+zcmV+=7ux8FP)<h;3K|Lk000e1NJLTq00Eo;002}71ONa49E3^V00002VoOIv0RM-N
 z%)bBt7T!rjK~#9!?VW3I99NZqzuVpO(9<5-ma!dTYwU!O1cx9c1V|NBN`~dR6d=Qr
 z;9Wu?k?a=B0u`Gjfm)z~9jXYhOTeO*uml3JYO~8D0oK~=BfOGWu#f~N!5-W3Te4>)
 zjYgVh_x_lkQTI&G^c`g+&6xhCT<%dn=AQ0*`kZ_3x#x;^P>w=|ETAD!nMOe;4fx2R
@@ -2425,14 +2425,14 @@ zntO)Bsb@2f>)9Xy)CEPqd3ZD)!gH8BJZeXNYNm&WN0I*rsl^JT&aD`J00000NkvXX
 Hu0mjf>GD|)
 
 literal 0
-Hc-jL100001
+HcmV?d00001
 
 diff --git a/chrome/android/java/res_vanadium/mipmap-hdpi/app_icon.png b/chrome/android/java/res_vanadium/mipmap-hdpi/app_icon.png
 new file mode 100644
 index 0000000000000000000000000000000000000000..9533ce927dbb3f4d3849d9a2c062ff31850ae454
 GIT binary patch
 literal 2578
-zc-jFH3hniYP)<h;3K|Lk000e1NJLTq002k;002k`1ONa4|Kxkj00002VoOIv0RM-N
+zcmV+t3hniYP)<h;3K|Lk000e1NJLTq002k;002k`1ONa4|Kxkj00002VoOIv0RM-N
 z%)bBt3Cl@DK~!ko&6;g&9K{*Oe>1yxw$JbO8P_4Po#2Ed#34XHNoYhVQYlDKP@zf@
 zQc+t$^PyEskqT=10YutL<)xL{(l30d1VJe&MXDf_hLlDD6d<%Nae@tbabi31OJdIN
 zcelIK4?BCeciy|(%Zu9QboTA+?#yrg^UO0dI}873CN6Rw>VE|!0D;tB_gDcA3Wb9@
@@ -2484,14 +2484,14 @@ zXXB@sW|~>%NnwTFPc9S4yIy9tcp`dZ$9=x*cD58r()wd%HYdv}pnUV*K$DqAt8PAy
 o?sU%izlC<8Z|MbZHC}-I7X>G&nZLZnpa1{>07*qoM6N<$f{)wb@Bjb+
 
 literal 0
-Hc-jL100001
+HcmV?d00001
 
 diff --git a/chrome/android/java/res_vanadium/mipmap-hdpi/app_shortcut_icon.png b/chrome/android/java/res_vanadium/mipmap-hdpi/app_shortcut_icon.png
 new file mode 100644
 index 0000000000000000000000000000000000000000..b054450f1534f806b8b28213b33778e75c450725
 GIT binary patch
 literal 2574
-zc-jFD3i0)cP)<h;3K|Lk000e1NJLTq002k;002k`1ONa4|Kxkj00002VoOIv0RM-N
+zcmV+p3i0)cP)<h;3K|Lk000e1NJLTq002k;002k`1ONa4|Kxkj00002VoOIv0RM-N
 z%)bBt3CBr9K~!ko&6;^^9Mu`XfA7uguD!lC_PS1-!*(tL*pNUdN+2abRSqc#R6!}C
 z1qrp3KPpiQYAPrK)F9MC)k+AYs>dH(IRMd0B|r(ZB&j$|m6XIzq6Fe3Hu%V4d$YE8
 zXXf>fdAmEip4r1m)PAcy=FOY;{pNe$eDC-c{?A05<u=s+3P=C~i9jIru>u?v3I{b)
@@ -2543,14 +2543,14 @@ zWRetC+4<xOfim?aW;T@*Axuc;4IC`eq?jVDU+y1ID%#<iS;{$+naiXqGASO%Gw9Fo
 kUub9gFFpTM;~B_*0oNUsuT)Zgn*aa+07*qoM6N<$f)V!8^8f$<
 
 literal 0
-Hc-jL100001
+HcmV?d00001
 
 diff --git a/chrome/android/java/res_vanadium/mipmap-hdpi/app_single_page_icon.png b/chrome/android/java/res_vanadium/mipmap-hdpi/app_single_page_icon.png
 new file mode 100644
 index 0000000000000000000000000000000000000000..c544d46ce870ad2efc9984da57d853df5f28c3e4
 GIT binary patch
 literal 1496
-zc-jHj1t<E6P)<h;3K|Lk000e1NJLTq002k;002k`1ONa4|Kxkj00002VoOIv0RM-N
+zcmV;}1t<E6P)<h;3K|Lk000e1NJLTq002k;002k`1ONa4|Kxkj00002VoOIv0RM-N
 z%)bBt1(8WaK~!ko?b`2e6LlQG@%P=W?K))Z24hoTs|p6?$Lh2BfG~M5;$Pr1Wj^x}
 z{sW36K3pQk7!uKpghWvzBqkV8%rM|G!+wOx07D$pzyfq^D_w8x*53Kx?%Hd6cfD(`
 z3nqS>w9DOn?_T}>xX<T%9sFPZV@0sraU-UFob9vTrvM^~<B3DpIk;!RH_(k}ZZZ?G
@@ -2581,14 +2581,14 @@ zb9Vz0S$6R(3Mwlk<(uP|zFE1&9p;Jypy25m-peMs=@i;G#UkAzy<H3QPvlf;W_s}!
 yNoJTUbk%x+03vLpg;t=E9BZr*C&^Md2H;<$gf3O<DB$=20000<MNUMnLSTXr)4V<a
 
 literal 0
-Hc-jL100001
+HcmV?d00001
 
 diff --git a/chrome/android/java/res_vanadium/mipmap-mdpi/app_icon.png b/chrome/android/java/res_vanadium/mipmap-mdpi/app_icon.png
 new file mode 100644
 index 0000000000000000000000000000000000000000..5c340f7a0936223c14d858784e18e38443264df5
 GIT binary patch
 literal 1532
-zc-jH{1q1qtP)<h;3K|Lk000e1NJLTq001xm001xu1ONa4{R=S+00002VoOIv0RM-N
+zcmV<Y1q1qtP)<h;3K|Lk000e1NJLTq001xm001xu1ONa4{R=S+00002VoOIv0RM-N
 z%)bBt1+_^;K~z}7wU}LO6jc<*fAhK9FSj4Gl@^fFmXCf&_%0<7pdv9*FyTp!k%UB(
 zB1RJR!53qA-~}{B5jF7z2vK}6qQ*dCNDwS7U<+0QrBIr*wA609Eo^tUyEEg%%<SjP
 zwqQIrnPl#q^Z(y_&bjxVJMce?FiS17nfeA`SnWR(2#82ki_~VRNmwpc;R9nrzZ>h+
@@ -2620,14 +2620,14 @@ zm1+;i!}o^%y8HLd?$8i^0)&aWZc4NGS7FwHIpmUy2MLG~A;c6RqC~U(MwktOtz}*V
 i?5f^Os2P5PnDQ@s4<gB_=JK-u0000<MNUMnLSTa0>e?Ux
 
 literal 0
-Hc-jL100001
+HcmV?d00001
 
 diff --git a/chrome/android/java/res_vanadium/mipmap-mdpi/app_shortcut_icon.png b/chrome/android/java/res_vanadium/mipmap-mdpi/app_shortcut_icon.png
 new file mode 100644
 index 0000000000000000000000000000000000000000..8723f01f61d163b947af43af0c871695ed25ee6a
 GIT binary patch
 literal 1534
-zc-jH}1p)erP)<h;3K|Lk000e1NJLTq001xm001xu1ONa4{R=S+00002VoOIv0RM-N
+zcmV<a1p)erP)<h;3K|Lk000e1NJLTq001xm001xu1ONa4{R=S+00002VoOIv0RM-N
 z%)bBt1-D5=K~z}7wU}9KR8<(qf9Gy9okFLDLWP3Tg~gVtY*J7NNWhp7jKL)amniWC
 z2*yNt@Ie!NASNs-1PGB3aUp^)LP!)f1~h5dAp)`#DN-m@pbN~_nR|~9_uiSgGk4m8
 z@w>^)+_U`t=X~F}=X`hIe>Tz2R`zALmw<Gx|12O7Xf>mPjWmjhREbiM9cBy1<iTXq
@@ -2659,14 +2659,14 @@ zvaW21dAB2et?hKnnRBONZQP=hI7xqaUjlZ$y$ci(B7}hkq(~4WN{l4Q-u_1DkAU0C
 kebcbBdV4`xeI`u6zY8!J8&ZgeVgLXD07*qoM6N<$f-H)~aR2}S
 
 literal 0
-Hc-jL100001
+HcmV?d00001
 
 diff --git a/chrome/android/java/res_vanadium/mipmap-mdpi/app_single_page_icon.png b/chrome/android/java/res_vanadium/mipmap-mdpi/app_single_page_icon.png
 new file mode 100644
 index 0000000000000000000000000000000000000000..2ef668f35442a8681129f3db24c6fed504d61ae4
 GIT binary patch
 literal 1206
-zc-jHB1WEgeP)<h;3K|Lk000e1NJLTq001xm001xu1ONa4{R=S+00002VoOIv0RM-N
+zcmV;n1WEgeP)<h;3K|Lk000e1NJLTq001xm001xu1ONa4{R=S+00002VoOIv0RM-N
 z%)bBt1aC=1K~z}7)s|amTtyhie>3OI*-M&DlQt=(ZPKKrTErVsP(iB{eW(a(B2=qr
 zrTA8T$+I`a7HI|XLBt39V5Fo~RPaGjOG~8?YM@}129uQZlBBV1ZkyfgIcLU)J>6ta
 zb~l^Ty!g%2&VKX%4gdM(I|Kjs5aEdfZ|rz`W_2}7En2_t+WT#8S%AY&Jar`798NL_
@@ -2692,14 +2692,14 @@ z`4MAz0~f`Crd?apPTtB&j}wQ>e3|OqR`bB7hf<qU+=t8bTz_xh>7irvlg?-T2X2kH
 Ud&;davH$=807*qoM6N<$g0vVglK=n!
 
 literal 0
-Hc-jL100001
+HcmV?d00001
 
 diff --git a/chrome/android/java/res_vanadium/mipmap-xhdpi/app_icon.png b/chrome/android/java/res_vanadium/mipmap-xhdpi/app_icon.png
 new file mode 100644
 index 0000000000000000000000000000000000000000..2110d524c9c403b80301dd34709d4f6fcc430f28
 GIT binary patch
 literal 3727
-zc-jGv4sh{_P)<h;3K|Lk000e1NJLTq003YB003YJ1ONa4NRhv@00002VoOIv0RM-N
+zcmV;A4sh{_P)<h;3K|Lk000e1NJLTq003YB003YJ1ONa4NRhv@00002VoOIv0RM-N
 z%)bBt4oFEvK~#9!?VM?BT-SBSe{Y!?awu{rky<E9q83w|B}<lV$yH+4ixMM+<2Y^|
 zApX!GY10O^fueDP26ciKU4p_6)EGe>%L$UY1q@{Y?80_qYqjHgk+Nu`EZGz#$|NO{
 z5*KkB&b)c=_QShx8@`!&Z%Ety&@+(c&0FsM|Ia<=-gD2pm+=4c@rv@Hl~`P|DEj_C
@@ -2773,14 +2773,14 @@ z9k%K%AG1#Yxqn*%9UWbMYjPp9L%?(fLrhE;_#FIcjJeuX<!lB}<Wj@nvNy-CEq8V~
 tXMdbzt~W?J>%)T!-Glpw=5&Y9{{mHf#%w_K>9PO-002ovPDHLkV1nv5AYT9g
 
 literal 0
-Hc-jL100001
+HcmV?d00001
 
 diff --git a/chrome/android/java/res_vanadium/mipmap-xhdpi/app_shortcut_icon.png b/chrome/android/java/res_vanadium/mipmap-xhdpi/app_shortcut_icon.png
 new file mode 100644
 index 0000000000000000000000000000000000000000..dce04b58684dd6c7ee265ddf332facaf9d4073e9
 GIT binary patch
 literal 3664
-zc-jF_4zKZvP)<h;3K|Lk000e1NJLTq003YB003YJ1ONa4NRhv@00002VoOIv0RM-N
+zcmV-W4zKZvP)<h;3K|Lk000e1NJLTq003YB003YJ1ONa4NRhv@00002VoOIv0RM-N
 z%)bBt4hcy_K~#9!?VNd#99MnEKd-xIW@m4$q&=k7v9edPBnw@(1oDA|%@LO&#)UBz
 zl2o8b{ve@J_8-KQ9qg(EFiAy<330F?6fPXa2tpC;U?dDeaj+v|qcgT-tye2)SI25E
 z?KL|y-Tm@MzdmNRXQpR%WaSTjU8<e#cYVLV_j~XC-X-|0Tw4)WEyw(vW!~TacLW3=
@@ -2853,14 +2853,14 @@ zdH=Tr1_p-utE+?1E&<CO46(30;8pmqF{*W|%D;jUT;B07eYjnd<+buEolUFu1xf#?
 ie=zsl`$JVdRQG?1!InhXyR7v90000<MNUMnLSTaK4EbIF
 
 literal 0
-Hc-jL100001
+HcmV?d00001
 
 diff --git a/chrome/android/java/res_vanadium/mipmap-xhdpi/app_single_page_icon.png b/chrome/android/java/res_vanadium/mipmap-xhdpi/app_single_page_icon.png
 new file mode 100644
 index 0000000000000000000000000000000000000000..a0a80433631765f9bd91707fffb16cffe7160a95
 GIT binary patch
 literal 2639
-zc-jF^3b6HwP)<h;3K|Lk000e1NJLTq003YB003YJ1ONa4NRhv@00002VoOIv0RM-N
+zcmV-V3b6HwP)<h;3K|Lk000e1NJLTq003YB003YJ1ONa4NRhv@00002VoOIv0RM-N
 z%)bBt3J6I=K~#9!?VEXQ9Mu`XfA7t)-nAW{I0=q%oTN}eI76V9L^;$WC<Roh6jeRd
 zmi|+<DkZ9D)gm<kK|u)70}1u7LPbi7qN-4pMh#a{A);y$jwGgd?f8z*wb#e)%zOP~
 zXHT#9w8yT>H?n5eGyCTIz4yIuzVDki@PT|F|KB2tpYqTZH~utoBUYhv6aX^ysjx`Y
@@ -2913,14 +2913,14 @@ z>F6ur*vMv@X{p`OzN_g&bz5Xzh>x;>gX2z&4E3CO>p%Z?hMD9XgGBN*v9<sJ7Hzb$
 xfm(tDkkqtonVp;KM-pR!IcAt*l<DPu{$JS7*jWIpcGUm?002ovPDHLkV1jo9>>B_8
 
 literal 0
-Hc-jL100001
+HcmV?d00001
 
 diff --git a/chrome/android/java/res_vanadium/mipmap-xxhdpi/app_icon.png b/chrome/android/java/res_vanadium/mipmap-xxhdpi/app_icon.png
 new file mode 100644
 index 0000000000000000000000000000000000000000..f4894e5b5b5047708bad46853f06c3bd68e54aa0
 GIT binary patch
 literal 6160
-zc-jFF81LtaP)<h;3K|Lk000e1NJLTq0058x0058(1ONa4O;0K_00002VoOIv0RM-N
+zcmV+r81LtaP)<h;3K|Lk000e1NJLTq0058x0058(1ONa4O;0K_00002VoOIv0RM-N
 z%)bBt7s*LPK~#9!?VWj$9MyTif89OTUfN4qUAvM%Vzo#}kw8e`00IoMAyC-Zv11cE
 z#ARa2c9khRNmU%jE?jneRKQ1U2OQsb0CQs(64)FD34sBFBqRhvNGt6n?Xv9LGu@p(
 z`g%RnJ<~JOqr>HIYIgg4{oZfB?|b)a_>25S{vu5j=_Gi*exgUPS<jU0zmn^?14Vaj
@@ -3041,14 +3041,14 @@ ze;qSGZcNx~(z;hnFCCERG|Xu(gX37CIo5#0=as%T&i%$B5IZ^CZx(=KhUWMH@_Mq@
 iy8!i)|Hl}MBmWOUsYCM~E)RwP0000<MNUMnLSTZfrRkLb
 
 literal 0
-Hc-jL100001
+HcmV?d00001
 
 diff --git a/chrome/android/java/res_vanadium/mipmap-xxhdpi/app_shortcut_icon.png b/chrome/android/java/res_vanadium/mipmap-xxhdpi/app_shortcut_icon.png
 new file mode 100644
 index 0000000000000000000000000000000000000000..ddde3d59f00d5eb17564a8214ad9cdcffa38a299
 GIT binary patch
 literal 6046
-zc-jG;7h&j$P)<h;3K|Lk000e1NJLTq0058x0058(1ONa4O;0K_00002VoOIv0RM-N
+zcmV;P7h&j$P)<h;3K|Lk000e1NJLTq0058x0058(1ONa4O;0K_00002VoOIv0RM-N
 z%)bBt7gtF{K~#9!?VWj)TveICe{ZR!_a&VUounJGbs9nffg}(V64^#n#2FDs85vv{
 zopGC^cpM$^3>;>hGc%%&3JT~jxE|RD)G@3IgCrn<glvRBmJZ!XC+Q?zUF%!skGI`d
 z>#M3)oy6l;C!KoRefR$A`@Z|#`|iCD{v>~rKS={cIsxu)9`6}!)IBBlujJeBK{0*b
@@ -3167,14 +3167,14 @@ zV!CK#q7I3sCI;VAG`@7|0Ezd@e}SC;jYZ&J8rI(@JH^YuPBoxnca{qFhz~g^_%@~T
 Y|1QPj5%LR(VE_OC07*qoM6N<$f_t{1X8-^I
 
 literal 0
-Hc-jL100001
+HcmV?d00001
 
 diff --git a/chrome/android/java/res_vanadium/mipmap-xxhdpi/app_single_page_icon.png b/chrome/android/java/res_vanadium/mipmap-xxhdpi/app_single_page_icon.png
 new file mode 100644
 index 0000000000000000000000000000000000000000..a18ac214a3cbcd93fd5722bdc4da33de245e68bf
 GIT binary patch
 literal 3485
-zc-jG-4Px?%P)<h;3K|Lk000e1NJLTq0058x0058(1ONa4O;0K_00002VoOIv0RM-N
+zcmV;O4Px?%P)<h;3K|Lk000e1NJLTq0058x0058(1ONa4O;0K_00002VoOIv0RM-N
 z%)bBt4OU4+K~#9!?VVd}9Mv6%znxusv+LNqu^kL)LYxaC2~=@_(pC`3B`AqXD<Pyl
 zqME)IDe&5tC{k5beQ1COS`pd+53SO2DHR}62uU%}HW$Lpae&;M*h%cHowZ}H?cJT3
 zKFnojc4u~Xc4u~H?fgdZ&gIOUbH4n~WzKEjrf%w{ZtA9Ps!<iF<fgB><y|}~b=M`t
@@ -3244,14 +3244,14 @@ zgb5-t4~Wb$j|ikmGVW|ei-iG5Q8TSXi4+uUY37+F#f@U6m7V?%zd0TLfLr+m00000
 LNkvXXu0mjf=__DT
 
 literal 0
-Hc-jL100001
+HcmV?d00001
 
 diff --git a/chrome/android/java/res_vanadium/mipmap-xxxhdpi/app_icon.png b/chrome/android/java/res_vanadium/mipmap-xxxhdpi/app_icon.png
 new file mode 100644
 index 0000000000000000000000000000000000000000..1e02f37a1a940619f19cb73eb3605e14e8b0cfef
 GIT binary patch
 literal 9104
-zc-jGwBX8V^P)<h;3K|Lk000e1NJLTq006)M006)U1ONa4_|>G000002VoOIv0RM-N
+zcmV;BBX8V^P)<h;3K|Lk000e1NJLTq006)M006)U1ONa4_|>G000002VoOIv0RM-N
 z%)bBtBS}d_K~#9!?VWd&9MzrgKNY%rva)7I5-1QPB!UbAga|emY{2&6*v9dAkKb7z
 zN1ns_t?_y9t@rKPn>hB`hPAy8Zygq6!ai)+0}j{(BQi(`fk8+JWsPP=(nu3JR(O9@
 zPTf`ARXqdCZ_b3O>AH36`@O$#e>W7oA#cbV@`k)2|5Zhp?h0g7SADuG8&~A%u0UN8
@@ -3429,14 +3429,14 @@ z&TnT3ZAJm_ecYKSLdb8y_m^AzAbV#p&N$%xk2#Y?sB;t)z0T1Ll>ZM}!uj~k+35iQ
 O0000<MNUMnLSTY_yT{`I
 
 literal 0
-Hc-jL100001
+HcmV?d00001
 
 diff --git a/chrome/android/java/res_vanadium/mipmap-xxxhdpi/app_shortcut_icon.png b/chrome/android/java/res_vanadium/mipmap-xxxhdpi/app_shortcut_icon.png
 new file mode 100644
 index 0000000000000000000000000000000000000000..462b433a801f6fcea98599426cb227a3849dccd0
 GIT binary patch
 literal 8910
-zc-jHZA~D^GP)<h;3K|Lk000e1NJLTq006)M006)U1ONa4_|>G000002VoOIv0RM-N
+zcmV;<A~D^GP)<h;3K|Lk000e1NJLTq006)M006)U1ONa4_|>G000002VoOIv0RM-N
 z%)bBtB8N#tK~#9!?VWkN9aWX@zg2aHd+v~%fh0HcL=r+6LP&%Jh$12ZMOsDM0bl!h
 zDk6NaZTs1_KJAZ<s2}X6ecIAW<In;R@W~{Kq9C9UkRb^K2r(oiWWJemhcnjj{-}94
 z=Tz0HI`=}e&gTwQr)t-(-*4}=)?RypH|0%vQ{I#}<-e;4Bb|Yi@~Vw=X2VKmq%+V^
@@ -3610,14 +3610,14 @@ zXcEEoJ9rftXX!V^9j|uw-*{Iq7*#U*2=M02`B(7#=M*o<n(O?i1K#_ZqgjLoM}E;7
 c9F0Qx|B}Q+Z=dlMDF6Tf07*qoM6N<$f|_$^VgLXD
 
 literal 0
-Hc-jL100001
+HcmV?d00001
 
 diff --git a/chrome/android/java/res_vanadium/mipmap-xxxhdpi/app_single_page_icon.png b/chrome/android/java/res_vanadium/mipmap-xxxhdpi/app_single_page_icon.png
 new file mode 100644
 index 0000000000000000000000000000000000000000..ee550d2496b8ee610665e0973b6c1009bdec18bb
 GIT binary patch
 literal 6162
-zc-jFH813hYP)<h;3K|Lk000e1NJLTq006)M006)U1ONa4_|>G000002VoOIv0RM-N
+zcmV+t813hYP)<h;3K|Lk000e1NJLTq006)M006)U1ONa4_|>G000002VoOIv0RM-N
 z%)bBt7t2XRK~#9!?VWj$99MnEKd+~!XJ$|BuJ(|1uCQfn3uANmEDMNbT$DrEMTH|V
 zMJiOPph75;0*XKKN0P!fBos~+kUx?lIHnLbm>AnQK#Z_ui^CwxGD2(J(ysQ@&fatM
 z@$yIa+&$O!%+73UzFQhi_sqP0{r$f8d%ySI@4bc=T4<q#7FuYbg%(<9;ZlRBRYDJ5
@@ -3738,7 +3738,7 @@ z4=n*~D0DMGYE(<3jW9uiIZ-V(EMl0%i4%8ROr2S#S@mO;TLNUD(nALwgmP#XXsB2P
 kGn<knmRQIH8Lkfh4<#z;WpdrDCIA2c07*qoM6N<$g5lVO)Bpeg
 
 literal 0
-Hc-jL100001
+HcmV?d00001
 
 diff --git a/chrome/android/java/res_vanadium/values/channel_constants.xml b/chrome/android/java/res_vanadium/values/channel_constants.xml
 new file mode 100644
@@ -3755,5 +3755,5 @@ index 000000000000..934572cd12f2
 +    <string name="search_widget_title" translatable="false">Vanadium search</string>
 +</resources>
 -- 
-2.23.0
+2.21.0
 

--- a/0006-remove-Help-feedback-menu-entry.patch
+++ b/0006-remove-Help-feedback-menu-entry.patch
@@ -1,7 +1,7 @@
-From 552ffa6b0ebdf52814a74610f348e6c29bdd6df1 Mon Sep 17 00:00:00 2001
+From 443ff5c274e1225bd01702491fea815f158a0451 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Sat, 6 Jul 2019 05:56:45 -0400
-Subject: [PATCH 06/47] remove Help & feedback menu entry
+Subject: [PATCH 06/50] remove Help & feedback menu entry
 
 ---
  chrome/android/java/res/menu/main_menu.xml               | 2 --
@@ -92,5 +92,5 @@ index 89e06cee37c9..167775145d8c 100644
          availableItemIds.add(R.id.preferences_id);
  
 -- 
-2.23.0
+2.21.0
 

--- a/0007-hide-passwords.google.com-link-when-not-supported.patch
+++ b/0007-hide-passwords.google.com-link-when-not-supported.patch
@@ -1,7 +1,7 @@
-From 330d0c4f971d209ad21d8657e54c9dee20f513ba Mon Sep 17 00:00:00 2001
+From 85d480a09ec4b8101c3d6531be485643ac18505f Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Sun, 13 Aug 2017 19:33:04 -0400
-Subject: [PATCH 07/47] hide passwords.google.com link when not supported
+Subject: [PATCH 07/50] hide passwords.google.com link when not supported
 
 ---
  .../preferences/password/SavePasswordsPreferences.java        | 4 ++++
@@ -30,5 +30,5 @@ index 314b2020a429..a5ec6e58f32f 100644
              return; // Don't add the Manage Account link if it's present.
          }
 -- 
-2.23.0
+2.21.0
 

--- a/0008-disable-first-run-welcome-page.patch
+++ b/0008-disable-first-run-welcome-page.patch
@@ -1,7 +1,7 @@
-From 94a4aeadd6b09b1866c0b4484dd328a278cc2493 Mon Sep 17 00:00:00 2001
+From 2ccc625af915bb06ae2f5bc44bf5988ef51296bf Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Thu, 24 Nov 2016 08:19:03 -0500
-Subject: [PATCH 08/47] disable first run welcome page
+Subject: [PATCH 08/50] disable first run welcome page
 
 ---
  .../chromium/chrome/browser/firstrun/FirstRunActivity.java    | 4 ++--
@@ -30,5 +30,5 @@ index 344604b637e6..9ed1d99ebb1f 100644
                      mResultSignInAccountName = mFreProperties.getString(
                              SigninFirstRunFragment.FORCE_SIGNIN_ACCOUNT_TO);
 -- 
-2.23.0
+2.21.0
 

--- a/0009-disable-seed-based-field-trials.patch
+++ b/0009-disable-seed-based-field-trials.patch
@@ -1,7 +1,7 @@
-From 634610272b0f00b2195d27628c4c8ae77609fc36 Mon Sep 17 00:00:00 2001
+From 2afbeafd253054faf2c1cb57f2dcedf23304f3b2 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Tue, 25 Dec 2018 16:19:51 -0500
-Subject: [PATCH 09/47] disable seed-based field trials
+Subject: [PATCH 09/50] disable seed-based field trials
 
 ---
  components/variations/service/variations_field_trial_creator.cc | 2 ++
@@ -23,5 +23,5 @@ index c35a39c14b7d..add1740d44ac 100644
  
    platform_field_trials->SetupFeatureControllingFieldTrials(used_seed,
 -- 
-2.23.0
+2.21.0
 

--- a/0010-disable-navigation-error-correction-by-default.patch
+++ b/0010-disable-navigation-error-correction-by-default.patch
@@ -1,7 +1,7 @@
-From e54170f03fab09c5d8bac26eddd80fee904cc83a Mon Sep 17 00:00:00 2001
+From ec4e81eada2ca6b56cbd06dedc68ba99e0d899f6 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Wed, 23 Nov 2016 08:29:58 -0500
-Subject: [PATCH 10/47] disable navigation error correction by default
+Subject: [PATCH 10/50] disable navigation error correction by default
 
 ---
  chrome/browser/ui/navigation_correction_tab_observer.cc | 2 +-
@@ -21,5 +21,5 @@ index 40256d42872f..6d802c92bcaf 100644
  }
  
 -- 
-2.23.0
+2.21.0
 

--- a/0011-disable-contextual-search-by-default.patch
+++ b/0011-disable-contextual-search-by-default.patch
@@ -1,7 +1,7 @@
-From 18eda9be53f4ab71bc7b8c4da0a1507d7965a42d Mon Sep 17 00:00:00 2001
+From 1a211874486165d3115aa8893499d76d750307ba Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Wed, 23 Nov 2016 09:26:51 -0500
-Subject: [PATCH 11/47] disable contextual search by default
+Subject: [PATCH 11/50] disable contextual search by default
 
 ---
  chrome/browser/profiles/profile.cc | 2 +-
@@ -21,5 +21,5 @@ index 28d3c597acc9..01dcc5449fdf 100644
  #endif  // defined(OS_ANDROID)
    registry->RegisterBooleanPref(prefs::kSessionExitedCleanly, true);
 -- 
-2.23.0
+2.21.0
 

--- a/0012-disable-network-prediction-by-default.patch
+++ b/0012-disable-network-prediction-by-default.patch
@@ -1,7 +1,7 @@
-From 48728810ddef1f1054a907450d19d8d0d009f85c Mon Sep 17 00:00:00 2001
+From b9e6ade216d81a9649d50c048df77ba37fc84479 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Wed, 23 Nov 2016 08:31:44 -0500
-Subject: [PATCH 12/47] disable network prediction by default
+Subject: [PATCH 12/50] disable network prediction by default
 
 ---
  chrome/browser/net/prediction_options.h | 2 +-
@@ -21,5 +21,5 @@ index 2ae6a1093090..7fc83de1aa0f 100644
  
  enum class NetworkPredictionStatus {
 -- 
-2.23.0
+2.21.0
 

--- a/0013-disable-metrics-by-default.patch
+++ b/0013-disable-metrics-by-default.patch
@@ -1,7 +1,7 @@
-From a18cb11e1511d1513af47e7057b1237b7e9b2ce0 Mon Sep 17 00:00:00 2001
+From ae03628c01182d3d411e8bb34e5bd50a9d6a02ca Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Thu, 24 Nov 2016 11:41:00 -0500
-Subject: [PATCH 13/47] disable metrics by default
+Subject: [PATCH 13/50] disable metrics by default
 
 ---
  .../chromium/chrome/browser/firstrun/FirstRunActivityBase.java  | 2 +-
@@ -21,5 +21,5 @@ index 9c69e1071c79..70ef53e01211 100644
      private boolean mNativeInitialized;
  
 -- 
-2.23.0
+2.21.0
 

--- a/0014-disable-hyperlink-auditing-by-default.patch
+++ b/0014-disable-hyperlink-auditing-by-default.patch
@@ -1,7 +1,7 @@
-From e10e1db85372189d582252dee0b369cbc6393431 Mon Sep 17 00:00:00 2001
+From 21a8185cafd5c20aad933b4306e079958a4949d9 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Sat, 26 Nov 2016 14:57:22 -0500
-Subject: [PATCH 14/47] disable hyperlink auditing by default
+Subject: [PATCH 14/50] disable hyperlink auditing by default
 
 ---
  chrome/browser/chrome_content_browser_client.cc | 2 +-
@@ -21,5 +21,5 @@ index 84354ff218e8..80130662bb26 100644
    // Register user prefs for mapping SitePerProcess and IsolateOrigins in
    // user policy in addition to the same named ones in Local State (which are
 -- 
-2.23.0
+2.21.0
 

--- a/0015-disable-showing-popular-sites-by-default.patch
+++ b/0015-disable-showing-popular-sites-by-default.patch
@@ -1,7 +1,7 @@
-From 512c6aa4b04e6c0179d3fe40a89da8a331e81290 Mon Sep 17 00:00:00 2001
+From 7ad3f01a01476a074e91d4371ce822888d7e8d8c Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Tue, 6 Mar 2018 00:27:41 -0500
-Subject: [PATCH 15/47] disable showing popular sites by default
+Subject: [PATCH 15/50] disable showing popular sites by default
 
 ---
  components/ntp_tiles/features.cc | 4 ++--
@@ -27,5 +27,5 @@ index a5baa537fa48..0ba16de13cbf 100644
  
  }  // namespace ntp_tiles
 -- 
-2.23.0
+2.21.0
 

--- a/0016-disable-article-suggestions-feature-by-default.patch
+++ b/0016-disable-article-suggestions-feature-by-default.patch
@@ -1,7 +1,7 @@
-From f3c573f748b167e5a3593384471cd722f50b88ef Mon Sep 17 00:00:00 2001
+From 96b2b692911b5d1029c7b31b2ba4f91263f46db5 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Thu, 8 Mar 2018 22:43:12 -0500
-Subject: [PATCH 16/47] disable article suggestions feature by default
+Subject: [PATCH 16/50] disable article suggestions feature by default
 
 ---
  components/ntp_snippets/features.cc | 2 +-
@@ -21,5 +21,5 @@ index 2b7f345cb31a..1a942fd00266 100644
  const base::Feature kRemoteSuggestionsEmulateM58FetchingSchedule{
      "RemoteSuggestionsEmulateM58FetchingSchedule",
 -- 
-2.23.0
+2.21.0
 

--- a/0017-disable-prefetching-suggested-pages-by-default.patch
+++ b/0017-disable-prefetching-suggested-pages-by-default.patch
@@ -1,7 +1,7 @@
-From e6cc842dfb734a19ef545d8fc3ec042612c2359e Mon Sep 17 00:00:00 2001
+From 63fc97a0b8d21193b544b9681d1a699e3615de6a Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Fri, 12 Jul 2019 04:10:21 -0400
-Subject: [PATCH 17/47] disable prefetching suggested pages by default
+Subject: [PATCH 17/50] disable prefetching suggested pages by default
 
 ---
  components/offline_pages/core/offline_page_feature.cc | 2 +-
@@ -21,5 +21,5 @@ index b6c93de8591d..f636030659a7 100644
  const base::Feature kOfflinePagesCTV2Feature{"OfflinePagesCTV2",
                                               base::FEATURE_DISABLED_BY_DEFAULT};
 -- 
-2.23.0
+2.21.0
 

--- a/0018-disable-sensors-access-by-default.patch
+++ b/0018-disable-sensors-access-by-default.patch
@@ -1,7 +1,7 @@
-From 37719c490826e2c19d410ff1faa98bc34ead9ad4 Mon Sep 17 00:00:00 2001
+From 2f6babac9987eb8bddb42f5dc889c3d33666ebb0 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Sun, 16 Jun 2019 15:57:29 -0400
-Subject: [PATCH 18/47] disable sensors access by default
+Subject: [PATCH 18/50] disable sensors access by default
 
 ---
  .../content_settings/core/browser/content_settings_registry.cc  | 2 +-
@@ -21,5 +21,5 @@ index dc67564cd90f..afc957e75885 100644
             ValidSettings(CONTENT_SETTING_ALLOW, CONTENT_SETTING_BLOCK),
             WebsiteSettingsInfo::SINGLE_ORIGIN_ONLY_SCOPE,
 -- 
-2.23.0
+2.21.0
 

--- a/0019-disable-third-party-cookies-by-default.patch
+++ b/0019-disable-third-party-cookies-by-default.patch
@@ -1,7 +1,7 @@
-From e088fb0dc66897f9e5d1bffdcaf8a4bd65588cd0 Mon Sep 17 00:00:00 2001
+From 5a4ba18b55f749213678d6f90825628a3d4e3064 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Sun, 16 Jun 2019 16:01:31 -0400
-Subject: [PATCH 19/47] disable third party cookies by default
+Subject: [PATCH 19/50] disable third party cookies by default
 
 ---
  components/content_settings/core/browser/cookie_settings.cc | 2 +-
@@ -21,5 +21,5 @@ index 44b4fc031d81..bbfc5e8477ca 100644
    registry->RegisterBooleanPref(
        prefs::kCookieControlsEnabled, false,
 -- 
-2.23.0
+2.21.0
 

--- a/0020-disable-background-sync-by-default.patch
+++ b/0020-disable-background-sync-by-default.patch
@@ -1,7 +1,7 @@
-From f9701a77827679f906b2398362a344ef3f5aae13 Mon Sep 17 00:00:00 2001
+From 956924358192522d100a1fabd15753720aba1972 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Sun, 16 Jun 2019 21:57:26 -0400
-Subject: [PATCH 20/47] disable background sync by default
+Subject: [PATCH 20/50] disable background sync by default
 
 ---
  .../content_settings/core/browser/content_settings_registry.cc  | 2 +-
@@ -21,5 +21,5 @@ index afc957e75885..063a0b560c3b 100644
             ValidSettings(CONTENT_SETTING_ALLOW, CONTENT_SETTING_BLOCK),
             WebsiteSettingsInfo::SINGLE_ORIGIN_ONLY_SCOPE,
 -- 
-2.23.0
+2.21.0
 

--- a/0021-disable-payment-support-by-default.patch
+++ b/0021-disable-payment-support-by-default.patch
@@ -1,7 +1,7 @@
-From 29bed92b58937fea5ac4c66b35a50724089429fe Mon Sep 17 00:00:00 2001
+From 413e69fe7d4f4e4b41ec0a6e0894a0f62b8fd14d Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Tue, 18 Jun 2019 22:28:53 -0400
-Subject: [PATCH 21/47] disable payment support by default
+Subject: [PATCH 21/50] disable payment support by default
 
 ---
  components/payments/core/payment_prefs.cc | 2 +-
@@ -21,5 +21,5 @@ index 9590d9494ed1..787ff68af12a 100644
  }
  
 -- 
-2.23.0
+2.21.0
 

--- a/0022-disable-media-router-media-remoting-by-default.patch
+++ b/0022-disable-media-router-media-remoting-by-default.patch
@@ -1,7 +1,7 @@
-From 268a45d5991db6cf33bc58960df722743d69ca5e Mon Sep 17 00:00:00 2001
+From ca977f4c4e348b84e436521f3ff5804a431008ff Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Thu, 4 Jul 2019 18:11:27 -0400
-Subject: [PATCH 22/47] disable media router media remoting by default
+Subject: [PATCH 22/50] disable media router media remoting by default
 
 ---
  chrome/browser/profiles/profile.cc | 2 +-
@@ -21,5 +21,5 @@ index 01dcc5449fdf..288a33d15bff 100644
  
    registry->RegisterDictionaryPref(prefs::kWebShareVisitedTargets);
 -- 
-2.23.0
+2.21.0
 

--- a/0023-disable-media-router-by-default.patch
+++ b/0023-disable-media-router-by-default.patch
@@ -1,7 +1,7 @@
-From 65f50aa9c119b4cd25a814a7753e661be6dc710e Mon Sep 17 00:00:00 2001
+From df65f651d96b64df55bb62f1260942a6c903087d Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Thu, 4 Jul 2019 19:08:52 -0400
-Subject: [PATCH 23/47] disable media router by default
+Subject: [PATCH 23/50] disable media router by default
 
 ---
  .../media/router/media_router_feature.cc      | 19 +++++++++----------
@@ -59,5 +59,5 @@ index 084648e9606f..8eae19f81d76 100644
    registry->RegisterBooleanPref(
        prefs::kOobeMarketingOptInScreenFinished, false,
 -- 
-2.23.0
+2.21.0
 

--- a/0024-disable-offering-translations-by-default.patch
+++ b/0024-disable-offering-translations-by-default.patch
@@ -1,7 +1,7 @@
-From 6f14d2d83b8ddf8dbe4e07fbc3c2662892e5ad63 Mon Sep 17 00:00:00 2001
+From 31efac02dede557e284a15e02a3c0df8f90be63e Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Fri, 12 Jul 2019 03:58:01 -0400
-Subject: [PATCH 24/47] disable offering translations by default
+Subject: [PATCH 24/50] disable offering translations by default
 
 ---
  chrome/browser/ui/browser_ui_prefs.cc | 2 +-
@@ -21,5 +21,5 @@ index 7da71a9bd7c5..b96cae0345fd 100644
    registry->RegisterStringPref(prefs::kCloudPrintEmail, std::string());
    registry->RegisterBooleanPref(prefs::kCloudPrintProxyEnabled, true);
 -- 
-2.23.0
+2.21.0
 

--- a/0025-disable-browser-sign-in-feature-by-default.patch
+++ b/0025-disable-browser-sign-in-feature-by-default.patch
@@ -1,7 +1,7 @@
-From ab58c180a9e2693b38846657e3d9cff52efc3c72 Mon Sep 17 00:00:00 2001
+From 403e69187c3874c33adb03d82f38175059957e2a Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Fri, 12 Jul 2019 04:23:18 -0400
-Subject: [PATCH 25/47] disable browser sign in feature by default
+Subject: [PATCH 25/50] disable browser sign in feature by default
 
 ---
  .../signin/internal/identity_manager/primary_account_manager.cc | 2 +-
@@ -21,5 +21,5 @@ index 91105525fcc7..ca5c044ed6b4 100644
  
    // Deprecated prefs: will be removed in a future release.
 -- 
-2.23.0
+2.21.0
 

--- a/0026-disable-safe-browsing-reporting-opt-in-by-default.patch
+++ b/0026-disable-safe-browsing-reporting-opt-in-by-default.patch
@@ -1,7 +1,7 @@
-From c9ac4ef25ad59a9ee04393a4f6e0b31b411a8a37 Mon Sep 17 00:00:00 2001
+From a8c8cbc60cdf219d627dd3db061fc3fa8aa3077f Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Fri, 12 Jul 2019 05:22:11 -0400
-Subject: [PATCH 26/47] disable safe browsing reporting opt-in by default
+Subject: [PATCH 26/50] disable safe browsing reporting opt-in by default
 
 ---
  components/safe_browsing/common/safe_browsing_prefs.cc | 2 +-
@@ -21,5 +21,5 @@ index a3607c3b7cf4..664a2314aab5 100644
        prefs::kSafeBrowsingEnabled, true,
        user_prefs::PrefRegistrySyncable::SYNCABLE_PREF);
 -- 
-2.23.0
+2.21.0
 

--- a/0027-enable-dubious-Do-Not-Track-feature-by-default.patch
+++ b/0027-enable-dubious-Do-Not-Track-feature-by-default.patch
@@ -1,7 +1,7 @@
-From 361f9b8c5ebaf2781fe97f7db298f91ddbde80a2 Mon Sep 17 00:00:00 2001
+From d4dd625e0f1bb2caa41752abb0eb4dc809a49b01 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Tue, 1 Aug 2017 11:16:11 -0400
-Subject: [PATCH 27/47] enable dubious Do Not Track feature by default
+Subject: [PATCH 27/50] enable dubious Do Not Track feature by default
 
 ---
  chrome/browser/ui/browser_ui_prefs.cc | 2 +-
@@ -21,5 +21,5 @@ index b96cae0345fd..50ad4d5dc596 100644
  #if !defined(OS_CHROMEOS) && !defined(OS_ANDROID)
    registry->RegisterBooleanPref(prefs::kPrintPreviewUseSystemDefaultPrinter,
 -- 
-2.23.0
+2.21.0
 

--- a/0028-mark-non-secure-origins-as-non-secure-by-default.patch
+++ b/0028-mark-non-secure-origins-as-non-secure-by-default.patch
@@ -1,7 +1,7 @@
-From 4aaafc6633d64f4bf09ab68f39ac04f820f4aff5 Mon Sep 17 00:00:00 2001
+From 9ee62506eddb2d04585d1108b7beb73d78f528b2 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Fri, 20 Oct 2017 21:20:50 -0400
-Subject: [PATCH 28/47] mark non-secure origins as non-secure by default
+Subject: [PATCH 28/50] mark non-secure origins as non-secure by default
 
 ---
  components/security_state/core/security_state.cc | 8 +++-----
@@ -30,5 +30,5 @@ index b402dc745d2f..06b2c870262d 100644
  
  std::string GetHistogramSuffixForSecurityLevel(
 -- 
-2.23.0
+2.21.0
 

--- a/0029-enable-strict-site-isolation-by-default-on-Android.patch
+++ b/0029-enable-strict-site-isolation-by-default-on-Android.patch
@@ -1,7 +1,7 @@
-From 3cf1822075e627deda7d0bdb438ffe835035c4bb Mon Sep 17 00:00:00 2001
+From 22df0789f6dd29a1d6047c18f1b493fedbf3e0e1 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Thu, 2 May 2019 07:15:32 -0400
-Subject: [PATCH 29/47] enable strict site isolation by default on Android
+Subject: [PATCH 29/50] enable strict site isolation by default on Android
 
 ---
  chrome/browser/about_flags.cc    | 19 -------------------
@@ -57,5 +57,5 @@ index 0f6bd7979c2e..ae663ab50d84 100644
  
  // Controls a mode for dynamically process-isolating sites where the user has
 -- 
-2.23.0
+2.21.0
 

--- a/0030-disable-search-engine-permissions-by-default.patch
+++ b/0030-disable-search-engine-permissions-by-default.patch
@@ -1,7 +1,7 @@
-From f7aa22b0519ed230cfc46cf27650c846cf2ed5c3 Mon Sep 17 00:00:00 2001
+From 40ee0d476081d6831953840c31564dc04926315b Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Tue, 1 Aug 2017 20:29:56 -0400
-Subject: [PATCH 30/47] disable search engine permissions by default
+Subject: [PATCH 30/50] disable search engine permissions by default
 
 Disable the geolocation and notification permissions for the default
 search engine by default.
@@ -63,5 +63,5 @@ index f55019c639f2..69c98e105903 100644
  
      // Update the content setting with the auto-grants for the DSE.
 -- 
-2.23.0
+2.21.0
 

--- a/0031-stub-out-the-battery-status-API.patch
+++ b/0031-stub-out-the-battery-status-API.patch
@@ -1,7 +1,7 @@
-From e580f9ecceb0eeafdcbb59296468cb6c35e74ca0 Mon Sep 17 00:00:00 2001
+From 3eddfdac896580fb28f8aa72c7a0232463faebbf Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Mon, 17 Jun 2019 11:29:21 -0400
-Subject: [PATCH 31/47] stub out the battery status API
+Subject: [PATCH 31/50] stub out the battery status API
 
 Pretend that the device is always plugged in and fully charged.
 ---
@@ -63,5 +63,5 @@ index 25c3e426682c..34b21b674c1a 100644
  
  void BatteryManager::RegisterWithDispatcher() {
 -- 
-2.23.0
+2.21.0
 

--- a/0032-always-use-local-new-tab-page.patch
+++ b/0032-always-use-local-new-tab-page.patch
@@ -1,7 +1,7 @@
-From bc43234fe4d8eae51f5b01147d906162ab6022ae Mon Sep 17 00:00:00 2001
+From 39118c74680554d050eef6a9cd39e84cf1a911ea Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Mon, 17 Jun 2019 13:14:22 -0400
-Subject: [PATCH 32/47] always use local new tab page
+Subject: [PATCH 32/50] always use local new tab page
 
 ---
  chrome/browser/search/search.cc | 2 +-
@@ -21,5 +21,5 @@ index cb14223db6bc..5e2a808dc7a6 100644
  
  // Used to look up the URL to use for the New Tab page. Also tracks how we
 -- 
-2.23.0
+2.21.0
 

--- a/0033-disable-search-provider-logo.patch
+++ b/0033-disable-search-provider-logo.patch
@@ -1,7 +1,7 @@
-From d6c06eb74a533f5ec0801933dd0a5f4a4b6a626c Mon Sep 17 00:00:00 2001
+From 091c2b4dfd2c7e529452dc856a60d96727974629 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Mon, 17 Jun 2019 12:03:52 -0400
-Subject: [PATCH 33/47] disable search provider logo
+Subject: [PATCH 33/50] disable search provider logo
 
 ---
  .../template_url_service_factory_android.cc   | 31 +------------------
@@ -50,5 +50,5 @@ index 59dbdfae09c9..3a00f3637bfd 100644
 +  return false;
  }
 -- 
-2.23.0
+2.21.0
 

--- a/0034-stop-ignoring-download-location-prompt-setting.patch
+++ b/0034-stop-ignoring-download-location-prompt-setting.patch
@@ -1,7 +1,7 @@
-From 40f33fd2497766cd0e75e22234272e968835a9c4 Mon Sep 17 00:00:00 2001
+From 89437f51e7256f3a2d2a280d781a02ddd9450be1 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Fri, 28 Jun 2019 16:56:37 -0400
-Subject: [PATCH 34/47] stop ignoring download location prompt setting
+Subject: [PATCH 34/50] stop ignoring download location prompt setting
 
 ---
  .../download/DownloadLocationDialogBridge.java     | 14 --------------
@@ -33,5 +33,5 @@ index 64823b27d948..251558b0565f 100644
          if (mDialogModel != null) return;
  
 -- 
-2.23.0
+2.21.0
 

--- a/0035-show-download-prompt-again-by-default.patch
+++ b/0035-show-download-prompt-again-by-default.patch
@@ -1,7 +1,7 @@
-From 02cd58fbda4085694a5dcac6c44a7b38a925829b Mon Sep 17 00:00:00 2001
+From 48bc811b85bed0f8951a1d943e5cbe154fa02901 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Fri, 28 Jun 2019 17:48:49 -0400
-Subject: [PATCH 35/47] show download prompt again by default
+Subject: [PATCH 35/50] show download prompt again by default
 
 ---
  .../chrome/browser/download/DownloadLocationCustomView.java   | 4 ----
@@ -23,5 +23,5 @@ index f25930b612d1..9311a63f3092 100644
  
          mFileName.setText(suggestedPath.getName());
 -- 
-2.23.0
+2.21.0
 

--- a/0036-rename-Sync-and-Google-services-Services.patch
+++ b/0036-rename-Sync-and-Google-services-Services.patch
@@ -1,7 +1,7 @@
-From e3d676b54c467d84eeeed398ef7561620678a26b Mon Sep 17 00:00:00 2001
+From 0ddb21db2d2d01d2fd781e9eaa7148372b8ef072 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Fri, 2 Aug 2019 23:28:06 -0400
-Subject: [PATCH 36/47] rename Sync and Google services -> Services
+Subject: [PATCH 36/50] rename Sync and Google services -> Services
 
 ---
  chrome/android/java/strings/android_chrome_strings.grd | 6 +++---
@@ -34,5 +34,5 @@ index f5baf099106f..9081f46eee2a 100644
        <message name="IDS_USAGE_AND_CRASH_REPORTS_TITLE" desc="Title for a preference that enables sending usage statistics and crash reports.">
          Help improve Vanadium's features and performance
 -- 
-2.23.0
+2.21.0
 

--- a/0037-remove-data-reduction-preference.patch
+++ b/0037-remove-data-reduction-preference.patch
@@ -1,7 +1,7 @@
-From 2a9650f11658cd1ed05719ebb0c143e54035aef9 Mon Sep 17 00:00:00 2001
+From b64ac35b344f64368b3f1cedb7a4631e7e9ee2a2 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Fri, 2 Aug 2019 22:06:31 -0400
-Subject: [PATCH 37/47] remove data reduction preference
+Subject: [PATCH 37/50] remove data reduction preference
 
 ---
  chrome/android/java/res/xml/main_preferences.xml       | 10 +++++-----
@@ -56,5 +56,5 @@ index 56f952c159ff..95307f421bbc 100644
  
      private Preference addPreferenceIfAbsent(String key) {
 -- 
-2.23.0
+2.21.0
 

--- a/0038-remove-translate-offer-preference.patch
+++ b/0038-remove-translate-offer-preference.patch
@@ -1,7 +1,7 @@
-From 97c72a738720f29ec3c2b899cb76f345dc5342a7 Mon Sep 17 00:00:00 2001
+From cd047ff0d3795f6bcd14d31ed33b946434b6fca1 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Fri, 2 Aug 2019 21:11:17 -0400
-Subject: [PATCH 38/47] remove translate offer preference
+Subject: [PATCH 38/50] remove translate offer preference
 
 ---
  .../java/res/xml/languages_preferences.xml    |  8 ++---
@@ -93,5 +93,5 @@ index 9081f46eee2a..a849a9512258 100644
          Offer to translate
        </message>
 -- 
-2.23.0
+2.21.0
 

--- a/0039-remove-sync-preferences.patch
+++ b/0039-remove-sync-preferences.patch
@@ -1,7 +1,7 @@
-From 1678604de9724b0f27d94419b03971478c30e5f2 Mon Sep 17 00:00:00 2001
+From e405ffa2644b37fffdc670b9c04a3774741cffbd Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Fri, 2 Aug 2019 21:12:28 -0400
-Subject: [PATCH 39/47] remove sync preferences
+Subject: [PATCH 39/50] remove sync preferences
 
 ---
  .../res/xml/sync_and_services_preferences.xml |  58 ++++----
@@ -308,5 +308,5 @@ index a849a9512258..2a310c0a2eea 100644
          Manage sync
        </message>
 -- 
-2.23.0
+2.21.0
 

--- a/0040-remove-navigation-error-preference.patch
+++ b/0040-remove-navigation-error-preference.patch
@@ -1,7 +1,7 @@
-From af4d8556879b5310e14aadd465aa684055fbb442 Mon Sep 17 00:00:00 2001
+From 882d76ae3121765e9965c07d6828f90021e697e1 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Fri, 2 Aug 2019 23:46:41 -0400
-Subject: [PATCH 40/47] remove navigation error preference
+Subject: [PATCH 40/50] remove navigation error preference
 
 ---
  .../res/xml/sync_and_services_preferences.xml | 10 ++++-----
@@ -122,5 +122,5 @@ index 2a310c0a2eea..f792846416da 100644
          Make searches and browsing better
        </message>
 -- 
-2.23.0
+2.21.0
 

--- a/0041-remove-safe-browsing-reporting-preference.patch
+++ b/0041-remove-safe-browsing-reporting-preference.patch
@@ -1,7 +1,7 @@
-From 333fc39233617bc9954f27e9a969b483749e4be4 Mon Sep 17 00:00:00 2001
+From cba96c601c9399cfed347af392482ef97fd6667c Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Fri, 2 Aug 2019 23:48:41 -0400
-Subject: [PATCH 41/47] remove safe browsing reporting preference
+Subject: [PATCH 41/50] remove safe browsing reporting preference
 
 ---
  .../res/xml/sync_and_services_preferences.xml | 10 +++----
@@ -122,5 +122,5 @@ index f792846416da..8acc87d03667 100644
          Safe Browsing (protects you and your device from dangerous sites)
        </message>
 -- 
-2.23.0
+2.21.0
 

--- a/0042-remove-usage-and-crash-reports-preference.patch
+++ b/0042-remove-usage-and-crash-reports-preference.patch
@@ -1,7 +1,7 @@
-From 5833209dfcf8dd6ffc162da03264989d334b608e Mon Sep 17 00:00:00 2001
+From 48e48ac627ca6f66efbaa7af2a0ec09b7f97c492 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Fri, 2 Aug 2019 23:49:13 -0400
-Subject: [PATCH 42/47] remove usage and crash reports preference
+Subject: [PATCH 42/50] remove usage and crash reports preference
 
 ---
  .../res/xml/sync_and_services_preferences.xml | 10 +++----
@@ -126,5 +126,5 @@ index 8acc87d03667..a56576cb45f2 100644
          Cancel sync?
        </message>
 -- 
-2.23.0
+2.21.0
 

--- a/0043-remove-url-keyed-anonymized-data-preference.patch
+++ b/0043-remove-url-keyed-anonymized-data-preference.patch
@@ -1,7 +1,7 @@
-From 847ff46b64bbc7fa80ad982bd04ccec02c62ab22 Mon Sep 17 00:00:00 2001
+From a03f829680f0d9c796ba27e3db4d37c42e40a146 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Fri, 2 Aug 2019 23:50:03 -0400
-Subject: [PATCH 43/47] remove url keyed anonymized data preference
+Subject: [PATCH 43/50] remove url keyed anonymized data preference
 
 ---
  .../res/xml/sync_and_services_preferences.xml | 10 +++----
@@ -128,5 +128,5 @@ index a56576cb45f2..977b4ecd7fcc 100644
          For more settings that relate to privacy, security, and data collection, see <ph name="BEGIN_LINK">&lt;link&gt;</ph>Services<ph name="END_LINK">&lt;/link&gt;</ph>
        </message>
 -- 
-2.23.0
+2.21.0
 

--- a/0044-disable-contextual-search-by-default.patch
+++ b/0044-disable-contextual-search-by-default.patch
@@ -1,7 +1,7 @@
-From 0976fc3f6f8a747a193470b693bdec2348243445 Mon Sep 17 00:00:00 2001
+From 867cb658c1c0bc33d1dd960f6e92c7410625b14b Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Sat, 3 Aug 2019 00:28:49 -0400
-Subject: [PATCH 44/47] disable contextual search by default
+Subject: [PATCH 44/50] disable contextual search by default
 
 ---
  .../browser/contextualsearch/ContextualSearchFieldTrial.java    | 2 +-
@@ -21,5 +21,5 @@ index d1c3b35adece..2e758da20f31 100644
  
      /**
 -- 
-2.23.0
+2.21.0
 

--- a/0045-remove-redundant-services-preference-category.patch
+++ b/0045-remove-redundant-services-preference-category.patch
@@ -1,7 +1,7 @@
-From b44bb388d59bf25be9d6f2a97ffd75f02f10cf42 Mon Sep 17 00:00:00 2001
+From 09eb546cd2f1163339e161866ddeef998df2c8ce Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Sat, 3 Aug 2019 00:34:43 -0400
-Subject: [PATCH 45/47] remove redundant services preference category
+Subject: [PATCH 45/50] remove redundant services preference category
 
 ---
  .../java/res/xml/sync_and_services_preferences.xml        | 8 ++++----
@@ -79,5 +79,5 @@ index 977b4ecd7fcc..3d604c1f35b1 100644
          Autocomplete searches and URLs
        </message>
 -- 
-2.23.0
+2.21.0
 

--- a/0046-redirect-settings-help-icon.patch
+++ b/0046-redirect-settings-help-icon.patch
@@ -1,7 +1,7 @@
-From 21e639d0a90c4c11bab66b9e7cb8e66c89dac3b2 Mon Sep 17 00:00:00 2001
+From d85fdc41dde3018559d55689694d9198067b5cc2 Mon Sep 17 00:00:00 2001
 From: Zoraver Kang <zkang@wpi.edu>
 Date: Fri, 16 Aug 2019 02:03:45 -0400
-Subject: [PATCH 46/47] redirect settings help icon
+Subject: [PATCH 46/50] redirect settings help icon
 
 ---
  .../src/org/chromium/chrome/browser/help/HelpAndFeedback.java   | 2 +-
@@ -21,5 +21,5 @@ index 68d16fbccc90..d735b12944c4 100644
  
      private static HelpAndFeedback sInstance;
 -- 
-2.23.0
+2.21.0
 

--- a/0047-set-default-search-engine-to-DuckDuckGo.patch
+++ b/0047-set-default-search-engine-to-DuckDuckGo.patch
@@ -1,7 +1,7 @@
-From 959817ca2ec59d936d664a0a2a51e342e6030052 Mon Sep 17 00:00:00 2001
+From 75ef618b5cfd39e228e808f97244789f5542fa1c Mon Sep 17 00:00:00 2001
 From: Zoraver Kang <zkang@wpi.edu>
 Date: Sat, 17 Aug 2019 15:53:50 -0400
-Subject: [PATCH 47/47] set default search engine to DuckDuckGo
+Subject: [PATCH 47/50] set default search engine to DuckDuckGo
 
 ---
  components/search_engines/template_url_prepopulate_data.cc | 2 +-
@@ -21,5 +21,5 @@ index 5fd11a9daa81..70d3b24b7540 100644
          itr == t_urls.end() ? 0 : std::distance(t_urls.begin(), itr);
    }
 -- 
-2.23.0
+2.21.0
 

--- a/0048-enable-subresource-filter-on-all-sites.patch
+++ b/0048-enable-subresource-filter-on-all-sites.patch
@@ -1,0 +1,71 @@
+From c82ca2db20b38b964b0db6a16e87619a85632c97 Mon Sep 17 00:00:00 2001
+From: Zoraver Kang <zkang@wpi.edu>
+Date: Thu, 22 Aug 2019 01:24:00 -0400
+Subject: [PATCH 48/50] enable subresource filter on all sites
+
+---
+ .../core/browser/subresource_filter_features.cc     | 13 ++++++++++++-
+ .../core/browser/subresource_filter_features.h      |  2 ++
+ 2 files changed, 14 insertions(+), 1 deletion(-)
+
+diff --git a/components/subresource_filter/core/browser/subresource_filter_features.cc b/components/subresource_filter/core/browser/subresource_filter_features.cc
+index 6e2b5e1c5f2e..699638f12cb1 100644
+--- a/components/subresource_filter/core/browser/subresource_filter_features.cc
++++ b/components/subresource_filter/core/browser/subresource_filter_features.cc
+@@ -128,7 +128,9 @@ std::vector<Configuration> FillEnabledPresetConfigurations(
+       {kPresetPerformanceTestingDryRunOnAllSites, ad_tagging_enabled,
+        &Configuration::MakePresetForPerformanceTestingDryRunOnAllSites},
+       {kPresetLiveRunForBetterAds, true,
+-       &Configuration::MakePresetForLiveRunForBetterAds}};
++       &Configuration::MakePresetForLiveRunForBetterAds},
++      {kPresetLiveRunOnAllSites, true,
++       &Configuration::MakePresetForLiveRunOnAllSites}};
+ 
+   CommaSeparatedStrings enabled_presets(
+       TakeVariationParamOrReturnEmpty(params, kEnablePresetsParameterName));
+@@ -270,6 +272,7 @@ const char kPresetPerformanceTestingDryRunOnAllSites[] =
+     "performance_testing_dryrun_on_all_sites";
+ const char kPresetLiveRunForBetterAds[] =
+     "liverun_on_better_ads_violating_sites";
++const char kPresetLiveRunOnAllSites[] = "liverun_on_all_sites";
+ 
+ // Configuration --------------------------------------------------------------
+ 
+@@ -300,6 +303,14 @@ Configuration Configuration::MakePresetForLiveRunForBetterAds() {
+   return config;
+ }
+ 
++// static
++Configuration Configuration::MakePresetForLiveRunOnAllSites() {
++  Configuration config(mojom::ActivationLevel::kEnabled,
++                       ActivationScope::ALL_SITES);
++  config.activation_conditions.priority = 600;
++  return config;
++}
++
+ Configuration::Configuration() = default;
+ Configuration::Configuration(mojom::ActivationLevel activation_level,
+                              ActivationScope activation_scope,
+diff --git a/components/subresource_filter/core/browser/subresource_filter_features.h b/components/subresource_filter/core/browser/subresource_filter_features.h
+index 72549240ceca..a70a923b701b 100644
+--- a/components/subresource_filter/core/browser/subresource_filter_features.h
++++ b/components/subresource_filter/core/browser/subresource_filter_features.h
+@@ -122,6 +122,7 @@ struct Configuration {
+   static Configuration MakePresetForLiveRunOnPhishingSites();
+   static Configuration MakePresetForPerformanceTestingDryRunOnAllSites();
+   static Configuration MakePresetForLiveRunForBetterAds();
++  static Configuration MakePresetForLiveRunOnAllSites();
+ 
+   ActivationConditions activation_conditions;
+   ActivationOptions activation_options;
+@@ -219,6 +220,7 @@ extern const char kDisablePresetsParameterName[];
+ extern const char kPresetLiveRunOnPhishingSites[];
+ extern const char kPresetPerformanceTestingDryRunOnAllSites[];
+ extern const char kPresetLiveRunForBetterAds[];
++extern const char kPresetLiveRunOnAllSites[];
+ 
+ }  // namespace subresource_filter
+ 
+-- 
+2.21.0
+

--- a/0049-disable-AdsBlockedInfoBar.patch
+++ b/0049-disable-AdsBlockedInfoBar.patch
@@ -1,0 +1,28 @@
+From 626551ffc60d9d7afa773b93ebca41235d8d9966 Mon Sep 17 00:00:00 2001
+From: Zoraver Kang <zkang@wpi.edu>
+Date: Mon, 26 Aug 2019 17:54:28 -0400
+Subject: [PATCH 49/50] disable AdsBlockedInfoBar
+
+---
+ .../subresource_filter/chrome_subresource_filter_client.cc   | 5 -----
+ 1 file changed, 5 deletions(-)
+
+diff --git a/chrome/browser/subresource_filter/chrome_subresource_filter_client.cc b/chrome/browser/subresource_filter/chrome_subresource_filter_client.cc
+index 573bf1133dad..94523bdf760d 100644
+--- a/chrome/browser/subresource_filter/chrome_subresource_filter_client.cc
++++ b/chrome/browser/subresource_filter/chrome_subresource_filter_client.cc
+@@ -159,11 +159,6 @@ void ChromeSubresourceFilterClient::LogAction(SubresourceFilterAction action) {
+ }
+ 
+ void ChromeSubresourceFilterClient::ShowUI(const GURL& url) {
+-#if defined(OS_ANDROID)
+-  InfoBarService* infobar_service =
+-      InfoBarService::FromWebContents(web_contents());
+-  AdsBlockedInfobarDelegate::Create(infobar_service);
+-#endif
+   TabSpecificContentSettings* content_settings =
+       TabSpecificContentSettings::FromWebContents(web_contents());
+   content_settings->OnContentBlocked(CONTENT_SETTINGS_TYPE_ADS);
+-- 
+2.21.0
+

--- a/0050-update-subresource-filter-rules-after-startup.patch
+++ b/0050-update-subresource-filter-rules-after-startup.patch
@@ -1,0 +1,34 @@
+From 7471757fb56994c5361a666b650cd765680e5e23 Mon Sep 17 00:00:00 2001
+From: Zoraver Kang <zkang@wpi.edu>
+Date: Sat, 7 Sep 2019 03:55:56 -0400
+Subject: [PATCH 50/50] update subresource filter rules after startup
+
+---
+ chrome/browser/after_startup_task_utils.cc | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/chrome/browser/after_startup_task_utils.cc b/chrome/browser/after_startup_task_utils.cc
+index 698d5c5ca080..01b5bba88337 100644
+--- a/chrome/browser/after_startup_task_utils.cc
++++ b/chrome/browser/after_startup_task_utils.cc
+@@ -19,6 +19,7 @@
+ #include "base/task/post_task.h"
+ #include "base/task_runner.h"
+ #include "build/build_config.h"
++#include "chrome/browser/ui/webui/components_ui.h"
+ #include "content/public/browser/browser_task_traits.h"
+ #include "content/public/browser/browser_thread.h"
+ #include "content/public/browser/page_visibility_state.h"
+@@ -135,6 +136,9 @@ void SetBrowserStartupIsComplete() {
+   g_after_startup_tasks.Get().clear();
+   g_after_startup_tasks.Get().shrink_to_fit();
+ 
++  // Update Subresource Filter Rules component
++  ComponentsUI::OnDemandUpdate("gcmjkmgdlgnkkcocmoeiminaijmmjnii");
++
+ #if defined(OS_LINUX) && !defined(OS_CHROMEOS)
+   // Make sure we complete the startup notification sequence, or launchers will
+   // get confused by not receiving the expected message from the main process.
+-- 
+2.21.0
+


### PR DESCRIPTION
Addresses #10. Tested in the emulator on a number of webpages and behaved as described below.

The subresource filter does not seem to be applied unless Subresource Filter Rules has a version greater than 0.0.0.0 (visible and updatable on chrome://components). I do not know if Vanadium updates these components automatically; I never observed it in the emulator, but I also never left the emulator running for more than a few minutes at a time. On my own phone running GrapheneOS, I believe that the Subresource Filter Rules component had a valid version, but I manually updated it after and can't remember for sure.

When a site on which ads are being blocked is first loaded, a snackbar appears that states that ads are being blocked. When "more info" is pressed, it says that "this site shows intrusive or misleading ads" and gives the user the option to disable blocking. At first I considered this annoying, but upon further reflection, I decided that it was acceptable, as reimplementing a user interface to allow users to disable blocking for a specific site would be outside the scope of this project.