### PR TITLE
add additional disabling for AImageReader

### DIFF
--- a/0048-temporarily-disable-AImageReader-support.patch
+++ b/0048-temporarily-disable-AImageReader-support.patch
@@ -1,4 +1,4 @@
-From 24e749dc28f7934f7882c2625514c4d82ded5d0f Mon Sep 17 00:00:00 2001
+From 376452a5ea0066e0f89f75aa49e933c5dd829de8 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Sat, 26 Oct 2019 00:16:58 -0400
 Subject: [PATCH 48/49] temporarily disable AImageReader support
@@ -7,8 +7,9 @@ This works around a CFI failure issue:
 
 https://bugs.chromium.org/p/chromium/issues/detail?id=977583
 ---
- gpu/ipc/service/gpu_init.cc | 8 ++++----
- 1 file changed, 4 insertions(+), 4 deletions(-)
+ gpu/ipc/service/gpu_init.cc  | 8 ++++----
+ media/base/media_switches.cc | 2 +-
+ 2 files changed, 5 insertions(+), 5 deletions(-)
 
 diff --git a/gpu/ipc/service/gpu_init.cc b/gpu/ipc/service/gpu_init.cc
 index 0aa6832893e7..f76131050d93 100644
@@ -38,6 +39,19 @@ index 0aa6832893e7..f76131050d93 100644
  
    UMA_HISTOGRAM_ENUMERATION("GPU.GLImplementation", gl::GetGLImplementation());
  }
+diff --git a/media/base/media_switches.cc b/media/base/media_switches.cc
+index e7c7c5374c04..c805afbec9b6 100644
+--- a/media/base/media_switches.cc
++++ b/media/base/media_switches.cc
+@@ -457,7 +457,7 @@ const base::Feature kMediaDrmPreprovisioningAtStartup{
+ 
+ // Enables the Android Image Reader path for Video decoding(for AVDA and MCVD)
+ const base::Feature kAImageReaderVideoOutput{"AImageReaderVideoOutput",
+-                                             base::FEATURE_ENABLED_BY_DEFAULT};
++                                             base::FEATURE_DISABLED_BY_DEFAULT};
+ 
+ // Prevents using SurfaceLayer for videos. This is meant to be used by embedders
+ // that cannot support SurfaceLayer at the moment.
 -- 
-2.24.0
+2.24.1
 


### PR DESCRIPTION
Tested on Sargo -- the issue.

Closes https://github.com/GrapheneOS/os_issue_tracker/issues/166.

Related:
https://github.com/bromite/bromite/issues/445

https://github.com/bromite/bromite/blob/master/build/patches/Revert-Merge-to-M78-Enable-AImageReader-by-default.patch

https://bugs.chromium.org/p/chromium/issues/detail?id=977583&q=aimagereader&colspec=ID%20Pri%20M%20Stars%20ReleaseBlock%20Component%20Status%20Owner%20Summary%20OS%20Modified
