### PR TITLE
disable hardware-accelerated decoding on arm64

### DIFF
--- a/0048-Revert-Merge-to-M78-Enable-AImageReader-by-default.patch
+++ b/0048-Revert-Merge-to-M78-Enable-AImageReader-by-default.patch
@@ -1,19 +1,18 @@
-From 9620766034eb9987d2729a30ba8edb45e63ba968 Mon Sep 17 00:00:00 2001
-From: Daniel Micay <danielmicay@gmail.com>
-Date: Sat, 26 Oct 2019 00:16:58 -0400
-Subject: [PATCH 48/49] temporarily disable AImageReader support
+From: csagan5 <32685696+csagan5@users.noreply.github.com>
+Date: Mon, 14 Oct 2019 20:27:33 +0200
+Subject: [PATCH 48/49] Revert "[Merge to M78] Enable AImageReader by default."
 
-This works around a CFI failure issue:
+This reverts commit 60c3d4531b180b911767fb3ea7c3553d7f408c25.
 
-https://bugs.chromium.org/p/chromium/issues/detail?id=977583
+Automatically disable hardware acceleration for Android Q on arm64
 ---
  chrome/browser/android/chrome_startup_flags.cc | 9 +++++++++
- gpu/ipc/service/gpu_init.cc                    | 8 ++++----
+ gpu/config/gpu_finch_features.cc               | 2 +-
+ gpu/ipc/service/gpu_init.cc                    | 8 ++------
  media/base/media_switches.cc                   | 2 +-
- 3 files changed, 14 insertions(+), 5 deletions(-)
+ 4 files changed, 13 insertions(+), 8 deletions(-)
 
 diff --git a/chrome/browser/android/chrome_startup_flags.cc b/chrome/browser/android/chrome_startup_flags.cc
-index eb0d3ed9aa21..e86955881ae6 100644
 --- a/chrome/browser/android/chrome_startup_flags.cc
 +++ b/chrome/browser/android/chrome_startup_flags.cc
 @@ -6,6 +6,7 @@
@@ -46,39 +45,47 @@ index eb0d3ed9aa21..e86955881ae6 100644
    // Enable DOM Distiller backend.
    SetCommandLineSwitch(switches::kEnableDomDistiller);
  }
+diff --git a/gpu/config/gpu_finch_features.cc b/gpu/config/gpu_finch_features.cc
+--- a/gpu/config/gpu_finch_features.cc
++++ b/gpu/config/gpu_finch_features.cc
+@@ -31,7 +31,7 @@ bool FieldIsInBlacklist(const char* current_value, std::string blacklist_str) {
+ #if defined(OS_ANDROID)
+ // Use android AImageReader when playing videos with MediaPlayer.
+ const base::Feature kAImageReaderMediaPlayer{"AImageReaderMediaPlayer",
+-                                             base::FEATURE_ENABLED_BY_DEFAULT};
++                                             base::FEATURE_DISABLED_BY_DEFAULT};
+ 
+ // Use android SurfaceControl API for managing display compositor's buffer queue
+ // and using overlays on Android.
 diff --git a/gpu/ipc/service/gpu_init.cc b/gpu/ipc/service/gpu_init.cc
-index 0aa6832893e7..f76131050d93 100644
 --- a/gpu/ipc/service/gpu_init.cc
 +++ b/gpu/ipc/service/gpu_init.cc
-@@ -493,9 +493,9 @@ bool GpuInit::InitializeAndStartSandbox(base::CommandLine* command_line,
+@@ -493,9 +493,7 @@ bool GpuInit::InitializeAndStartSandbox(base::CommandLine* command_line,
  
  #if defined(OS_ANDROID)
    // Disable AImageReader if the workaround is enabled.
 -  if (gpu_feature_info_.IsWorkaroundEnabled(DISABLE_AIMAGEREADER)) {
-+  //if (gpu_feature_info_.IsWorkaroundEnabled(DISABLE_AIMAGEREADER)) {
-     base::android::AndroidImageReader::DisableSupport();
+-    base::android::AndroidImageReader::DisableSupport();
 -  }
-+  //}
++  base::android::AndroidImageReader::DisableSupport();
  #endif
  #if defined(USE_OZONE)
    gpu_feature_info_.supported_buffer_formats_for_allocation_and_texturing =
-@@ -523,9 +523,9 @@ void GpuInit::InitializeInProcess(base::CommandLine* command_line,
+@@ -523,9 +521,7 @@ void GpuInit::InitializeInProcess(base::CommandLine* command_line,
    default_offscreen_surface_ = gl::init::CreateOffscreenGLSurface(gfx::Size());
  
    // Disable AImageReader if the workaround is enabled.
 -  if (gpu_feature_info_.IsWorkaroundEnabled(DISABLE_AIMAGEREADER)) {
-+  //if (gpu_feature_info_.IsWorkaroundEnabled(DISABLE_AIMAGEREADER)) {
-     base::android::AndroidImageReader::DisableSupport();
+-    base::android::AndroidImageReader::DisableSupport();
 -  }
-+  //}
++  base::android::AndroidImageReader::DisableSupport();
  
    UMA_HISTOGRAM_ENUMERATION("GPU.GLImplementation", gl::GetGLImplementation());
  }
 diff --git a/media/base/media_switches.cc b/media/base/media_switches.cc
-index e7c7c5374c04..c805afbec9b6 100644
 --- a/media/base/media_switches.cc
 +++ b/media/base/media_switches.cc
-@@ -457,7 +457,7 @@ const base::Feature kMediaDrmPreprovisioningAtStartup{
+@@ -453,7 +453,7 @@ const base::Feature kMediaDrmPreprovisioningAtStartup{
  
  // Enables the Android Image Reader path for Video decoding(for AVDA and MCVD)
  const base::Feature kAImageReaderVideoOutput{"AImageReaderVideoOutput",
@@ -88,5 +95,5 @@ index e7c7c5374c04..c805afbec9b6 100644
  // Prevents using SurfaceLayer for videos. This is meant to be used by embedders
  // that cannot support SurfaceLayer at the moment.
 -- 
-2.24.1
+2.17.1
 

--- a/0048-Revert-Merge-to-M78-Enable-AImageReader-by-default.patch
+++ b/0048-Revert-Merge-to-M78-Enable-AImageReader-by-default.patch
@@ -1,3 +1,4 @@
+From 04a010aa4b4cd10d4a093d35b2d8e7346929f14a Mon Sep 17 00:00:00 2001
 From: csagan5 <32685696+csagan5@users.noreply.github.com>
 Date: Mon, 14 Oct 2019 20:27:33 +0200
 Subject: [PATCH 48/49] Revert "[Merge to M78] Enable AImageReader by default."
@@ -13,6 +14,7 @@ Automatically disable hardware acceleration for Android Q on arm64
  4 files changed, 13 insertions(+), 8 deletions(-)
 
 diff --git a/chrome/browser/android/chrome_startup_flags.cc b/chrome/browser/android/chrome_startup_flags.cc
+index eb0d3ed9aa21..e86955881ae6 100644
 --- a/chrome/browser/android/chrome_startup_flags.cc
 +++ b/chrome/browser/android/chrome_startup_flags.cc
 @@ -6,6 +6,7 @@
@@ -46,6 +48,7 @@ diff --git a/chrome/browser/android/chrome_startup_flags.cc b/chrome/browser/and
    SetCommandLineSwitch(switches::kEnableDomDistiller);
  }
 diff --git a/gpu/config/gpu_finch_features.cc b/gpu/config/gpu_finch_features.cc
+index ddb2ed78da45..6b4db27801aa 100644
 --- a/gpu/config/gpu_finch_features.cc
 +++ b/gpu/config/gpu_finch_features.cc
 @@ -31,7 +31,7 @@ bool FieldIsInBlacklist(const char* current_value, std::string blacklist_str) {
@@ -58,6 +61,7 @@ diff --git a/gpu/config/gpu_finch_features.cc b/gpu/config/gpu_finch_features.cc
  // Use android SurfaceControl API for managing display compositor's buffer queue
  // and using overlays on Android.
 diff --git a/gpu/ipc/service/gpu_init.cc b/gpu/ipc/service/gpu_init.cc
+index 0aa6832893e7..05991c7b3457 100644
 --- a/gpu/ipc/service/gpu_init.cc
 +++ b/gpu/ipc/service/gpu_init.cc
 @@ -493,9 +493,7 @@ bool GpuInit::InitializeAndStartSandbox(base::CommandLine* command_line,
@@ -83,9 +87,10 @@ diff --git a/gpu/ipc/service/gpu_init.cc b/gpu/ipc/service/gpu_init.cc
    UMA_HISTOGRAM_ENUMERATION("GPU.GLImplementation", gl::GetGLImplementation());
  }
 diff --git a/media/base/media_switches.cc b/media/base/media_switches.cc
+index e7c7c5374c04..c805afbec9b6 100644
 --- a/media/base/media_switches.cc
 +++ b/media/base/media_switches.cc
-@@ -453,7 +453,7 @@ const base::Feature kMediaDrmPreprovisioningAtStartup{
+@@ -457,7 +457,7 @@ const base::Feature kMediaDrmPreprovisioningAtStartup{
  
  // Enables the Android Image Reader path for Video decoding(for AVDA and MCVD)
  const base::Feature kAImageReaderVideoOutput{"AImageReaderVideoOutput",
@@ -95,5 +100,5 @@ diff --git a/media/base/media_switches.cc b/media/base/media_switches.cc
  // Prevents using SurfaceLayer for videos. This is meant to be used by embedders
  // that cannot support SurfaceLayer at the moment.
 -- 
-2.17.1
+2.24.1
 

--- a/0048-temporarily-disable-AImageReader-support.patch
+++ b/0048-temporarily-disable-AImageReader-support.patch
@@ -1,4 +1,4 @@
-From 376452a5ea0066e0f89f75aa49e933c5dd829de8 Mon Sep 17 00:00:00 2001
+From 9620766034eb9987d2729a30ba8edb45e63ba968 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Sat, 26 Oct 2019 00:16:58 -0400
 Subject: [PATCH 48/49] temporarily disable AImageReader support
@@ -7,10 +7,45 @@ This works around a CFI failure issue:
 
 https://bugs.chromium.org/p/chromium/issues/detail?id=977583
 ---
- gpu/ipc/service/gpu_init.cc  | 8 ++++----
- media/base/media_switches.cc | 2 +-
- 2 files changed, 5 insertions(+), 5 deletions(-)
+ chrome/browser/android/chrome_startup_flags.cc | 9 +++++++++
+ gpu/ipc/service/gpu_init.cc                    | 8 ++++----
+ media/base/media_switches.cc                   | 2 +-
+ 3 files changed, 14 insertions(+), 5 deletions(-)
 
+diff --git a/chrome/browser/android/chrome_startup_flags.cc b/chrome/browser/android/chrome_startup_flags.cc
+index eb0d3ed9aa21..e86955881ae6 100644
+--- a/chrome/browser/android/chrome_startup_flags.cc
++++ b/chrome/browser/android/chrome_startup_flags.cc
+@@ -6,6 +6,7 @@
+ 
+ #include "chrome/browser/android/chrome_startup_flags.h"
+ 
++#include "base/android/build_info.h"
+ #include "base/android/jni_android.h"
+ #include "base/android/jni_string.h"
+ #include "base/android/scoped_java_ref.h"
+@@ -16,6 +17,7 @@
+ #include "chrome/common/chrome_switches.h"
+ #include "components/browser_sync/browser_sync_switches.h"
+ #include "components/dom_distiller/core/dom_distiller_switches.h"
++#include "content/public/common/content_switches.h"
+ #include "media/base/media_switches.h"
+ 
+ namespace {
+@@ -40,6 +42,13 @@ void SetChromeSpecificCommandLineFlags() {
+   if (base::SysInfo::IsLowEndDevice())
+     SetCommandLineSwitchASCII(switches::kDisableSyncTypes, "Favicon Images");
+ 
++#ifdef ARCH_CPU_ARM64
++  // workaround for Android 10 "Q" arm64 crash
++  if (base::android::BuildInfo::GetInstance()->sdk_int() > base::android::SDK_VERSION_P) {
++    SetCommandLineSwitchASCII(switches::kDisableAcceleratedVideoDecode, "true");
++  }
++#endif
++
+   // Enable DOM Distiller backend.
+   SetCommandLineSwitch(switches::kEnableDomDistiller);
+ }
 diff --git a/gpu/ipc/service/gpu_init.cc b/gpu/ipc/service/gpu_init.cc
 index 0aa6832893e7..f76131050d93 100644
 --- a/gpu/ipc/service/gpu_init.cc


### PR DESCRIPTION
I was still getting crashes on blueline using #52 . I followed @csagan5's advice and disabled hardware-accelerated decoding with this patch and have confirmed it fixes the crashes on the Pixel 3.