### PR TITLE
Port to 80.0.3987.87

### DIFF
--- a/0001-use-64-bit-WebView-processes.patch
+++ b/0001-use-64-bit-WebView-processes.patch
@@ -1,24 +1,24 @@
-From b0bf179dae6f1761b288336394a1ef7aa79b44ff Mon Sep 17 00:00:00 2001
+From 99a86b0efc8f502804fe632b998ec35e34bab6f0 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Thu, 26 Jan 2017 01:30:12 -0500
 Subject: [PATCH 01/49] use 64-bit WebView processes
 
 ---
- android_webview/apk/java/AndroidManifest.xml | 1 -
+ android_webview/nonembedded/java/AndroidManifest.xml | 1 -
  1 file changed, 1 deletion(-)
 
-diff --git a/android_webview/apk/java/AndroidManifest.xml b/android_webview/apk/java/AndroidManifest.xml
-index 4bd637bcdd1d..f4acac1886e7 100644
---- a/android_webview/apk/java/AndroidManifest.xml
-+++ b/android_webview/apk/java/AndroidManifest.xml
-@@ -22,7 +22,6 @@
+diff --git a/android_webview/nonembedded/java/AndroidManifest.xml b/android_webview/nonembedded/java/AndroidManifest.xml
+index c9dea7bfb8c7..c6cdceed002d 100644
+--- a/android_webview/nonembedded/java/AndroidManifest.xml
++++ b/android_webview/nonembedded/java/AndroidManifest.xml
+@@ -25,7 +25,6 @@
                   android:icon="@{{manifest_package|default('com.android.webview')}}:drawable/icon_webview"
-                  android:name="{{ application_name|default('com.android.webview.chromium.WebViewApkApplication') }}"
+                  android:name="{{ application_name|default('org.chromium.android_webview.nonembedded.WebViewApkApplication') }}"
                   android:multiArch="true"
--                 android:use32bitAbi="true"
+-                 {{ use32bitAbi|default('android:use32bitAbi="true"') }}
                   android:extractNativeLibs="{{ trichrome_library is not defined }}">
          {# This part is shared between stand-alone WebView and Monochrome #}
          {% macro common(manifest_package, webview_lib) %}
 -- 
-2.24.0
+2.25.0
 

--- a/0002-switch-to-fstack-protector-strong.patch
+++ b/0002-switch-to-fstack-protector-strong.patch
@@ -1,4 +1,4 @@
-From ca9a93c90cd4b53714b5275bbbe3d326cb20b666 Mon Sep 17 00:00:00 2001
+From 315291167755c4fc00305661eea80ea1bbf58907 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Wed, 26 Dec 2018 10:20:24 -0500
 Subject: [PATCH 02/49] switch to -fstack-protector-strong
@@ -8,10 +8,10 @@ Subject: [PATCH 02/49] switch to -fstack-protector-strong
  1 file changed, 1 insertion(+), 5 deletions(-)
 
 diff --git a/build/config/compiler/BUILD.gn b/build/config/compiler/BUILD.gn
-index 93ad68a613b3..4ad2888337d9 100644
+index fbf8335f11ba..63eb5c03701e 100644
 --- a/build/config/compiler/BUILD.gn
 +++ b/build/config/compiler/BUILD.gn
-@@ -288,16 +288,12 @@ config("compiler") {
+@@ -293,16 +293,12 @@ config("compiler") {
          cflags += [ "-fstack-protector" ]
        }
      } else if ((is_posix && !is_chromeos && !is_nacl) || is_fuchsia) {
@@ -30,5 +30,5 @@ index 93ad68a613b3..4ad2888337d9 100644
      }
  
 -- 
-2.24.0
+2.25.0
 

--- a/0003-enable-fwrapv-in-Clang-for-non-UBSan-builds.patch
+++ b/0003-enable-fwrapv-in-Clang-for-non-UBSan-builds.patch
@@ -1,4 +1,4 @@
-From 5362dcaf370b286474fea991cb86940054cae514 Mon Sep 17 00:00:00 2001
+From 22f42dc333da62a1da0854c0499709d9553a5946 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Thu, 22 Dec 2016 07:15:34 -0500
 Subject: [PATCH 03/49] enable -fwrapv in Clang for non-UBSan builds
@@ -8,10 +8,10 @@ Subject: [PATCH 03/49] enable -fwrapv in Clang for non-UBSan builds
  1 file changed, 4 insertions(+)
 
 diff --git a/build/config/compiler/BUILD.gn b/build/config/compiler/BUILD.gn
-index 4ad2888337d9..8baa7af5680d 100644
+index 63eb5c03701e..e9f7a8cfdfca 100644
 --- a/build/config/compiler/BUILD.gn
 +++ b/build/config/compiler/BUILD.gn
-@@ -297,6 +297,10 @@ config("compiler") {
+@@ -302,6 +302,10 @@ config("compiler") {
        }
      }
  
@@ -23,5 +23,5 @@ index 4ad2888337d9..8baa7af5680d 100644
      if (fatal_linker_warnings && !(is_chromeos && current_cpu == "arm") &&
          !is_mac && !is_ios && current_os != "aix") {
 -- 
-2.24.0
+2.25.0
 

--- a/0004-Vanadium-branding.patch
+++ b/0004-Vanadium-branding.patch
@@ -1,4 +1,4 @@
-From 48c98fca9f81ec9d796b1e9ce1badf05bb96924b Mon Sep 17 00:00:00 2001
+From 2cf2e64b16ca434923953d3e16271b9c928845c9 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Sun, 6 Aug 2017 12:45:14 -0400
 Subject: [PATCH 04/49] Vanadium branding
@@ -65,10 +65,10 @@ Current incantation of the recolor command:
  create mode 100644 chrome/android/java/res_vanadium/values/channel_constants.xml
 
 diff --git a/chrome/android/BUILD.gn b/chrome/android/BUILD.gn
-index f0c7c5c7f7eb..9308269b72da 100644
+index 8b76fc6199a1..cd528bacd833 100644
 --- a/chrome/android/BUILD.gn
 +++ b/chrome/android/BUILD.gn
-@@ -93,7 +93,7 @@ generate_ui_locale_resources("ui_locale_string_resources") {
+@@ -109,7 +109,7 @@ generate_ui_locale_resources("ui_locale_string_resources") {
  android_resources("chrome_app_java_resources") {
    resource_dirs = [
      "java/res",
@@ -77,7 +77,7 @@ index f0c7c5c7f7eb..9308269b72da 100644
    ]
  
    if (enable_android_night_mode) {
-@@ -1085,7 +1085,7 @@ android_resources("chrome_public_test_apk_resources") {
+@@ -1063,7 +1063,7 @@ android_resources("chrome_public_test_apk_resources") {
  
  # Overrides icon / name defined in chrome_app_java_resources.
  android_resources("chrome_public_apk_resources") {
@@ -105,7 +105,7 @@ new file mode 100644
 index 0000000000000000000000000000000000000000..d9d6661c938b2907e30da3ae87cdb2894db5592d
 GIT binary patch
 literal 11327
-zc-jF!EWp!=P)<h;3K|Lk000e1NJLTq006@P006@X1ONa4m3D0*00002VoOIv0RM-N
+zcmV-FEWp!=P)<h;3K|Lk000e1NJLTq006@P006@X1ONa4m3D0*00002VoOIv0RM-N
 z%)bBtEBHx7K~#9!?VWj)99MnsKlfJkKKmk#mXTyhSd#Y*%Ra`5ZCUog#tV)yF&KC+
 z<|GDU90K9Jge8O+2<PDNut@^%ybwqX4mOD~#x|Rm=jGuAZ?Y}P+NBwdW}lwvwYsb7
 zzCWs$s-B*i?&)QO$#0HE)79N|Z~eaax7^?T-QN}0Q9VgAq==9~B1y1@DNLZ1EKwAS
@@ -326,14 +326,14 @@ zJ0a3!Go$*HoHB+u);$m(um^Pmpo6HZ%F^*i{~yS0JYSiOkN*Gw002ovPDHLkV1iRV
 Bx8MK(
 
 literal 0
-Hc-jL100001
+HcmV?d00001
 
 diff --git a/chrome/android/java/res_vanadium/drawable-hdpi/product_logo_name.png b/chrome/android/java/res_vanadium/drawable-hdpi/product_logo_name.png
 new file mode 100644
 index 0000000000000000000000000000000000000000..8678cbbb730de9c3ff9d3dba7d928d60f28bd550
 GIT binary patch
 literal 1998
-zc-jHZ2Qm1GP)<h;3K|Lk000e1NJLTq005f+001Be1ONa4uVuoq00002VoOIv0RM-N
+zcmV;<2Qm1GP)<h;3K|Lk000e1NJLTq005f+001Be1ONa4uVuoq00002VoOIv0RM-N
 z%)bBt2Zu>SK~!ko<=J0sWOWq>@Xx*Tue$}h(?xgL^$(e{1YKD$ttiGof~^Vx9)MOu
 zG$zJ$V+<<#(2`(G2$D7sv-n`r`s9OR+7Oj!jP4K>9x$+jvMdlpCd<G5<L-9a?Y7g-
 zOlN%PbUM?eP`V|f@STVG{k!LP&i9^kf9KpA+yX)cp|aCLam8fei-l{8d&(cGTp%zN
@@ -374,14 +374,14 @@ zza1|{8eS^B9}!%))KF3pS28cMJ#j<i+Hm*uwq56aHaKx+;rQJ1`Nz)uvHbcbt!9+#
 gs)YxeZ9!A;U++Vmx7pctfdBvi07*qoM6N<$g5_ZC5&!@I
 
 literal 0
-Hc-jL100001
+HcmV?d00001
 
 diff --git a/chrome/android/java/res_vanadium/drawable-mdpi/fre_product_logo.png b/chrome/android/java/res_vanadium/drawable-mdpi/fre_product_logo.png
 new file mode 100644
 index 0000000000000000000000000000000000000000..40b88b5225ddff2fb47116a99a38999218e744ec
 GIT binary patch
 literal 6794
-zc-jGq8g=D~P)<h;3K|Lk000e1NJLTq004pj004pr1ONa4APU%a00002VoOIv0RM-N
+zcmV;58g=D~P)<h;3K|Lk000e1NJLTq004pj004pr1ONa4APU%a00002VoOIv0RM-N
 z%)bBt8be7$K~#9!)tz~iB*lH_KM{G<)z|bjJ@>)D%!mO-Fw7-DAPmTokc7~a^mM>3
 zZzcS8pLT_9R@Sb(&)T)*U3n#2eztCw(_%quSrW30g+~aD#AO%`F)++9!yMhycU9M2
 zm6esTe`IDI-BsOnwFSR?U7eMc85!}--xa_3MWpxuOOYgpLdU@%#5jW(oWUeO8V!Yp
@@ -514,14 +514,14 @@ zhj>D$5MmkU-7e!>Q2kdIXfIhW74NXI16-hOVT5&Tll`hE8(I@M7MRpEgsm*{#hgm!
 s;^t9aPfn=Q!52i_!lZI+YPsnD1F3svQs!l<l>h($07*qoM6N<$g1%n2wg3PC
 
 literal 0
-Hc-jL100001
+HcmV?d00001
 
 diff --git a/chrome/android/java/res_vanadium/drawable-mdpi/product_logo_name.png b/chrome/android/java/res_vanadium/drawable-mdpi/product_logo_name.png
 new file mode 100644
 index 0000000000000000000000000000000000000000..5f92063170520afa34dd48fa6610ea122439e916
 GIT binary patch
 literal 1200
-zc-jH51W)^kP)<h;3K|Lk000e1NJLTq003tI000#T1ONa4@uE1m00002VoOIv0RM-N
+zcmV;h1W)^kP)<h;3K|Lk000e1NJLTq003tI000#T1ONa4@uE1m00002VoOIv0RM-N
 z%)bBt1Zhb`K~z}7&DURyTy+%(@Xx(>_FsX@O}84i3U(VMgzx}UVwc9o;1FXpBtoWy
 z2j6rWUf_X*Ex|`ac1+~Kw;kh?hR6=+gBnd1V-!O{cS$sAG|)-^n3k4yW}(~d?#%4H
 zJk0Ig(t_M=8p?UO_x{fBob&yjbAEqr@Ss2<(bv_zXSLeh+uv!6mFS39qGs}1Psy+Z
@@ -547,14 +547,14 @@ z^+sAqN|1`A|9R&d!QRnoG_`We?y>N~$>SGZU49|`b6{BT;s2taFnJGY>5Ee&#m%|^
 O0000<MNUMnLSTZ4d0|-q
 
 literal 0
-Hc-jL100001
+HcmV?d00001
 
 diff --git a/chrome/android/java/res_vanadium/drawable-xhdpi/fre_product_logo.png b/chrome/android/java/res_vanadium/drawable-xhdpi/fre_product_logo.png
 new file mode 100644
 index 0000000000000000000000000000000000000000..07ecccb90a3786c3c3d7ac33a3f8cb2d2ee555b2
 GIT binary patch
 literal 16100
-zc-jHvJ{!S_P)<h;3K|Lk000e1NJLTq009I5009ID1ONa4WC4PK00002VoOIv0RM-N
+zcmV<AJ{!S_P)<h;3K|Lk000e1NJLTq009I5009ID1ONa4WC4PK00002VoOIv0RM-N
 z%)bBtKAlNKK~#9!?Y()N9A|y!|9+mT>T52|jP6^OWZ9N1VOvH9-zHeb#!fgw4%lQv
 z$ijkcSV%%nLjpgJCFC%egaq>2WV4%1AUFXM8<TL^1|O0SNyfU5(Tp@#&(+g+RXzJh
 zbx&7!Rrhqy^fjzM^HOW3y6UOt_&(q3`99xAyqU#AATUW`(?ymf-K5CSOD`ws#wNu|
@@ -866,14 +866,14 @@ zHcQ#BHdrh4<*AJ_B6{r&$*>;S8h$!F714vru|u<1B12pyR4S0QllFOiQcu_e_IP%D
 q!#O!IXc-t}kqB(e_H@WD3jY_Ejr#a36nZuQ0000<MNUMnLSTZIDYe}I
 
 literal 0
-Hc-jL100001
+HcmV?d00001
 
 diff --git a/chrome/android/java/res_vanadium/drawable-xhdpi/product_logo_name.png b/chrome/android/java/res_vanadium/drawable-xhdpi/product_logo_name.png
 new file mode 100644
 index 0000000000000000000000000000000000000000..ee268c83d97f8d6b73eac0dbe25a204dcc91d4da
 GIT binary patch
 literal 2609
-zc-jFm3eNS3P)<h;3K|Lk000e1NJLTq007Pa001fo1ONa4QNyg;00002VoOIv0RM-N
+zcmV-13eNS3P)<h;3K|Lk000e1NJLTq007Pa001fo1ONa4QNyg;00002VoOIv0RM-N
 z%)bBt3F=8iK~#9!?VEp$9Az2DKl9G)>|MKe?OY3KEzmHhZ7oJh_b?bl5q6Cl$`8$6
 zVyeMtyrsqjL?Wkupu|7C13_#I&?Eea{E9vN5hVoEGmQ!{$}OUR0>T#Bv=rLj-0j}p
 z?#}Mc_{YxP?flr@59Y4e+;@|^n`hsd?>o=)KF|BS&-<SA1?mt~siI;sg@r%{tPPb<
@@ -926,14 +926,14 @@ zR{4SA1I10^GC3}7F0I#ApB+75niI9R&DV<0m-ZK5R*5d?U#*rgcSy_XegEQref)de
 TPbPHy00000NkvXXu0mjf*Ld(I
 
 literal 0
-Hc-jL100001
+HcmV?d00001
 
 diff --git a/chrome/android/java/res_vanadium/drawable-xxhdpi/fre_product_logo.png b/chrome/android/java/res_vanadium/drawable-xxhdpi/fre_product_logo.png
 new file mode 100644
 index 0000000000000000000000000000000000000000..4f300d7f849b005ba63163d63a643f3aeb737aea
 GIT binary patch
 literal 26693
-zc-jCpK+3;~P)<h;3K|Lk000e1NJLTq00D*o00D*w1ONa4)rszI00002VoOIv0RM-N
+zcmV)WK(4=uP)<h;3K|Lk000e1NJLTq00D*o00D*w1ONa4)rszI00002VoOIv0RM-N
 z%)bBtXZ}e<K~#9!?Y(!LBu9Ps|E}tuxOs2)a#YSbC6rMH1Ok&yFg9R#z!)AIunpLL
 z%wufxke!VaVEiK*3?>O1Bmol20R<$TPP(+WySF*bPV7*>KYC`TXQroTW_M<HW_CaQ
 zy4&5E>h9|5`qVenx4tD_$?8A=kjBJDrvsA(Bz>49u+a!}I!}@z!wwdh;UrRoh%-qC
@@ -1249,7 +1249,7 @@ zdcKKqUq4ciB!{qTmJ6-Wr*uL*_0Tg2KpGerq@K0fPBJ*qNO3#8zT<uz$-B{8IEHn3
 z5G2ug55gx)5<nM6+b~wufriD%p(7mSsG}z7$fu09GoisrTOZ*OCh77ir8C53+`>W=
 zkzqAfmrLe(DVH+jn;lOl#X&6e8Z#xe261c>!<(Mk&NjB?#DU0|Pqs$oYlT2#m^;{1
 zK?R!U{p?|;N#x^dybFzK_VRna>lZ-L&9j^!*y2l}ydlV7{<7cbp@$x1m@r|YaDTh3
-zcPoBe8^Jv+(B;#`0T3wf*90>}crP?X+R4?Rf+UIHeT13ued0h?E@(BTlWdKlRiKF9
+zcPoBe8^Jv+(B;#`1T#c<FEmBk$<?5OB#GdCgqiVu;y_j|Xf>vj0rV#e*ldlVRiKF9
 zzd)QAF{Fisg^lsB*(9T4{U12UP(|6GGsHFgDzj_+8dobLmCYQl<C+R8l1(=UnIKeS
 z{=C+pg0lxv`oY}h?#>J}7UE&M3C6_6;YUo+U*RQ9^M1}{x^BBzHZL@$Igj@-U7=i*
 zMSh7u)-+JI3Kc*jsgl3QkS0w!_ly!XY&^QwRcjOkL5}l%)#Lk`1Pd5^jQ$FN%#Fip
@@ -1449,14 +1449,14 @@ zmdO6dLevV2PCKFk1e8tyg&_<~Vak+T6mgOyRl46yrqzfT&dhB~rQ@;TuHku8A=pF*
 gCy1=|1GgRie-#m>m)v0)5&!@I07*qoM6N<$f-sBn4*&oF
 
 literal 0
-Hc-jL100001
+HcmV?d00001
 
 diff --git a/chrome/android/java/res_vanadium/drawable-xxhdpi/product_logo_name.png b/chrome/android/java/res_vanadium/drawable-xxhdpi/product_logo_name.png
 new file mode 100644
 index 0000000000000000000000000000000000000000..fc327262fd9479d15200e5ebca3f5335a1ce12c4
 GIT binary patch
 literal 4270
-zc-jH35K-@mP)<h;3K|Lk000e1NJLTq00A`s002J-1ONa4EBcpR00002VoOIv0RM-N
+zcmV;f5K-@mP)<h;3K|Lk000e1NJLTq00A`s002J-1ONa4EBcpR00002VoOIv0RM-N
 z%)bBt5NAn5K~#9!?VVe28`pWqe`j}b;Y}oD-6h)*Bwyq{=mJ@mRC}5zU^<Q`Gqz+Z
 zeTeH!(@;q|(_}iGkvxslNj>RMO&_Z1q%mnH(^#G+rXu^L^(CS+aZ^=^B}kQ%Sh6F*
 zvUQ^rkst|@xGb>S2P_r~VlR*kg0O`@W(W{x&+fOoe|+aV-{q{>jujFrDn4X#q|wQs
@@ -1541,14 +1541,14 @@ z*2`;HlJ4qiTN*q=E}fs&#<Ev(?_^F){hCug1Ockg5ozLPfoK}+P1Fbf4>8lX6)B~&
 QLI3~&07*qoM6N<$f)Jt_fB*mh
 
 literal 0
-Hc-jL100001
+HcmV?d00001
 
 diff --git a/chrome/android/java/res_vanadium/drawable-xxxhdpi/fre_product_logo.png b/chrome/android/java/res_vanadium/drawable-xxxhdpi/fre_product_logo.png
 new file mode 100644
 index 0000000000000000000000000000000000000000..52abcdfc19c13770971730c8bd4d8267a633ac22
 GIT binary patch
 literal 39011
-zc-jC^K(D`vP)<h;3K|Lk000e1NJLTq00IaA00IaI1ONa4q4nPA00002VoOIv0RM-N
+zcmV)xK$E|TP)<h;3K|Lk000e1NJLTq00IaA00IaI1ONa4q4nPA00002VoOIv0RM-N
 z%)bBtfB;EEK~#9!?45U<Bu9Dozg686H{RY}4!S!@r;~KbIR}u)29a!IW57g%jcpvk
 z*v7^YkWF#`1I9MI7>j5yK}Z5cKmiFPp?tcy;WqD1?ojU^J+qT~W_o64cEa{=KGN+>
 zcXd})S3UjYN4%U)f<TbQL}8<$6GAeJKr%ppX#$u?G&IiV3C4(GBH78~gpi!VA)*ZN
@@ -1864,8 +1864,8 @@ zAtnhgKOCs$P3V5aDezV6u~v$0uvy^wynth#$$`xf0p8CnqrUc_F4zn*#b5GChFJ2r
 z5hb(i=REEqMHn5c!e*%UTlq2X-i@Ux&b;~)*1AtUB%suzu^jo8u(a1K;J{=qAA117
 z!d2dV!`cB!f;4BKm+9y$SJ-pk0t(y1o7z1i&Jz9n36_gjL?sA@`8W?U($2}F`^bTV
 z^*q4G8L4AsDl%NlAW4$cryp=XCOmKGVtYX)jYXxF-uwru!(BsBK0`UJ2P|A3BeDFE
-zIs2oD-DjQFsTzblrrE-d0)GVe?1;5;Ce}w1@(@6b=d!PkgkKf_P(ZK0JNPkQAX1Y2
-z)rS{2RiwYbee9^i+Az-!&Lu+z1Kopup!8T}iM?7oQTE-texSSu)rnT+D|xwRPGr^q
+zIs2oD-DjQFsTzblrrE-d0)GVe?1;5;Ce}w1@(@6b=d!PkgkKgr_%UA~Qj+}DhZi_i
+zq`$y@?5M-qFwYLoB|`=P(m*Z01Kopup!8T}iM?7oQTE-texSSu)rnT+D|xwRPGr^q
 z`z$M*w=~KW&L>Us;`GKAKG~)~Vz9s&L|t5z>Vtp^9`EkwI?z~Rh~FcD>5+l8Sx1}?
 zVbJG`3k~+WAA=8)tRsnx%@UU}LNaTnZj>J=wL>V^mhRuZ^8;>%L~kO3C~N8M%tG>J
 zYzkl0znn2?c~vXqS%%i>{DG6baFD%D{YlEziPbrW{PZ~RW^pJyKhBHT$FxTkmqIeg
@@ -2181,10 +2181,10 @@ zNnf2<2ZGFV7&#Sq5%Z!T1<mSWRjmw#kO+8If0gm=neZqf49^qbZ}*j=R=9KSn<z@G
 zn)^McHOPA^sDi&u5(K#pjhLToy$*y};u&O8e^us?f!Vg1)8lQqts>(H3O~?ZpZV_@
 zMhPtE{r9o@a93U_SF><=;`KaiOfp=|8F8xs02mNSL_t)@9;S%-$<jO{M3Mu<xaf5!
 z-X6znqawCtY1penWNDyH=!?M(v5(C%+R<JKy$m;Z<=nSYfkBm!j$*;VNtQOkb4ZaS
-z?ehm75hTqs81((-@J*wvbGYX=VO3)p0mBzO=nCPyI~0n*$AjxL@0;;S!YZM1cI8q%
-zfsHB>2nzEmmb);6MFxY**vc63wl3>#LJ*5*h%xx*)<0!XB-+}Wjv(UVFZ9nRne#2y
-ztANVy_tM|hvca+Nh${Ji;W3jqTe*w{;w`C6+=~ccbAWk5pHqL?2_kbx5Cn_J>xRD;
-zV-Bq|I<zKHsS-owY>LIdTVx1uEkPFiQm!7M0|%I9*H=bg-x=}09kTzV6?l#OVUjtY
+z?ehm75hTqs81((-@J*wvbGYX=VO3)p3gNsv6pFydgX=TzoAF7)Dxq?A<x)L?jVcld
+z3iB$KyD)=A27}Ak${6vsF6(YW5Q}GsG5F`!KV?uP+S;3rAmZXL^v@@m^DWk^fXeUp
+z(%;px!Ljg&D*1omF_So3xr_zkEvZc0iwIzIfO$fnQ-9eBB6CL&1dGV)hQAhL4y`jf
+zv?fuh5<}%|ip9TMWC(CAK^FW{t{$NS2bcjR7ux7%*H=bg-x=}09kTzV6?l#OVUjtY
 z(OfkYyCYTdGH^RytVYcJ>X;kPWuBx9Z{edH8j?dy(|7mo*VtAk@CO}35EOP&T&Ld|
 zXBOEho$5K1O8)Mag~H>i2H%iBYLXzrbAXtiJJAy~bPh6&cBi`DN_R>QF}>Y%Dd&PA
 zu;cox)E)7?lHs;TIIIO!^OJYe5#)a_hhuKMlwC}b@Xd`LprLb!DMC-CUZoOxR(Tsh
@@ -2301,14 +2301,14 @@ z_ovCc>JVL~6Nel*qf8EkA(UZKq##1!Qp6RmDdR~WZ@xb2TgT;pb#Gjxe1+ay)NW^0
 f`ch_Jq&DIIbfZ@m$+<~>00000NkvXXu0mjf!$8AO
 
 literal 0
-Hc-jL100001
+HcmV?d00001
 
 diff --git a/chrome/android/java/res_vanadium/drawable-xxxhdpi/product_logo_name.png b/chrome/android/java/res_vanadium/drawable-xxxhdpi/product_logo_name.png
 new file mode 100644
 index 0000000000000000000000000000000000000000..5f16990a7eb67c441bfc62d50a4e92f95c0f4f22
 GIT binary patch
 literal 5925
-zc-jFa7ux8FP)<h;3K|Lk000e1NJLTq00Eo;002}71ONa49E3^V00002VoOIv0RM-N
+zcmV+=7ux8FP)<h;3K|Lk000e1NJLTq00Eo;002}71ONa49E3^V00002VoOIv0RM-N
 z%)bBt7T!rjK~#9!?VW3I99NZqzuVpO(9<5-ma!dTYwU!O1cx9c1V|NBN`~dR6d=Qr
 z;9Wu?k?a=B0u`Gjfm)z~9jXYhOTeO*uml3JYO~8D0oK~=BfOGWu#f~N!5-W3Te4>)
 zjYgVh_x_lkQTI&G^c`g+&6xhCT<%dn=AQ0*`kZ_3x#x;^P>w=|ETAD!nMOe;4fx2R
@@ -2425,14 +2425,14 @@ zntO)Bsb@2f>)9Xy)CEPqd3ZD)!gH8BJZeXNYNm&WN0I*rsl^JT&aD`J00000NkvXX
 Hu0mjf>GD|)
 
 literal 0
-Hc-jL100001
+HcmV?d00001
 
 diff --git a/chrome/android/java/res_vanadium/mipmap-hdpi/app_icon.png b/chrome/android/java/res_vanadium/mipmap-hdpi/app_icon.png
 new file mode 100644
 index 0000000000000000000000000000000000000000..9533ce927dbb3f4d3849d9a2c062ff31850ae454
 GIT binary patch
 literal 2578
-zc-jFH3hniYP)<h;3K|Lk000e1NJLTq002k;002k`1ONa4|Kxkj00002VoOIv0RM-N
+zcmV+t3hniYP)<h;3K|Lk000e1NJLTq002k;002k`1ONa4|Kxkj00002VoOIv0RM-N
 z%)bBt3Cl@DK~!ko&6;g&9K{*Oe>1yxw$JbO8P_4Po#2Ed#34XHNoYhVQYlDKP@zf@
 zQc+t$^PyEskqT=10YutL<)xL{(l30d1VJe&MXDf_hLlDD6d<%Nae@tbabi31OJdIN
 zcelIK4?BCeciy|(%Zu9QboTA+?#yrg^UO0dI}873CN6Rw>VE|!0D;tB_gDcA3Wb9@
@@ -2484,14 +2484,14 @@ zXXB@sW|~>%NnwTFPc9S4yIy9tcp`dZ$9=x*cD58r()wd%HYdv}pnUV*K$DqAt8PAy
 o?sU%izlC<8Z|MbZHC}-I7X>G&nZLZnpa1{>07*qoM6N<$f{)wb@Bjb+
 
 literal 0
-Hc-jL100001
+HcmV?d00001
 
 diff --git a/chrome/android/java/res_vanadium/mipmap-hdpi/app_shortcut_icon.png b/chrome/android/java/res_vanadium/mipmap-hdpi/app_shortcut_icon.png
 new file mode 100644
 index 0000000000000000000000000000000000000000..b054450f1534f806b8b28213b33778e75c450725
 GIT binary patch
 literal 2574
-zc-jFD3i0)cP)<h;3K|Lk000e1NJLTq002k;002k`1ONa4|Kxkj00002VoOIv0RM-N
+zcmV+p3i0)cP)<h;3K|Lk000e1NJLTq002k;002k`1ONa4|Kxkj00002VoOIv0RM-N
 z%)bBt3CBr9K~!ko&6;^^9Mu`XfA7uguD!lC_PS1-!*(tL*pNUdN+2abRSqc#R6!}C
 z1qrp3KPpiQYAPrK)F9MC)k+AYs>dH(IRMd0B|r(ZB&j$|m6XIzq6Fe3Hu%V4d$YE8
 zXXf>fdAmEip4r1m)PAcy=FOY;{pNe$eDC-c{?A05<u=s+3P=C~i9jIru>u?v3I{b)
@@ -2543,14 +2543,14 @@ zWRetC+4<xOfim?aW;T@*Axuc;4IC`eq?jVDU+y1ID%#<iS;{$+naiXqGASO%Gw9Fo
 kUub9gFFpTM;~B_*0oNUsuT)Zgn*aa+07*qoM6N<$f)V!8^8f$<
 
 literal 0
-Hc-jL100001
+HcmV?d00001
 
 diff --git a/chrome/android/java/res_vanadium/mipmap-hdpi/app_single_page_icon.png b/chrome/android/java/res_vanadium/mipmap-hdpi/app_single_page_icon.png
 new file mode 100644
 index 0000000000000000000000000000000000000000..c544d46ce870ad2efc9984da57d853df5f28c3e4
 GIT binary patch
 literal 1496
-zc-jHj1t<E6P)<h;3K|Lk000e1NJLTq002k;002k`1ONa4|Kxkj00002VoOIv0RM-N
+zcmV;}1t<E6P)<h;3K|Lk000e1NJLTq002k;002k`1ONa4|Kxkj00002VoOIv0RM-N
 z%)bBt1(8WaK~!ko?b`2e6LlQG@%P=W?K))Z24hoTs|p6?$Lh2BfG~M5;$Pr1Wj^x}
 z{sW36K3pQk7!uKpghWvzBqkV8%rM|G!+wOx07D$pzyfq^D_w8x*53Kx?%Hd6cfD(`
 z3nqS>w9DOn?_T}>xX<T%9sFPZV@0sraU-UFob9vTrvM^~<B3DpIk;!RH_(k}ZZZ?G
@@ -2581,14 +2581,14 @@ zb9Vz0S$6R(3Mwlk<(uP|zFE1&9p;Jypy25m-peMs=@i;G#UkAzy<H3QPvlf;W_s}!
 yNoJTUbk%x+03vLpg;t=E9BZr*C&^Md2H;<$gf3O<DB$=20000<MNUMnLSTXr)4V<a
 
 literal 0
-Hc-jL100001
+HcmV?d00001
 
 diff --git a/chrome/android/java/res_vanadium/mipmap-mdpi/app_icon.png b/chrome/android/java/res_vanadium/mipmap-mdpi/app_icon.png
 new file mode 100644
 index 0000000000000000000000000000000000000000..5c340f7a0936223c14d858784e18e38443264df5
 GIT binary patch
 literal 1532
-zc-jH{1q1qtP)<h;3K|Lk000e1NJLTq001xm001xu1ONa4{R=S+00002VoOIv0RM-N
+zcmV<Y1q1qtP)<h;3K|Lk000e1NJLTq001xm001xu1ONa4{R=S+00002VoOIv0RM-N
 z%)bBt1+_^;K~z}7wU}LO6jc<*fAhK9FSj4Gl@^fFmXCf&_%0<7pdv9*FyTp!k%UB(
 zB1RJR!53qA-~}{B5jF7z2vK}6qQ*dCNDwS7U<+0QrBIr*wA609Eo^tUyEEg%%<SjP
 zwqQIrnPl#q^Z(y_&bjxVJMce?FiS17nfeA`SnWR(2#82ki_~VRNmwpc;R9nrzZ>h+
@@ -2620,14 +2620,14 @@ zm1+;i!}o^%y8HLd?$8i^0)&aWZc4NGS7FwHIpmUy2MLG~A;c6RqC~U(MwktOtz}*V
 i?5f^Os2P5PnDQ@s4<gB_=JK-u0000<MNUMnLSTa0>e?Ux
 
 literal 0
-Hc-jL100001
+HcmV?d00001
 
 diff --git a/chrome/android/java/res_vanadium/mipmap-mdpi/app_shortcut_icon.png b/chrome/android/java/res_vanadium/mipmap-mdpi/app_shortcut_icon.png
 new file mode 100644
 index 0000000000000000000000000000000000000000..8723f01f61d163b947af43af0c871695ed25ee6a
 GIT binary patch
 literal 1534
-zc-jH}1p)erP)<h;3K|Lk000e1NJLTq001xm001xu1ONa4{R=S+00002VoOIv0RM-N
+zcmV<a1p)erP)<h;3K|Lk000e1NJLTq001xm001xu1ONa4{R=S+00002VoOIv0RM-N
 z%)bBt1-D5=K~z}7wU}9KR8<(qf9Gy9okFLDLWP3Tg~gVtY*J7NNWhp7jKL)amniWC
 z2*yNt@Ie!NASNs-1PGB3aUp^)LP!)f1~h5dAp)`#DN-m@pbN~_nR|~9_uiSgGk4m8
 z@w>^)+_U`t=X~F}=X`hIe>Tz2R`zALmw<Gx|12O7Xf>mPjWmjhREbiM9cBy1<iTXq
@@ -2659,14 +2659,14 @@ zvaW21dAB2et?hKnnRBONZQP=hI7xqaUjlZ$y$ci(B7}hkq(~4WN{l4Q-u_1DkAU0C
 kebcbBdV4`xeI`u6zY8!J8&ZgeVgLXD07*qoM6N<$f-H)~aR2}S
 
 literal 0
-Hc-jL100001
+HcmV?d00001
 
 diff --git a/chrome/android/java/res_vanadium/mipmap-mdpi/app_single_page_icon.png b/chrome/android/java/res_vanadium/mipmap-mdpi/app_single_page_icon.png
 new file mode 100644
 index 0000000000000000000000000000000000000000..2ef668f35442a8681129f3db24c6fed504d61ae4
 GIT binary patch
 literal 1206
-zc-jHB1WEgeP)<h;3K|Lk000e1NJLTq001xm001xu1ONa4{R=S+00002VoOIv0RM-N
+zcmV;n1WEgeP)<h;3K|Lk000e1NJLTq001xm001xu1ONa4{R=S+00002VoOIv0RM-N
 z%)bBt1aC=1K~z}7)s|amTtyhie>3OI*-M&DlQt=(ZPKKrTErVsP(iB{eW(a(B2=qr
 zrTA8T$+I`a7HI|XLBt39V5Fo~RPaGjOG~8?YM@}129uQZlBBV1ZkyfgIcLU)J>6ta
 zb~l^Ty!g%2&VKX%4gdM(I|Kjs5aEdfZ|rz`W_2}7En2_t+WT#8S%AY&Jar`798NL_
@@ -2692,14 +2692,14 @@ z`4MAz0~f`Crd?apPTtB&j}wQ>e3|OqR`bB7hf<qU+=t8bTz_xh>7irvlg?-T2X2kH
 Ud&;davH$=807*qoM6N<$g0vVglK=n!
 
 literal 0
-Hc-jL100001
+HcmV?d00001
 
 diff --git a/chrome/android/java/res_vanadium/mipmap-xhdpi/app_icon.png b/chrome/android/java/res_vanadium/mipmap-xhdpi/app_icon.png
 new file mode 100644
 index 0000000000000000000000000000000000000000..2110d524c9c403b80301dd34709d4f6fcc430f28
 GIT binary patch
 literal 3727
-zc-jGv4sh{_P)<h;3K|Lk000e1NJLTq003YB003YJ1ONa4NRhv@00002VoOIv0RM-N
+zcmV;A4sh{_P)<h;3K|Lk000e1NJLTq003YB003YJ1ONa4NRhv@00002VoOIv0RM-N
 z%)bBt4oFEvK~#9!?VM?BT-SBSe{Y!?awu{rky<E9q83w|B}<lV$yH+4ixMM+<2Y^|
 zApX!GY10O^fueDP26ciKU4p_6)EGe>%L$UY1q@{Y?80_qYqjHgk+Nu`EZGz#$|NO{
 z5*KkB&b)c=_QShx8@`!&Z%Ety&@+(c&0FsM|Ia<=-gD2pm+=4c@rv@Hl~`P|DEj_C
@@ -2773,14 +2773,14 @@ z9k%K%AG1#Yxqn*%9UWbMYjPp9L%?(fLrhE;_#FIcjJeuX<!lB}<Wj@nvNy-CEq8V~
 tXMdbzt~W?J>%)T!-Glpw=5&Y9{{mHf#%w_K>9PO-002ovPDHLkV1nv5AYT9g
 
 literal 0
-Hc-jL100001
+HcmV?d00001
 
 diff --git a/chrome/android/java/res_vanadium/mipmap-xhdpi/app_shortcut_icon.png b/chrome/android/java/res_vanadium/mipmap-xhdpi/app_shortcut_icon.png
 new file mode 100644
 index 0000000000000000000000000000000000000000..dce04b58684dd6c7ee265ddf332facaf9d4073e9
 GIT binary patch
 literal 3664
-zc-jF_4zKZvP)<h;3K|Lk000e1NJLTq003YB003YJ1ONa4NRhv@00002VoOIv0RM-N
+zcmV-W4zKZvP)<h;3K|Lk000e1NJLTq003YB003YJ1ONa4NRhv@00002VoOIv0RM-N
 z%)bBt4hcy_K~#9!?VNd#99MnEKd-xIW@m4$q&=k7v9edPBnw@(1oDA|%@LO&#)UBz
 zl2o8b{ve@J_8-KQ9qg(EFiAy<330F?6fPXa2tpC;U?dDeaj+v|qcgT-tye2)SI25E
 z?KL|y-Tm@MzdmNRXQpR%WaSTjU8<e#cYVLV_j~XC-X-|0Tw4)WEyw(vW!~TacLW3=
@@ -2853,14 +2853,14 @@ zdH=Tr1_p-utE+?1E&<CO46(30;8pmqF{*W|%D;jUT;B07eYjnd<+buEolUFu1xf#?
 ie=zsl`$JVdRQG?1!InhXyR7v90000<MNUMnLSTaK4EbIF
 
 literal 0
-Hc-jL100001
+HcmV?d00001
 
 diff --git a/chrome/android/java/res_vanadium/mipmap-xhdpi/app_single_page_icon.png b/chrome/android/java/res_vanadium/mipmap-xhdpi/app_single_page_icon.png
 new file mode 100644
 index 0000000000000000000000000000000000000000..a0a80433631765f9bd91707fffb16cffe7160a95
 GIT binary patch
 literal 2639
-zc-jF^3b6HwP)<h;3K|Lk000e1NJLTq003YB003YJ1ONa4NRhv@00002VoOIv0RM-N
+zcmV-V3b6HwP)<h;3K|Lk000e1NJLTq003YB003YJ1ONa4NRhv@00002VoOIv0RM-N
 z%)bBt3J6I=K~#9!?VEXQ9Mu`XfA7t)-nAW{I0=q%oTN}eI76V9L^;$WC<Roh6jeRd
 zmi|+<DkZ9D)gm<kK|u)70}1u7LPbi7qN-4pMh#a{A);y$jwGgd?f8z*wb#e)%zOP~
 zXHT#9w8yT>H?n5eGyCTIz4yIuzVDki@PT|F|KB2tpYqTZH~utoBUYhv6aX^ysjx`Y
@@ -2913,14 +2913,14 @@ z>F6ur*vMv@X{p`OzN_g&bz5Xzh>x;>gX2z&4E3CO>p%Z?hMD9XgGBN*v9<sJ7Hzb$
 xfm(tDkkqtonVp;KM-pR!IcAt*l<DPu{$JS7*jWIpcGUm?002ovPDHLkV1jo9>>B_8
 
 literal 0
-Hc-jL100001
+HcmV?d00001
 
 diff --git a/chrome/android/java/res_vanadium/mipmap-xxhdpi/app_icon.png b/chrome/android/java/res_vanadium/mipmap-xxhdpi/app_icon.png
 new file mode 100644
 index 0000000000000000000000000000000000000000..f4894e5b5b5047708bad46853f06c3bd68e54aa0
 GIT binary patch
 literal 6160
-zc-jFF81LtaP)<h;3K|Lk000e1NJLTq0058x0058(1ONa4O;0K_00002VoOIv0RM-N
+zcmV+r81LtaP)<h;3K|Lk000e1NJLTq0058x0058(1ONa4O;0K_00002VoOIv0RM-N
 z%)bBt7s*LPK~#9!?VWj$9MyTif89OTUfN4qUAvM%Vzo#}kw8e`00IoMAyC-Zv11cE
 z#ARa2c9khRNmU%jE?jneRKQ1U2OQsb0CQs(64)FD34sBFBqRhvNGt6n?Xv9LGu@p(
 z`g%RnJ<~JOqr>HIYIgg4{oZfB?|b)a_>25S{vu5j=_Gi*exgUPS<jU0zmn^?14Vaj
@@ -3041,14 +3041,14 @@ ze;qSGZcNx~(z;hnFCCERG|Xu(gX37CIo5#0=as%T&i%$B5IZ^CZx(=KhUWMH@_Mq@
 iy8!i)|Hl}MBmWOUsYCM~E)RwP0000<MNUMnLSTZfrRkLb
 
 literal 0
-Hc-jL100001
+HcmV?d00001
 
 diff --git a/chrome/android/java/res_vanadium/mipmap-xxhdpi/app_shortcut_icon.png b/chrome/android/java/res_vanadium/mipmap-xxhdpi/app_shortcut_icon.png
 new file mode 100644
 index 0000000000000000000000000000000000000000..ddde3d59f00d5eb17564a8214ad9cdcffa38a299
 GIT binary patch
 literal 6046
-zc-jG;7h&j$P)<h;3K|Lk000e1NJLTq0058x0058(1ONa4O;0K_00002VoOIv0RM-N
+zcmV;P7h&j$P)<h;3K|Lk000e1NJLTq0058x0058(1ONa4O;0K_00002VoOIv0RM-N
 z%)bBt7gtF{K~#9!?VWj)TveICe{ZR!_a&VUounJGbs9nffg}(V64^#n#2FDs85vv{
 zopGC^cpM$^3>;>hGc%%&3JT~jxE|RD)G@3IgCrn<glvRBmJZ!XC+Q?zUF%!skGI`d
 z>#M3)oy6l;C!KoRefR$A`@Z|#`|iCD{v>~rKS={cIsxu)9`6}!)IBBlujJeBK{0*b
@@ -3167,14 +3167,14 @@ zV!CK#q7I3sCI;VAG`@7|0Ezd@e}SC;jYZ&J8rI(@JH^YuPBoxnca{qFhz~g^_%@~T
 Y|1QPj5%LR(VE_OC07*qoM6N<$f_t{1X8-^I
 
 literal 0
-Hc-jL100001
+HcmV?d00001
 
 diff --git a/chrome/android/java/res_vanadium/mipmap-xxhdpi/app_single_page_icon.png b/chrome/android/java/res_vanadium/mipmap-xxhdpi/app_single_page_icon.png
 new file mode 100644
 index 0000000000000000000000000000000000000000..a18ac214a3cbcd93fd5722bdc4da33de245e68bf
 GIT binary patch
 literal 3485
-zc-jG-4Px?%P)<h;3K|Lk000e1NJLTq0058x0058(1ONa4O;0K_00002VoOIv0RM-N
+zcmV;O4Px?%P)<h;3K|Lk000e1NJLTq0058x0058(1ONa4O;0K_00002VoOIv0RM-N
 z%)bBt4OU4+K~#9!?VVd}9Mv6%znxusv+LNqu^kL)LYxaC2~=@_(pC`3B`AqXD<Pyl
 zqME)IDe&5tC{k5beQ1COS`pd+53SO2DHR}62uU%}HW$Lpae&;M*h%cHowZ}H?cJT3
 zKFnojc4u~Xc4u~H?fgdZ&gIOUbH4n~WzKEjrf%w{ZtA9Ps!<iF<fgB><y|}~b=M`t
@@ -3244,14 +3244,14 @@ zgb5-t4~Wb$j|ikmGVW|ei-iG5Q8TSXi4+uUY37+F#f@U6m7V?%zd0TLfLr+m00000
 LNkvXXu0mjf=__DT
 
 literal 0
-Hc-jL100001
+HcmV?d00001
 
 diff --git a/chrome/android/java/res_vanadium/mipmap-xxxhdpi/app_icon.png b/chrome/android/java/res_vanadium/mipmap-xxxhdpi/app_icon.png
 new file mode 100644
 index 0000000000000000000000000000000000000000..1e02f37a1a940619f19cb73eb3605e14e8b0cfef
 GIT binary patch
 literal 9104
-zc-jGwBX8V^P)<h;3K|Lk000e1NJLTq006)M006)U1ONa4_|>G000002VoOIv0RM-N
+zcmV;BBX8V^P)<h;3K|Lk000e1NJLTq006)M006)U1ONa4_|>G000002VoOIv0RM-N
 z%)bBtBS}d_K~#9!?VWd&9MzrgKNY%rva)7I5-1QPB!UbAga|emY{2&6*v9dAkKb7z
 zN1ns_t?_y9t@rKPn>hB`hPAy8Zygq6!ai)+0}j{(BQi(`fk8+JWsPP=(nu3JR(O9@
 zPTf`ARXqdCZ_b3O>AH36`@O$#e>W7oA#cbV@`k)2|5Zhp?h0g7SADuG8&~A%u0UN8
@@ -3429,14 +3429,14 @@ z&TnT3ZAJm_ecYKSLdb8y_m^AzAbV#p&N$%xk2#Y?sB;t)z0T1Ll>ZM}!uj~k+35iQ
 O0000<MNUMnLSTY_yT{`I
 
 literal 0
-Hc-jL100001
+HcmV?d00001
 
 diff --git a/chrome/android/java/res_vanadium/mipmap-xxxhdpi/app_shortcut_icon.png b/chrome/android/java/res_vanadium/mipmap-xxxhdpi/app_shortcut_icon.png
 new file mode 100644
 index 0000000000000000000000000000000000000000..462b433a801f6fcea98599426cb227a3849dccd0
 GIT binary patch
 literal 8910
-zc-jHZA~D^GP)<h;3K|Lk000e1NJLTq006)M006)U1ONa4_|>G000002VoOIv0RM-N
+zcmV;<A~D^GP)<h;3K|Lk000e1NJLTq006)M006)U1ONa4_|>G000002VoOIv0RM-N
 z%)bBtB8N#tK~#9!?VWkN9aWX@zg2aHd+v~%fh0HcL=r+6LP&%Jh$12ZMOsDM0bl!h
 zDk6NaZTs1_KJAZ<s2}X6ecIAW<In;R@W~{Kq9C9UkRb^K2r(oiWWJemhcnjj{-}94
 z=Tz0HI`=}e&gTwQr)t-(-*4}=)?RypH|0%vQ{I#}<-e;4Bb|Yi@~Vw=X2VKmq%+V^
@@ -3610,14 +3610,14 @@ zXcEEoJ9rftXX!V^9j|uw-*{Iq7*#U*2=M02`B(7#=M*o<n(O?i1K#_ZqgjLoM}E;7
 c9F0Qx|B}Q+Z=dlMDF6Tf07*qoM6N<$f|_$^VgLXD
 
 literal 0
-Hc-jL100001
+HcmV?d00001
 
 diff --git a/chrome/android/java/res_vanadium/mipmap-xxxhdpi/app_single_page_icon.png b/chrome/android/java/res_vanadium/mipmap-xxxhdpi/app_single_page_icon.png
 new file mode 100644
 index 0000000000000000000000000000000000000000..ee550d2496b8ee610665e0973b6c1009bdec18bb
 GIT binary patch
 literal 6162
-zc-jFH813hYP)<h;3K|Lk000e1NJLTq006)M006)U1ONa4_|>G000002VoOIv0RM-N
+zcmV+t813hYP)<h;3K|Lk000e1NJLTq006)M006)U1ONa4_|>G000002VoOIv0RM-N
 z%)bBt7t2XRK~#9!?VWj$99MnEKd+~!XJ$|BuJ(|1uCQfn3uANmEDMNbT$DrEMTH|V
 zMJiOPph75;0*XKKN0P!fBos~+kUx?lIHnLbm>AnQK#Z_ui^CwxGD2(J(ysQ@&fatM
 z@$yIa+&$O!%+73UzFQhi_sqP0{r$f8d%ySI@4bc=T4<q#7FuYbg%(<9;ZlRBRYDJ5
@@ -3738,7 +3738,7 @@ z4=n*~D0DMGYE(<3jW9uiIZ-V(EMl0%i4%8ROr2S#S@mO;TLNUD(nALwgmP#XXsB2P
 kGn<knmRQIH8Lkfh4<#z;WpdrDCIA2c07*qoM6N<$g5lVO)Bpeg
 
 literal 0
-Hc-jL100001
+HcmV?d00001
 
 diff --git a/chrome/android/java/res_vanadium/values/channel_constants.xml b/chrome/android/java/res_vanadium/values/channel_constants.xml
 new file mode 100644
@@ -3755,5 +3755,5 @@ index 000000000000..934572cd12f2
 +    <string name="search_widget_title" translatable="false">Vanadium search</string>
 +</resources>
 -- 
-2.24.0
+2.25.0
 

--- a/0006-remove-Help-feedback-menu-entry.patch
+++ b/0006-remove-Help-feedback-menu-entry.patch
@@ -1,4 +1,4 @@
-From 26d05f951af6a2ea3790fd7289ba7ac7121bd968 Mon Sep 17 00:00:00 2001
+From 5a104113bb1415da8fe06da9cb60783dce63617c Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Sat, 6 Jul 2019 05:56:45 -0400
 Subject: [PATCH 06/49] remove Help & feedback menu entry
@@ -7,15 +7,15 @@ Subject: [PATCH 06/49] remove Help & feedback menu entry
  chrome/android/java/res/menu/main_menu.xml               | 2 --
  .../src/org/chromium/chrome/browser/ChromeActivity.java  | 9 ---------
  .../org/chromium/chrome/browser/KeyboardShortcuts.java   | 3 ---
- .../chrome/browser/customtabs/CustomTabActivity.java     | 2 +-
+ .../chrome/browser/customtabs/BaseCustomTabActivity.java | 2 +-
  .../browser/directactions/MenuDirectActionHandler.java   | 2 --
  5 files changed, 1 insertion(+), 17 deletions(-)
 
 diff --git a/chrome/android/java/res/menu/main_menu.xml b/chrome/android/java/res/menu/main_menu.xml
-index 4580a99b4e57..55f2a2f2fc38 100644
+index 8c1f91bc88ef..67d4dc8ca9fd 100644
 --- a/chrome/android/java/res/menu/main_menu.xml
 +++ b/chrome/android/java/res/menu/main_menu.xml
-@@ -76,8 +76,6 @@
+@@ -81,8 +81,6 @@
              android:icon="@drawable/reader_mode_prefs_icon" />
          <item android:id="@+id/preferences_id"
              android:title="@string/menu_preferences" />
@@ -25,10 +25,10 @@ index 4580a99b4e57..55f2a2f2fc38 100644
              android:title="@string/enter_vr" />
      </group>
 diff --git a/chrome/android/java/src/org/chromium/chrome/browser/ChromeActivity.java b/chrome/android/java/src/org/chromium/chrome/browser/ChromeActivity.java
-index 99cac3df4999..662eae9de666 100644
+index 3fdc4ba9b800..abcb25ca71be 100644
 --- a/chrome/android/java/src/org/chromium/chrome/browser/ChromeActivity.java
 +++ b/chrome/android/java/src/org/chromium/chrome/browser/ChromeActivity.java
-@@ -2177,15 +2177,6 @@ public abstract class ChromeActivity<C extends ChromeActivityComponent>
+@@ -2148,15 +2148,6 @@ public abstract class ChromeActivity<C extends ChromeActivityComponent>
  
          final Tab currentTab = getActivityTab();
  
@@ -41,11 +41,11 @@ index 99cac3df4999..662eae9de666 100644
 -            return true;
 -        }
 -
-         // All the code below assumes currentTab is not null, so return early if it is null.
-         if (currentTab == null) {
-             return false;
+         if (id == R.id.open_history_menu_id) {
+             // 'currentTab' could only be null when opening history from start surface, which is
+             // not available on tablet.
 diff --git a/chrome/android/java/src/org/chromium/chrome/browser/KeyboardShortcuts.java b/chrome/android/java/src/org/chromium/chrome/browser/KeyboardShortcuts.java
-index 054490a8ab41..5bfc451d5e58 100644
+index a8e7d3df840d..036b474be024 100644
 --- a/chrome/android/java/src/org/chromium/chrome/browser/KeyboardShortcuts.java
 +++ b/chrome/android/java/src/org/chromium/chrome/browser/KeyboardShortcuts.java
 @@ -342,9 +342,6 @@ public class KeyboardShortcuts {
@@ -58,18 +58,18 @@ index 054490a8ab41..5bfc451d5e58 100644
              }
          }
  
-diff --git a/chrome/android/java/src/org/chromium/chrome/browser/customtabs/CustomTabActivity.java b/chrome/android/java/src/org/chromium/chrome/browser/customtabs/CustomTabActivity.java
-index 2dd2bba2f1ac..a0856be51f70 100644
---- a/chrome/android/java/src/org/chromium/chrome/browser/customtabs/CustomTabActivity.java
-+++ b/chrome/android/java/src/org/chromium/chrome/browser/customtabs/CustomTabActivity.java
-@@ -441,7 +441,7 @@ public class CustomTabActivity extends ChromeActivity<CustomTabActivityComponent
+diff --git a/chrome/android/java/src/org/chromium/chrome/browser/customtabs/BaseCustomTabActivity.java b/chrome/android/java/src/org/chromium/chrome/browser/customtabs/BaseCustomTabActivity.java
+index 840a0bf35829..09cedda544e8 100644
+--- a/chrome/android/java/src/org/chromium/chrome/browser/customtabs/BaseCustomTabActivity.java
++++ b/chrome/android/java/src/org/chromium/chrome/browser/customtabs/BaseCustomTabActivity.java
+@@ -125,7 +125,7 @@ public abstract class BaseCustomTabActivity<C extends ChromeActivityComponent>
+     @Override
      public boolean onMenuOrKeyboardAction(int id, boolean fromMenu) {
          // Disable creating new tabs, bookmark, history, print, help, focus_url, etc.
-         if (id == R.id.focus_url_bar || id == R.id.all_bookmarks_menu_id
--                || id == R.id.help_id || id == R.id.recent_tabs_menu_id
-+                || id == R.id.recent_tabs_menu_id
-                 || id == R.id.new_incognito_tab_menu_id || id == R.id.new_tab_menu_id
-                 || id == R.id.open_history_menu_id) {
+-        if (id == R.id.focus_url_bar || id == R.id.all_bookmarks_menu_id || id == R.id.help_id
++        if (id == R.id.focus_url_bar || id == R.id.all_bookmarks_menu_id
+                 || id == R.id.recent_tabs_menu_id || id == R.id.new_incognito_tab_menu_id
+                 || id == R.id.new_tab_menu_id || id == R.id.open_history_menu_id) {
              return true;
 diff --git a/chrome/android/java/src/org/chromium/chrome/browser/directactions/MenuDirectActionHandler.java b/chrome/android/java/src/org/chromium/chrome/browser/directactions/MenuDirectActionHandler.java
 index 77387b08a5d9..46cd9af4429a 100644
@@ -92,5 +92,5 @@ index 77387b08a5d9..46cd9af4429a 100644
          availableItemIds.add(R.id.preferences_id);
  
 -- 
-2.24.0
+2.25.0
 

--- a/0007-hide-passwords.google.com-link-when-not-supported.patch
+++ b/0007-hide-passwords.google.com-link-when-not-supported.patch
@@ -1,25 +1,25 @@
-From 20a7821694aeddb67d86039c96f26f9cd9d1de98 Mon Sep 17 00:00:00 2001
+From ffd3565367c1821122fc6d3b8d19f1d7289ccc08 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Sun, 13 Aug 2017 19:33:04 -0400
 Subject: [PATCH 07/49] hide passwords.google.com link when not supported
 
 ---
- .../preferences/password/SavePasswordsPreferences.java        | 4 ++++
+ .../browser/settings/password/SavePasswordsPreferences.java   | 4 ++++
  1 file changed, 4 insertions(+)
 
-diff --git a/chrome/android/java/src/org/chromium/chrome/browser/preferences/password/SavePasswordsPreferences.java b/chrome/android/java/src/org/chromium/chrome/browser/preferences/password/SavePasswordsPreferences.java
-index 2b0d5f935624..067e629a8823 100644
---- a/chrome/android/java/src/org/chromium/chrome/browser/preferences/password/SavePasswordsPreferences.java
-+++ b/chrome/android/java/src/org/chromium/chrome/browser/preferences/password/SavePasswordsPreferences.java
-@@ -35,6 +35,7 @@ import org.chromium.chrome.browser.preferences.PreferencesLauncher;
- import org.chromium.chrome.browser.preferences.SearchUtils;
- import org.chromium.chrome.browser.preferences.TextMessagePreference;
+diff --git a/chrome/android/java/src/org/chromium/chrome/browser/settings/password/SavePasswordsPreferences.java b/chrome/android/java/src/org/chromium/chrome/browser/settings/password/SavePasswordsPreferences.java
+index a33fee3890c8..17bf177e96ea 100644
+--- a/chrome/android/java/src/org/chromium/chrome/browser/settings/password/SavePasswordsPreferences.java
++++ b/chrome/android/java/src/org/chromium/chrome/browser/settings/password/SavePasswordsPreferences.java
+@@ -32,6 +32,7 @@ import org.chromium.chrome.browser.password_manager.PasswordManagerLauncher;
+ import org.chromium.chrome.browser.preferences.Pref;
+ import org.chromium.chrome.browser.preferences.PrefServiceBridge;
  import org.chromium.chrome.browser.profiles.Profile;
 +import org.chromium.chrome.browser.signin.IdentityServicesProvider;
- import org.chromium.ui.text.SpanApplier;
- 
- import java.util.Locale;
-@@ -442,6 +443,9 @@ public class SavePasswordsPreferences
+ import org.chromium.chrome.browser.settings.ChromeBaseCheckBoxPreference;
+ import org.chromium.chrome.browser.settings.ChromeBasePreference;
+ import org.chromium.chrome.browser.settings.ChromeSwitchPreference;
+@@ -449,6 +450,9 @@ public class SavePasswordsPreferences
          if (mSearchQuery != null && !mNoPasswords) {
              return; // Don't add the Manage Account link if there is a search going on.
          }
@@ -30,5 +30,5 @@ index 2b0d5f935624..067e629a8823 100644
              return; // Don't add the Manage Account link if it's present.
          }
 -- 
-2.24.0
+2.25.0
 

--- a/0008-disable-first-run-welcome-page.patch
+++ b/0008-disable-first-run-welcome-page.patch
@@ -1,4 +1,4 @@
-From 2756817b4a435bf6bf3296e726db457de36f3fea Mon Sep 17 00:00:00 2001
+From 6c2cc3235da2a5981ce413b7ce277fd257dd95fa Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Thu, 24 Nov 2016 08:19:03 -0500
 Subject: [PATCH 08/49] disable first run welcome page
@@ -8,7 +8,7 @@ Subject: [PATCH 08/49] disable first run welcome page
  1 file changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/chrome/android/java/src/org/chromium/chrome/browser/firstrun/FirstRunActivity.java b/chrome/android/java/src/org/chromium/chrome/browser/firstrun/FirstRunActivity.java
-index 15859475b338..52c39d39eb80 100644
+index 7d3e6d41afa0..e33a93c4f17a 100644
 --- a/chrome/android/java/src/org/chromium/chrome/browser/firstrun/FirstRunActivity.java
 +++ b/chrome/android/java/src/org/chromium/chrome/browser/firstrun/FirstRunActivity.java
 @@ -85,7 +85,7 @@ public class FirstRunActivity extends FirstRunActivityBase implements FirstRunPa
@@ -30,5 +30,5 @@ index 15859475b338..52c39d39eb80 100644
                      mResultSignInAccountName = mFreProperties.getString(
                              SigninFirstRunFragment.FORCE_SIGNIN_ACCOUNT_TO);
 -- 
-2.24.0
+2.25.0
 

--- a/0009-disable-seed-based-field-trials.patch
+++ b/0009-disable-seed-based-field-trials.patch
@@ -1,4 +1,4 @@
-From e61a91cd88401d47b486c27fb0da92e3633715be Mon Sep 17 00:00:00 2001
+From a0e56f4d89236bf2b97cfb6ee2fd157b96d86299 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Tue, 25 Dec 2018 16:19:51 -0500
 Subject: [PATCH 09/49] disable seed-based field trials
@@ -8,10 +8,10 @@ Subject: [PATCH 09/49] disable seed-based field trials
  1 file changed, 2 insertions(+)
 
 diff --git a/components/variations/service/variations_field_trial_creator.cc b/components/variations/service/variations_field_trial_creator.cc
-index a60947261042..f27798df9430 100644
+index e9bb5a78a51c..3cb9a5a50e31 100644
 --- a/components/variations/service/variations_field_trial_creator.cc
 +++ b/components/variations/service/variations_field_trial_creator.cc
-@@ -538,8 +538,10 @@ bool VariationsFieldTrialCreator::SetupFieldTrials(
+@@ -545,8 +545,10 @@ bool VariationsFieldTrialCreator::SetupFieldTrials(
  #endif  // BUILDFLAG(FIELDTRIAL_TESTING_ENABLED)
    bool used_seed = false;
    if (!used_testing_config) {
@@ -23,5 +23,5 @@ index a60947261042..f27798df9430 100644
  
    platform_field_trials->SetupFeatureControllingFieldTrials(used_seed,
 -- 
-2.24.0
+2.25.0
 

--- a/0010-disable-navigation-error-correction-by-default.patch
+++ b/0010-disable-navigation-error-correction-by-default.patch
@@ -1,4 +1,4 @@
-From 33984afa23cfb16cba85cfdd4d2059a46e23878b Mon Sep 17 00:00:00 2001
+From 61c17a63666f8b06ee0277d255f823797f077a4b Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Wed, 23 Nov 2016 08:29:58 -0500
 Subject: [PATCH 10/49] disable navigation error correction by default
@@ -8,10 +8,10 @@ Subject: [PATCH 10/49] disable navigation error correction by default
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/chrome/browser/ui/navigation_correction_tab_observer.cc b/chrome/browser/ui/navigation_correction_tab_observer.cc
-index 945d1b524702..3b7306826654 100644
+index 1b0287989406..f2aa068efdc3 100644
 --- a/chrome/browser/ui/navigation_correction_tab_observer.cc
 +++ b/chrome/browser/ui/navigation_correction_tab_observer.cc
-@@ -43,7 +43,7 @@ NavigationCorrectionTabObserver::~NavigationCorrectionTabObserver() {}
+@@ -57,7 +57,7 @@ void NavigationCorrectionTabObserver::SetAllowEnableCorrectionsForTesting(
  // static
  void NavigationCorrectionTabObserver::RegisterProfilePrefs(
      user_prefs::PrefRegistrySyncable* prefs) {
@@ -21,5 +21,5 @@ index 945d1b524702..3b7306826654 100644
  }
  
 -- 
-2.24.0
+2.25.0
 

--- a/0011-disable-contextual-search-by-default.patch
+++ b/0011-disable-contextual-search-by-default.patch
@@ -1,4 +1,4 @@
-From 231ea7b3b9dd2e18ca03fffcb8e31501451cbf81 Mon Sep 17 00:00:00 2001
+From 3076e51a1987087e6df847514cc3f6545ab13b23 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Wed, 23 Nov 2016 09:26:51 -0500
 Subject: [PATCH 11/49] disable contextual search by default
@@ -8,7 +8,7 @@ Subject: [PATCH 11/49] disable contextual search by default
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/chrome/browser/profiles/profile.cc b/chrome/browser/profiles/profile.cc
-index 9e0d25bc3367..20b9a2ee758a 100644
+index 2b1140fdd27e..85020f22f7fa 100644
 --- a/chrome/browser/profiles/profile.cc
 +++ b/chrome/browser/profiles/profile.cc
 @@ -154,7 +154,7 @@ void Profile::RegisterProfilePrefs(user_prefs::PrefRegistrySyncable* registry) {
@@ -21,5 +21,5 @@ index 9e0d25bc3367..20b9a2ee758a 100644
  #endif  // defined(OS_ANDROID)
    registry->RegisterBooleanPref(prefs::kSessionExitedCleanly, true);
 -- 
-2.24.0
+2.25.0
 

--- a/0012-disable-network-prediction-by-default.patch
+++ b/0012-disable-network-prediction-by-default.patch
@@ -1,4 +1,4 @@
-From 424c6e83307180d38552de983c1bd5bf479e37dd Mon Sep 17 00:00:00 2001
+From dc0315e719a2ee0a7054679e510cb649027edf78 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Wed, 23 Nov 2016 08:31:44 -0500
 Subject: [PATCH 12/49] disable network prediction by default
@@ -21,5 +21,5 @@ index 2ae6a1093090..7fc83de1aa0f 100644
  
  enum class NetworkPredictionStatus {
 -- 
-2.24.0
+2.25.0
 

--- a/0013-disable-metrics-by-default.patch
+++ b/0013-disable-metrics-by-default.patch
@@ -1,4 +1,4 @@
-From 854d6dcbe2e2932f76c3daf3ec20e766408a2bbe Mon Sep 17 00:00:00 2001
+From 7ad1b9874f6bb68829addb0385eac011bc6d941f Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Thu, 24 Nov 2016 11:41:00 -0500
 Subject: [PATCH 13/49] disable metrics by default
@@ -21,5 +21,5 @@ index 9c69e1071c79..70ef53e01211 100644
      private boolean mNativeInitialized;
  
 -- 
-2.24.0
+2.25.0
 

--- a/0014-disable-hyperlink-auditing-by-default.patch
+++ b/0014-disable-hyperlink-auditing-by-default.patch
@@ -1,4 +1,4 @@
-From 5aa0ab5fdeac50cd895a3f4b533bb4022890e9a1 Mon Sep 17 00:00:00 2001
+From ecca612f6ce44537fce07e76d2d3f4744d6a0bda Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Sat, 26 Nov 2016 14:57:22 -0500
 Subject: [PATCH 14/49] disable hyperlink auditing by default
@@ -8,10 +8,10 @@ Subject: [PATCH 14/49] disable hyperlink auditing by default
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/chrome/browser/chrome_content_browser_client.cc b/chrome/browser/chrome_content_browser_client.cc
-index 04a864ebd3e3..7efd2f0e59b7 100644
+index 5cdfec3a834b..d356e4f381ea 100644
 --- a/chrome/browser/chrome_content_browser_client.cc
 +++ b/chrome/browser/chrome_content_browser_client.cc
-@@ -1141,7 +1141,7 @@ void ChromeContentBrowserClient::RegisterLocalStatePrefs(
+@@ -1170,7 +1170,7 @@ void ChromeContentBrowserClient::RegisterLocalStatePrefs(
  void ChromeContentBrowserClient::RegisterProfilePrefs(
      user_prefs::PrefRegistrySyncable* registry) {
    registry->RegisterBooleanPref(prefs::kDisable3DAPIs, false);
@@ -21,5 +21,5 @@ index 04a864ebd3e3..7efd2f0e59b7 100644
    // Register user prefs for mapping SitePerProcess and IsolateOrigins in
    // user policy in addition to the same named ones in Local State (which are
 -- 
-2.24.0
+2.25.0
 

--- a/0015-disable-showing-popular-sites-by-default.patch
+++ b/0015-disable-showing-popular-sites-by-default.patch
@@ -1,4 +1,4 @@
-From aca9ecd9d033f601e7761c3a4a7a5b86a23f5b02 Mon Sep 17 00:00:00 2001
+From adfe7976a64df3ab8e805dcd126171c1d978d4b8 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Tue, 6 Mar 2018 00:27:41 -0500
 Subject: [PATCH 15/49] disable showing popular sites by default
@@ -28,5 +28,5 @@ index 6096def69b70..97ca547cdbb0 100644
  const base::FeatureState kDisplaySuggestionsServiceTilesDefaultState =
  #if defined(OS_ANDROID) || defined(OS_IOS)
 -- 
-2.24.0
+2.25.0
 

--- a/0016-disable-article-suggestions-feature-by-default.patch
+++ b/0016-disable-article-suggestions-feature-by-default.patch
@@ -1,4 +1,4 @@
-From 0162273ba5439ad83757769920d5707c5375283d Mon Sep 17 00:00:00 2001
+From 45c566fff96d80afb619602e1643f188094b07d1 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Thu, 8 Mar 2018 22:43:12 -0500
 Subject: [PATCH 16/49] disable article suggestions feature by default
@@ -9,7 +9,7 @@ Subject: [PATCH 16/49] disable article suggestions feature by default
  2 files changed, 3 insertions(+), 3 deletions(-)
 
 diff --git a/components/ntp_snippets/features.cc b/components/ntp_snippets/features.cc
-index 72fca90c4258..914192e00d5e 100644
+index 226d09dcb96a..50234b43c032 100644
 --- a/components/ntp_snippets/features.cc
 +++ b/components/ntp_snippets/features.cc
 @@ -39,7 +39,7 @@ const base::Feature* const kAllFeatures[] = {
@@ -37,5 +37,5 @@ index 6d2c34d2a74c..f002d0c0336d 100644
  
  void RemoteSuggestionsStatusServiceImpl::Init(
 -- 
-2.24.0
+2.25.0
 

--- a/0017-disable-prefetching-suggested-pages-by-default.patch
+++ b/0017-disable-prefetching-suggested-pages-by-default.patch
@@ -1,4 +1,4 @@
-From 46f0437e78421540acbd0e64df91bccd5c4cf4a1 Mon Sep 17 00:00:00 2001
+From 003c72b7da8b3e786c997b5eef9a400f79525f1e Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Fri, 12 Jul 2019 04:10:21 -0400
 Subject: [PATCH 17/49] disable prefetching suggested pages by default
@@ -21,5 +21,5 @@ index a21206a255ba..a2f1e95ad01a 100644
  const base::Feature kOfflinePagesCTV2Feature{"OfflinePagesCTV2",
                                               base::FEATURE_DISABLED_BY_DEFAULT};
 -- 
-2.24.0
+2.25.0
 

--- a/0018-disable-sensors-access-by-default.patch
+++ b/0018-disable-sensors-access-by-default.patch
@@ -1,4 +1,4 @@
-From 543a23f030b685827e10adfa4fb5ef56a63b586f Mon Sep 17 00:00:00 2001
+From 8ca0eecfce268c3da739f16e145cd9ae053dd8be Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Sun, 16 Jun 2019 15:57:29 -0400
 Subject: [PATCH 18/49] disable sensors access by default
@@ -8,18 +8,18 @@ Subject: [PATCH 18/49] disable sensors access by default
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/components/content_settings/core/browser/content_settings_registry.cc b/components/content_settings/core/browser/content_settings_registry.cc
-index 6c4ff4b6bfb8..586313e625c2 100644
+index 63282bda6285..922b681985b4 100644
 --- a/components/content_settings/core/browser/content_settings_registry.cc
 +++ b/components/content_settings/core/browser/content_settings_registry.cc
-@@ -413,7 +413,7 @@ void ContentSettingsRegistry::Init() {
+@@ -412,7 +412,7 @@ void ContentSettingsRegistry::Init() {
    // TODO(crbug.com/904439): Update this to "SECURE_ONLY" once
    // DeviceOrientationEvents and DeviceMotionEvents are only fired in secure
    // contexts.
--  Register(CONTENT_SETTINGS_TYPE_SENSORS, "sensors", CONTENT_SETTING_ALLOW,
-+  Register(CONTENT_SETTINGS_TYPE_SENSORS, "sensors", CONTENT_SETTING_BLOCK,
+-  Register(ContentSettingsType::SENSORS, "sensors", CONTENT_SETTING_ALLOW,
++  Register(ContentSettingsType::SENSORS, "sensors", CONTENT_SETTING_BLOCK,
             WebsiteSettingsInfo::UNSYNCABLE, WhitelistedSchemes(),
             ValidSettings(CONTENT_SETTING_ALLOW, CONTENT_SETTING_BLOCK),
             WebsiteSettingsInfo::SINGLE_ORIGIN_ONLY_SCOPE,
 -- 
-2.24.0
+2.25.0
 

--- a/0019-disable-third-party-cookies-by-default.patch
+++ b/0019-disable-third-party-cookies-by-default.patch
@@ -1,4 +1,4 @@
-From 9032e32f8d59285c5079dc24d9bbc697e699947a Mon Sep 17 00:00:00 2001
+From d5e9ec6505af0fa3bb8b5e6f4f0f169fedac22ec Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Sun, 16 Jun 2019 16:01:31 -0400
 Subject: [PATCH 19/49] disable third party cookies by default
@@ -8,7 +8,7 @@ Subject: [PATCH 19/49] disable third party cookies by default
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/components/content_settings/core/browser/cookie_settings.cc b/components/content_settings/core/browser/cookie_settings.cc
-index a8119bc317f5..3ff57d47744d 100644
+index 84d150c6bb34..63ff054a3070 100644
 --- a/components/content_settings/core/browser/cookie_settings.cc
 +++ b/components/content_settings/core/browser/cookie_settings.cc
 @@ -58,7 +58,7 @@ void CookieSettings::GetCookieSettings(
@@ -21,5 +21,5 @@ index a8119bc317f5..3ff57d47744d 100644
    registry->RegisterIntegerPref(
        prefs::kCookieControlsMode,
 -- 
-2.24.0
+2.25.0
 

--- a/0020-disable-background-sync-by-default.patch
+++ b/0020-disable-background-sync-by-default.patch
@@ -1,4 +1,4 @@
-From d5e177ea5bd14e0dcfd4df3c5b03ec1f7e61c150 Mon Sep 17 00:00:00 2001
+From f3afe3936d7328f0261fb9d9be6d63ac22d8cc93 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Sun, 16 Jun 2019 21:57:26 -0400
 Subject: [PATCH 20/49] disable background sync by default
@@ -8,18 +8,18 @@ Subject: [PATCH 20/49] disable background sync by default
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/components/content_settings/core/browser/content_settings_registry.cc b/components/content_settings/core/browser/content_settings_registry.cc
-index 586313e625c2..d64b1df4f6da 100644
+index 922b681985b4..24f2bb66a927 100644
 --- a/components/content_settings/core/browser/content_settings_registry.cc
 +++ b/components/content_settings/core/browser/content_settings_registry.cc
-@@ -309,7 +309,7 @@ void ContentSettingsRegistry::Init() {
+@@ -308,7 +308,7 @@ void ContentSettingsRegistry::Init() {
             ContentSettingsInfo::EXCEPTIONS_ON_SECURE_ORIGINS_ONLY);
  
-   Register(CONTENT_SETTINGS_TYPE_BACKGROUND_SYNC, "background-sync",
+   Register(ContentSettingsType::BACKGROUND_SYNC, "background-sync",
 -           CONTENT_SETTING_ALLOW, WebsiteSettingsInfo::UNSYNCABLE,
 +           CONTENT_SETTING_BLOCK, WebsiteSettingsInfo::UNSYNCABLE,
             WhitelistedSchemes(),
             ValidSettings(CONTENT_SETTING_ALLOW, CONTENT_SETTING_BLOCK),
             WebsiteSettingsInfo::SINGLE_ORIGIN_ONLY_SCOPE,
 -- 
-2.24.0
+2.25.0
 

--- a/0021-disable-payment-support-by-default.patch
+++ b/0021-disable-payment-support-by-default.patch
@@ -1,4 +1,4 @@
-From d02dd881fbdc7ab971b1a5af9d9579e3a7a1259d Mon Sep 17 00:00:00 2001
+From 92b204cbb3987badf5582e7a232e8390728f3508 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Tue, 18 Jun 2019 22:28:53 -0400
 Subject: [PATCH 21/49] disable payment support by default
@@ -21,5 +21,5 @@ index 9590d9494ed1..787ff68af12a 100644
  }
  
 -- 
-2.24.0
+2.25.0
 

--- a/0022-disable-media-router-media-remoting-by-default.patch
+++ b/0022-disable-media-router-media-remoting-by-default.patch
@@ -1,4 +1,4 @@
-From bb3bac23aebc60637e6f140bfbcfd53197dc00d3 Mon Sep 17 00:00:00 2001
+From 194f75c8e6bf10c845f84e62a6116cb212fe949c Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Thu, 4 Jul 2019 18:11:27 -0400
 Subject: [PATCH 22/49] disable media router media remoting by default
@@ -8,7 +8,7 @@ Subject: [PATCH 22/49] disable media router media remoting by default
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/chrome/browser/profiles/profile.cc b/chrome/browser/profiles/profile.cc
-index 20b9a2ee758a..532b7de3bb15 100644
+index 85020f22f7fa..fc01e015d02e 100644
 --- a/chrome/browser/profiles/profile.cc
 +++ b/chrome/browser/profiles/profile.cc
 @@ -232,7 +232,7 @@ void Profile::RegisterProfilePrefs(user_prefs::PrefRegistrySyncable* registry) {
@@ -21,5 +21,5 @@ index 20b9a2ee758a..532b7de3bb15 100644
  
    registry->RegisterDictionaryPref(prefs::kWebShareVisitedTargets);
 -- 
-2.24.0
+2.25.0
 

--- a/0023-disable-media-router-by-default.patch
+++ b/0023-disable-media-router-by-default.patch
@@ -1,4 +1,4 @@
-From 7899296117ff98293ff89c9c29f617600d4818ed Mon Sep 17 00:00:00 2001
+From f1577b18bd7f58b4cbd0064893a16d913d91c345 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Thu, 4 Jul 2019 19:08:52 -0400
 Subject: [PATCH 23/49] disable media router by default
@@ -9,10 +9,10 @@ Subject: [PATCH 23/49] disable media router by default
  2 files changed, 10 insertions(+), 11 deletions(-)
 
 diff --git a/chrome/browser/media/router/media_router_feature.cc b/chrome/browser/media/router/media_router_feature.cc
-index 13f8c0149911..c0fc552533a7 100644
+index 2d478addf60e..415d415e1110 100644
 --- a/chrome/browser/media/router/media_router_feature.cc
 +++ b/chrome/browser/media/router/media_router_feature.cc
-@@ -51,23 +51,22 @@ const PrefService::Preference* GetMediaRouterPref(
+@@ -45,23 +45,22 @@ const PrefService::Preference* GetMediaRouterPref(
      content::BrowserContext* context) {
    return user_prefs::UserPrefs::Get(context)->FindPreference(
        ::prefs::kEnableMediaRouter);
@@ -46,10 +46,10 @@ index 13f8c0149911..c0fc552533a7 100644
    return false;
  #endif  // defined(OS_ANDROID) || BUILDFLAG(ENABLE_EXTENSIONS)
 diff --git a/chrome/browser/profiles/profile_impl.cc b/chrome/browser/profiles/profile_impl.cc
-index 0343e41494ae..ad1875bcafe8 100644
+index 4dd1e8f42ea7..b80f0adef318 100644
 --- a/chrome/browser/profiles/profile_impl.cc
 +++ b/chrome/browser/profiles/profile_impl.cc
-@@ -423,7 +423,7 @@ void ProfileImpl::RegisterProfilePrefs(
+@@ -402,7 +402,7 @@ void ProfileImpl::RegisterProfilePrefs(
    registry->RegisterStringPref(
        prefs::kPrintPreviewDefaultDestinationSelectionRules, std::string());
    registry->RegisterBooleanPref(prefs::kForceEphemeralProfiles, false);
@@ -59,5 +59,5 @@ index 0343e41494ae..ad1875bcafe8 100644
    registry->RegisterBooleanPref(
        prefs::kOobeMarketingOptInScreenFinished, false,
 -- 
-2.24.0
+2.25.0
 

--- a/0024-disable-offering-translations-by-default.patch
+++ b/0024-disable-offering-translations-by-default.patch
@@ -1,4 +1,4 @@
-From e87176513794215471baa010d9c0327467472522 Mon Sep 17 00:00:00 2001
+From 309fa91a1b6941c78183e87d4d726c03b1b876ee Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Fri, 12 Jul 2019 03:58:01 -0400
 Subject: [PATCH 24/49] disable offering translations by default
@@ -21,5 +21,5 @@ index fa9ec80a9755..c97c1327ab58 100644
    registry->RegisterStringPref(prefs::kCloudPrintEmail, std::string());
    registry->RegisterBooleanPref(prefs::kCloudPrintProxyEnabled, true);
 -- 
-2.24.0
+2.25.0
 

--- a/0025-disable-browser-sign-in-feature-by-default.patch
+++ b/0025-disable-browser-sign-in-feature-by-default.patch
@@ -1,4 +1,4 @@
-From 8a0deaf85b3f980e687bd288ac7e3692ae3ff02c Mon Sep 17 00:00:00 2001
+From 1e149be2c71c6fc2d7c4437e50b27bfefb8f340d Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Fri, 12 Jul 2019 04:23:18 -0400
 Subject: [PATCH 25/49] disable browser sign in feature by default
@@ -8,7 +8,7 @@ Subject: [PATCH 25/49] disable browser sign in feature by default
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/components/signin/internal/identity_manager/primary_account_manager.cc b/components/signin/internal/identity_manager/primary_account_manager.cc
-index b96c00185420..d6f698daf7bc 100644
+index aebcdb1d75a1..96bf00085f9c 100644
 --- a/components/signin/internal/identity_manager/primary_account_manager.cc
 +++ b/components/signin/internal/identity_manager/primary_account_manager.cc
 @@ -56,7 +56,7 @@ void PrimaryAccountManager::RegisterProfilePrefs(PrefRegistrySimple* registry) {
@@ -21,5 +21,5 @@ index b96c00185420..d6f698daf7bc 100644
  }
  
 -- 
-2.24.0
+2.25.0
 

--- a/0026-disable-safe-browsing-reporting-opt-in-by-default.patch
+++ b/0026-disable-safe-browsing-reporting-opt-in-by-default.patch
@@ -1,4 +1,4 @@
-From 86df42381f06426dc97a5bfa7496e64f40509e91 Mon Sep 17 00:00:00 2001
+From 52adf70017428618fb4fa10d34fe449b1a563d6d Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Fri, 12 Jul 2019 05:22:11 -0400
 Subject: [PATCH 26/49] disable safe browsing reporting opt-in by default
@@ -8,7 +8,7 @@ Subject: [PATCH 26/49] disable safe browsing reporting opt-in by default
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/components/safe_browsing/common/safe_browsing_prefs.cc b/components/safe_browsing/common/safe_browsing_prefs.cc
-index 0b26d228a4dc..99a21e06e628 100644
+index 6e5781005cf7..b7a7797a037d 100644
 --- a/components/safe_browsing/common/safe_browsing_prefs.cc
 +++ b/components/safe_browsing/common/safe_browsing_prefs.cc
 @@ -169,7 +169,7 @@ void RegisterProfilePrefs(PrefRegistrySimple* registry) {
@@ -21,5 +21,5 @@ index 0b26d228a4dc..99a21e06e628 100644
        prefs::kSafeBrowsingEnabled, true,
        user_prefs::PrefRegistrySyncable::SYNCABLE_PREF);
 -- 
-2.24.0
+2.25.0
 

--- a/0027-enable-dubious-Do-Not-Track-feature-by-default.patch
+++ b/0027-enable-dubious-Do-Not-Track-feature-by-default.patch
@@ -1,4 +1,4 @@
-From a80139a4e50f6539c35600e1bf6adf19bfb4c044 Mon Sep 17 00:00:00 2001
+From 086179a182ae64054475857e637f9f1eb272e248 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Tue, 1 Aug 2017 11:16:11 -0400
 Subject: [PATCH 27/49] enable dubious Do Not Track feature by default
@@ -21,5 +21,5 @@ index c97c1327ab58..6b499cdb35df 100644
  #if !defined(OS_CHROMEOS) && !defined(OS_ANDROID)
    registry->RegisterBooleanPref(prefs::kPrintPreviewUseSystemDefaultPrinter,
 -- 
-2.24.0
+2.25.0
 

--- a/0028-mark-non-secure-origins-as-non-secure-by-default.patch
+++ b/0028-mark-non-secure-origins-as-non-secure-by-default.patch
@@ -1,4 +1,4 @@
-From daf8ce9d5d11760481ddc79be612ea9cf0f7ab7b Mon Sep 17 00:00:00 2001
+From 8092d81dd069823b4762188fe1995df93b982294 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Fri, 20 Oct 2017 21:20:50 -0400
 Subject: [PATCH 28/49] mark non-secure origins as non-secure by default
@@ -8,10 +8,10 @@ Subject: [PATCH 28/49] mark non-secure origins as non-secure by default
  1 file changed, 3 insertions(+), 5 deletions(-)
 
 diff --git a/components/security_state/core/security_state.cc b/components/security_state/core/security_state.cc
-index 9eec5f2b09d6..c62d6073bcc5 100644
+index f674cc925dfb..09a1127597b2 100644
 --- a/components/security_state/core/security_state.cc
 +++ b/components/security_state/core/security_state.cc
-@@ -41,17 +41,15 @@ SecurityLevel GetSecurityLevelForNonSecureFieldTrial(
+@@ -43,17 +43,15 @@ SecurityLevel GetSecurityLevelForNonSecureFieldTrial(
          features::kMarkHttpAsFeature,
          features::kMarkHttpAsFeatureParameterName);
  
@@ -31,7 +31,7 @@ index 9eec5f2b09d6..c62d6073bcc5 100644
 +  return DANGEROUS;
  }
  
- std::string GetHistogramSuffixForSecurityLevel(
+ SecurityLevel GetSecurityLevelForDisplayedMixedContent(bool suppress_warning) {
 -- 
-2.24.0
+2.25.0
 

--- a/0029-enable-strict-site-isolation-by-default-on-Android.patch
+++ b/0029-enable-strict-site-isolation-by-default-on-Android.patch
@@ -1,4 +1,4 @@
-From 73ea85a2d6c2c8e4075fb54bf0fe9094b5d1447d Mon Sep 17 00:00:00 2001
+From 2ff1773a1ecc89c413fcf584b818ccd6fdaf7dae Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Thu, 2 May 2019 07:15:32 -0400
 Subject: [PATCH 29/49] enable strict site isolation by default on Android
@@ -9,10 +9,10 @@ Subject: [PATCH 29/49] enable strict site isolation by default on Android
  2 files changed, 1 insertion(+), 25 deletions(-)
 
 diff --git a/chrome/browser/about_flags.cc b/chrome/browser/about_flags.cc
-index 656fd33db3f6..f26f104ddf56 100644
+index 68b7b19de59a..d57d127f1a37 100644
 --- a/chrome/browser/about_flags.cc
 +++ b/chrome/browser/about_flags.cc
-@@ -2063,25 +2063,6 @@ const FeatureEntry kFeatureEntries[] = {
+@@ -2124,25 +2124,6 @@ const FeatureEntry kFeatureEntries[] = {
       flag_descriptions::kHTTPAuthCommittedInterstitialsName,
       flag_descriptions::kHTTPAuthCommittedInterstitialsDescription, kOsAll,
       FEATURE_VALUE_TYPE(features::kHTTPAuthCommittedInterstitials)},
@@ -39,10 +39,10 @@ index 656fd33db3f6..f26f104ddf56 100644
       flag_descriptions::kIsolateOriginsDescription, kOsAll,
       ORIGIN_LIST_VALUE_TYPE(switches::kIsolateOrigins, "")},
 diff --git a/chrome/common/chrome_features.cc b/chrome/common/chrome_features.cc
-index 4b8205a3b367..cea537417d3a 100644
+index 92da6a9b69af..41915d080bec 100644
 --- a/chrome/common/chrome_features.cc
 +++ b/chrome/common/chrome_features.cc
-@@ -650,12 +650,7 @@ const base::Feature kShowTrustedPublisherURL{"ShowTrustedPublisherURL",
+@@ -658,12 +658,7 @@ const base::Feature kShowTrustedPublisherURL{"ShowTrustedPublisherURL",
  // TODO(alexmos): Move this and the other site isolation features below to
  // browser_features, as they are only used on the browser side.
  const base::Feature kSitePerProcess {
@@ -57,5 +57,5 @@ index 4b8205a3b367..cea537417d3a 100644
  
  // Controls a mode for dynamically process-isolating sites where the user has
 -- 
-2.24.0
+2.25.0
 

--- a/0030-disable-search-engine-permissions-by-default.patch
+++ b/0030-disable-search-engine-permissions-by-default.patch
@@ -1,4 +1,4 @@
-From 0d4834e131b19b5cc78e386495f6bfbc9ee2d6f8 Mon Sep 17 00:00:00 2001
+From 55c868fac7f6da61b05cfd17821c13f43d1a20c1 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Tue, 1 Aug 2017 20:29:56 -0400
 Subject: [PATCH 30/49] disable search engine permissions by default
@@ -10,7 +10,7 @@ search engine by default.
  1 file changed, 6 insertions(+), 14 deletions(-)
 
 diff --git a/chrome/browser/android/search_permissions/search_permissions_service.cc b/chrome/browser/android/search_permissions/search_permissions_service.cc
-index f55019c639f2..69c98e105903 100644
+index 918e5963b62e..e31afcf7939b 100644
 --- a/chrome/browser/android/search_permissions/search_permissions_service.cc
 +++ b/chrome/browser/android/search_permissions/search_permissions_service.cc
 @@ -190,7 +190,7 @@ void SearchPermissionsService::ResetDSEPermission(ContentSettingsType type) {
@@ -49,7 +49,7 @@ index f55019c639f2..69c98e105903 100644
  
      // Update the content setting with the auto-grants for the DSE.
 @@ -398,11 +392,9 @@ void SearchPermissionsService::InitializeSettingsIfNeeded() {
-         GetContentSetting(dse_origin, CONTENT_SETTINGS_TYPE_NOTIFICATIONS);
+         GetContentSetting(dse_origin, ContentSettingsType::NOTIFICATIONS);
      ContentSetting dse_notifications_setting = notifications_setting_to_restore;
      // If the user hasn't explicitly allowed or blocked notifications for the
 -    // DSE, initialize it to allowed.
@@ -63,5 +63,5 @@ index f55019c639f2..69c98e105903 100644
  
      // Update the content setting with the auto-grants for the DSE.
 -- 
-2.24.0
+2.25.0
 

--- a/0031-stub-out-the-battery-status-API.patch
+++ b/0031-stub-out-the-battery-status-API.patch
@@ -1,4 +1,4 @@
-From 65ae90fcc0076f76679bd80a74ce6fb1e66c21ba Mon Sep 17 00:00:00 2001
+From f6d7266463ae59a364019299ce40fb0bb13550c4 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Mon, 17 Jun 2019 11:29:21 -0400
 Subject: [PATCH 31/49] stub out the battery status API
@@ -63,5 +63,5 @@ index ca87910880bc..74009ec7b021 100644
  
  void BatteryManager::RegisterWithDispatcher() {
 -- 
-2.24.0
+2.25.0
 

--- a/0032-always-use-local-new-tab-page.patch
+++ b/0032-always-use-local-new-tab-page.patch
@@ -1,4 +1,4 @@
-From 27715b7963120b15e88f9bb63dd8c0a5e100a7a2 Mon Sep 17 00:00:00 2001
+From 0aae748d4f6d00a08f8479eba1a4dd7563cb4e8b Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Mon, 17 Jun 2019 13:14:22 -0400
 Subject: [PATCH 32/49] always use local new tab page
@@ -21,5 +21,5 @@ index c3a68e4d757a..f2a418605154 100644
  
  // Used to look up the URL to use for the New Tab page. Also tracks how we
 -- 
-2.24.0
+2.25.0
 

--- a/0033-disable-search-provider-logo.patch
+++ b/0033-disable-search-provider-logo.patch
@@ -1,4 +1,4 @@
-From 31d066609ca31672c7154862e97e29a4e0c4824b Mon Sep 17 00:00:00 2001
+From 586166720c96ca1143e14f009a46cc05071d760b Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Mon, 17 Jun 2019 12:03:52 -0400
 Subject: [PATCH 33/49] disable search provider logo
@@ -50,5 +50,5 @@ index 58aef45b461a..c27be5575d17 100644
 +  return false;
  }
 -- 
-2.24.0
+2.25.0
 

--- a/0034-stop-ignoring-download-location-prompt-setting.patch
+++ b/0034-stop-ignoring-download-location-prompt-setting.patch
@@ -1,17 +1,17 @@
-From 100fdf28cb6a40abf16226bfb9f2b4a13d5f3c3c Mon Sep 17 00:00:00 2001
+From e53caaf5a44e800b23d2837ef9a9d14624b6bb42 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Fri, 28 Jun 2019 16:56:37 -0400
 Subject: [PATCH 34/49] stop ignoring download location prompt setting
 
 ---
- .../download/DownloadLocationDialogBridge.java   | 16 ----------------
- 1 file changed, 16 deletions(-)
+ .../download/DownloadLocationDialogBridge.java    | 15 ---------------
+ 1 file changed, 15 deletions(-)
 
 diff --git a/chrome/android/java/src/org/chromium/chrome/browser/download/DownloadLocationDialogBridge.java b/chrome/android/java/src/org/chromium/chrome/browser/download/DownloadLocationDialogBridge.java
-index 6c1d7834fc55..191ad264f30c 100644
+index 92513b019c76..44373ec4a963 100644
 --- a/chrome/android/java/src/org/chromium/chrome/browser/download/DownloadLocationDialogBridge.java
 +++ b/chrome/android/java/src/org/chromium/chrome/browser/download/DownloadLocationDialogBridge.java
-@@ -110,22 +110,6 @@ public class DownloadLocationDialogBridge implements ModalDialogProperties.Contr
+@@ -109,21 +109,6 @@ public class DownloadLocationDialogBridge implements ModalDialogProperties.Contr
       * @param dirs An list of available download directories.
       */
      private void onDirectoryOptionsRetrieved(ArrayList<DirectoryOption> dirs) {
@@ -22,8 +22,7 @@ index 6c1d7834fc55..191ad264f30c 100644
 -            final DirectoryOption dir = dirs.get(0);
 -            if (dir.type == DirectoryOption.DownloadLocationDirectoryType.DEFAULT) {
 -                assert(!TextUtils.isEmpty(dir.location));
--                PrefServiceBridge.getInstance().setDownloadAndSaveFileDefaultDirectory(
--                        dir.location);
+-                setDownloadAndSaveFileDefaultDirectory(dir.location);
 -                DownloadLocationDialogBridgeJni.get().onComplete(
 -                        mNativeDownloadLocationDialogBridge, DownloadLocationDialogBridge.this,
 -                        mSuggestedPath);
@@ -35,5 +34,5 @@ index 6c1d7834fc55..191ad264f30c 100644
          if (mDialogModel != null) return;
  
 -- 
-2.24.0
+2.25.0
 

--- a/0035-show-download-prompt-again-by-default.patch
+++ b/0035-show-download-prompt-again-by-default.patch
@@ -1,4 +1,4 @@
-From affcc6b447ec746ba52082e09683ba91e9d38ae4 Mon Sep 17 00:00:00 2001
+From a2d111a8723978e92cd25e969004193b2cefe165 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Fri, 28 Jun 2019 17:48:49 -0400
 Subject: [PATCH 35/49] show download prompt again by default
@@ -8,20 +8,20 @@ Subject: [PATCH 35/49] show download prompt again by default
  1 file changed, 4 deletions(-)
 
 diff --git a/chrome/android/java/src/org/chromium/chrome/browser/download/DownloadLocationCustomView.java b/chrome/android/java/src/org/chromium/chrome/browser/download/DownloadLocationCustomView.java
-index 44beb6e3441d..4944192eefc9 100644
+index 8288d3b1fad7..a9af1beb0eae 100644
 --- a/chrome/android/java/src/org/chromium/chrome/browser/download/DownloadLocationCustomView.java
 +++ b/chrome/android/java/src/org/chromium/chrome/browser/download/DownloadLocationCustomView.java
-@@ -56,10 +56,6 @@ public class DownloadLocationCustomView
+@@ -55,10 +55,6 @@ public class DownloadLocationCustomView
      void initialize(@DownloadLocationDialogType int dialogType, File suggestedPath) {
          mDialogType = dialogType;
  
 -        // Automatically check "don't show again" the first time the user is seeing the dialog.
--        boolean isInitial = PrefServiceBridge.getInstance().getPromptForDownloadAndroid()
--                == DownloadPromptStatus.SHOW_INITIAL;
+-        boolean isInitial =
+-                DownloadUtils.getPromptForDownloadAndroid() == DownloadPromptStatus.SHOW_INITIAL;
 -        mDontShowAgain.setChecked(isInitial);
          mDontShowAgain.setOnCheckedChangeListener(this);
  
          mFileName.setText(suggestedPath.getName());
 -- 
-2.24.0
+2.25.0
 

--- a/0036-rename-Sync-and-Google-services-Services.patch
+++ b/0036-rename-Sync-and-Google-services-Services.patch
@@ -1,17 +1,17 @@
-From c5f67b8bd248c6618a51993a438dedc83e211333 Mon Sep 17 00:00:00 2001
+From 83d3a5fd17866679fcafbf459834355475eea0a3 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Fri, 2 Aug 2019 23:28:06 -0400
 Subject: [PATCH 36/49] rename Sync and Google services -> Services
 
 ---
- chrome/android/java/strings/android_chrome_strings.grd | 6 +++---
+ .../browser/ui/android/strings/android_chrome_strings.grd   | 6 +++---
  1 file changed, 3 insertions(+), 3 deletions(-)
 
-diff --git a/chrome/android/java/strings/android_chrome_strings.grd b/chrome/android/java/strings/android_chrome_strings.grd
-index 7066343864ba..c0c69950125c 100644
---- a/chrome/android/java/strings/android_chrome_strings.grd
-+++ b/chrome/android/java/strings/android_chrome_strings.grd
-@@ -346,10 +346,10 @@ CHAR-LIMIT guidelines:
+diff --git a/chrome/browser/ui/android/strings/android_chrome_strings.grd b/chrome/browser/ui/android/strings/android_chrome_strings.grd
+index 4303783f493c..87660d47a2a9 100644
+--- a/chrome/browser/ui/android/strings/android_chrome_strings.grd
++++ b/chrome/browser/ui/android/strings/android_chrome_strings.grd
+@@ -376,10 +376,10 @@ CHAR-LIMIT guidelines:
          Sign in to Vanadium
        </message>
        <message name="IDS_PREFS_SYNC_AND_SERVICES" desc="Title for Settings section to manage data collection for Sync and Google services. [CHAR-LIMIT=40]">
@@ -24,7 +24,7 @@ index 7066343864ba..c0c69950125c 100644
        </message>
        <message name="IDS_SIGNIN_PREF_SUMMARY" desc="Summary for the entry in Settings to sign in to Vanadium, explaining benefits of signing in.">
          Sync and personalize across devices
-@@ -413,7 +413,7 @@ CHAR-LIMIT guidelines:
+@@ -443,7 +443,7 @@ CHAR-LIMIT guidelines:
          Sends URLs of pages you visit to Google
        </message>
        <message name="IDS_PRIVACY_SYNC_AND_SERVICES_LINK" desc="The text for Privacy preferences that is shown after all preference rows.">
@@ -34,5 +34,5 @@ index 7066343864ba..c0c69950125c 100644
        <message name="IDS_USAGE_AND_CRASH_REPORTS_TITLE" desc="Title for a preference that enables sending usage statistics and crash reports.">
          Help improve Vanadium's features and performance
 -- 
-2.24.0
+2.25.0
 

--- a/0037-remove-data-reduction-preference.patch
+++ b/0037-remove-data-reduction-preference.patch
@@ -1,39 +1,36 @@
-From 240b7a82d51de71d5e0a5649f7c45eec8241cba7 Mon Sep 17 00:00:00 2001
+From 68d99e7208aa4d5d3172cd381d4506d41d0bacba Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Fri, 2 Aug 2019 22:06:31 -0400
 Subject: [PATCH 37/49] remove data reduction preference
 
 ---
- chrome/android/java/res/xml/main_preferences.xml       | 10 +++++-----
- .../chrome/browser/preferences/MainPreferences.java    |  8 ++++----
- 2 files changed, 9 insertions(+), 9 deletions(-)
+ chrome/android/java/res/xml/main_preferences.xml          | 4 ++--
+ .../chromium/chrome/browser/settings/MainPreferences.java | 8 ++++----
+ 2 files changed, 6 insertions(+), 6 deletions(-)
 
 diff --git a/chrome/android/java/res/xml/main_preferences.xml b/chrome/android/java/res/xml/main_preferences.xml
-index a5c50e6987dd..d9f02a3a7c09 100644
+index 198d14432dbb..8ea16680d110 100644
 --- a/chrome/android/java/res/xml/main_preferences.xml
 +++ b/chrome/android/java/res/xml/main_preferences.xml
 @@ -90,11 +90,11 @@
          android:key="languages"
          android:order="16"
          android:title="@string/prefs_languages"/>
--    <org.chromium.chrome.browser.preferences.ChromeBasePreference
--        android:fragment="org.chromium.chrome.browser.preferences.datareduction.DataReductionPreferenceFragment"
--        android:key="data_reduction"
--        android:order="17"
+-    <org.chromium.chrome.browser.settings.ChromeBasePreference
++    <!--<org.chromium.chrome.browser.settings.ChromeBasePreference
+         android:fragment="org.chromium.chrome.browser.settings.datareduction.DataReductionPreferenceFragment"
+         android:key="data_reduction"
+         android:order="17"
 -        android:title="@string/data_reduction_title_lite_mode"/>
-+    <!--<org.chromium.chrome.browser.preferences.ChromeBasePreference-->
-+        <!--android:fragment="org.chromium.chrome.browser.preferences.datareduction.DataReductionPreferenceFragment"-->
-+        <!--android:key="data_reduction"-->
-+        <!--android:order="17"-->
-+        <!--android:title="@string/data_reduction_title_lite_mode"/>-->
-     <org.chromium.chrome.browser.preferences.ChromeBasePreference
-         android:fragment="org.chromium.chrome.browser.preferences.download.DownloadPreferences"
++        android:title="@string/data_reduction_title_lite_mode"/>-->
+     <org.chromium.chrome.browser.settings.ChromeBasePreference
+         android:fragment="org.chromium.chrome.browser.settings.download.DownloadPreferences"
          android:key="downloads"
-diff --git a/chrome/android/java/src/org/chromium/chrome/browser/preferences/MainPreferences.java b/chrome/android/java/src/org/chromium/chrome/browser/preferences/MainPreferences.java
-index 374daebc1967..68305f478287 100644
---- a/chrome/android/java/src/org/chromium/chrome/browser/preferences/MainPreferences.java
-+++ b/chrome/android/java/src/org/chromium/chrome/browser/preferences/MainPreferences.java
-@@ -134,7 +134,7 @@ public class MainPreferences extends PreferenceFragmentCompat
+diff --git a/chrome/android/java/src/org/chromium/chrome/browser/settings/MainPreferences.java b/chrome/android/java/src/org/chromium/chrome/browser/settings/MainPreferences.java
+index 32213f862d26..1d8c27faab28 100644
+--- a/chrome/android/java/src/org/chromium/chrome/browser/settings/MainPreferences.java
++++ b/chrome/android/java/src/org/chromium/chrome/browser/settings/MainPreferences.java
+@@ -136,7 +136,7 @@ public class MainPreferences extends PreferenceFragmentCompat
          updatePasswordsPreference();
  
          setManagedPreferenceDelegateForPreference(PREF_SEARCH_ENGINE);
@@ -42,7 +39,7 @@ index 374daebc1967..68305f478287 100644
  
          if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
              // If we are on Android O+ the Notifications preference should lead to the Android
-@@ -221,9 +221,9 @@ public class MainPreferences extends PreferenceFragmentCompat
+@@ -223,9 +223,9 @@ public class MainPreferences extends PreferenceFragmentCompat
              removePreferenceIfPresent(PREF_DEVELOPER);
          }
  
@@ -56,5 +53,5 @@ index 374daebc1967..68305f478287 100644
  
      private Preference addPreferenceIfAbsent(String key) {
 -- 
-2.24.0
+2.25.0
 

--- a/0038-remove-translate-offer-preference.patch
+++ b/0038-remove-translate-offer-preference.patch
@@ -1,54 +1,56 @@
-From 55c8edf6617083fe23d5329c5804d7f6b6d5e44a Mon Sep 17 00:00:00 2001
+From 2b61b918997a8ab03a1bd0d03f18b334a6db1c7c Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Fri, 2 Aug 2019 21:11:17 -0400
 Subject: [PATCH 38/49] remove translate offer preference
 
 ---
- .../java/res/xml/languages_preferences.xml    |  8 ++---
- .../languages/LanguagesPreferences.java       | 36 +++++++++----------
- .../java/strings/android_chrome_strings.grd   |  6 ++--
- 3 files changed, 25 insertions(+), 25 deletions(-)
+ .../java/res/xml/languages_preferences.xml    |  8 ++--
+ .../languages/LanguagesPreferences.java       | 40 +++++++++----------
+ .../strings/android_chrome_strings.grd        |  6 +--
+ 3 files changed, 27 insertions(+), 27 deletions(-)
 
 diff --git a/chrome/android/java/res/xml/languages_preferences.xml b/chrome/android/java/res/xml/languages_preferences.xml
-index 64e48b61ec91..fe8068814ed6 100644
+index 5e7dfc61f959..3f8a4d1ac88f 100644
 --- a/chrome/android/java/res/xml/languages_preferences.xml
 +++ b/chrome/android/java/res/xml/languages_preferences.xml
 @@ -11,9 +11,9 @@
          android:layout="@layout/languages_preference"
          android:widgetLayout="@layout/accept_languages_list" />
  
--    <org.chromium.chrome.browser.preferences.ChromeSwitchPreference
+-    <org.chromium.chrome.browser.settings.ChromeSwitchPreference
 -        android:key="translate_switch"
 -        android:summaryOn="@string/languages_offer_translate_switch"
 -        android:summaryOff="@string/languages_offer_translate_switch" />
-+    <!--<org.chromium.chrome.browser.preferences.ChromeSwitchPreference-->
++    <!--<org.chromium.chrome.browser.settings.ChromeSwitchPreference-->
 +        <!--android:key="translate_switch"-->
 +        <!--android:summaryOn="@string/languages_offer_translate_switch"-->
 +        <!--android:summaryOff="@string/languages_offer_translate_switch" />-->
  
  </PreferenceScreen>
-diff --git a/chrome/android/java/src/org/chromium/chrome/browser/preferences/languages/LanguagesPreferences.java b/chrome/android/java/src/org/chromium/chrome/browser/preferences/languages/LanguagesPreferences.java
-index 8325886f3637..92878d9d0845 100644
---- a/chrome/android/java/src/org/chromium/chrome/browser/preferences/languages/LanguagesPreferences.java
-+++ b/chrome/android/java/src/org/chromium/chrome/browser/preferences/languages/LanguagesPreferences.java
-@@ -36,25 +36,25 @@ public class LanguagesPreferences
+diff --git a/chrome/android/java/src/org/chromium/chrome/browser/settings/languages/LanguagesPreferences.java b/chrome/android/java/src/org/chromium/chrome/browser/settings/languages/LanguagesPreferences.java
+index 3ced90a41e44..9dc16a6ab6d8 100644
+--- a/chrome/android/java/src/org/chromium/chrome/browser/settings/languages/LanguagesPreferences.java
++++ b/chrome/android/java/src/org/chromium/chrome/browser/settings/languages/LanguagesPreferences.java
+@@ -38,27 +38,27 @@ public class LanguagesPreferences
                  (LanguageListPreference) findPreference(PREFERRED_LANGUAGES_KEY);
          mLanguageListPref.registerActivityLauncher(this);
  
 -        ChromeSwitchPreference translateSwitch =
 -                (ChromeSwitchPreference) findPreference(TRANSLATE_SWITCH_KEY);
--        boolean isTranslateEnabled = PrefServiceBridge.getInstance().isTranslateEnabled();
+-        boolean isTranslateEnabled =
+-                PrefServiceBridge.getInstance().getBoolean(Pref.OFFER_TRANSLATE_ENABLED);
 -        translateSwitch.setChecked(isTranslateEnabled);
 +        //ChromeSwitchPreference translateSwitch =
 +                //(ChromeSwitchPreference) findPreference(TRANSLATE_SWITCH_KEY);
-+        //boolean isTranslateEnabled = PrefServiceBridge.getInstance().isTranslateEnabled();
++        //boolean isTranslateEnabled =
++                //PrefServiceBridge.getInstance().getBoolean(Pref.OFFER_TRANSLATE_ENABLED);
 +        //translateSwitch.setChecked(isTranslateEnabled);
  
 -        translateSwitch.setOnPreferenceChangeListener(new Preference.OnPreferenceChangeListener() {
 -            @Override
 -            public boolean onPreferenceChange(Preference preference, Object newValue) {
 -                boolean enabled = (boolean) newValue;
--                PrefServiceBridge.getInstance().setTranslateEnabled(enabled);
+-                PrefServiceBridge.getInstance().setBoolean(Pref.OFFER_TRANSLATE_ENABLED, enabled);
 -                LanguagesManager.recordAction(enabled ? LanguagesManager.LanguageSettingsActionType
 -                                                                .ENABLE_TRANSLATE_GLOBALLY
 -                                                      : LanguagesManager.LanguageSettingsActionType
@@ -56,13 +58,14 @@ index 8325886f3637..92878d9d0845 100644
 -                return true;
 -            }
 -        });
--        translateSwitch.setManagedPreferenceDelegate(
--                preference -> PrefServiceBridge.getInstance().isTranslateManaged());
+-        translateSwitch.setManagedPreferenceDelegate(preference
+-                -> PrefServiceBridge.getInstance().isManagedPreference(
+-                        Pref.OFFER_TRANSLATE_ENABLED));
 +        //translateSwitch.setOnPreferenceChangeListener(new Preference.OnPreferenceChangeListener() {
 +            //@Override
 +            //public boolean onPreferenceChange(Preference preference, Object newValue) {
 +                //boolean enabled = (boolean) newValue;
-+                //PrefServiceBridge.getInstance().setTranslateEnabled(enabled);
++                //PrefServiceBridge.getInstance().setBoolean(Pref.OFFER_TRANSLATE_ENABLED, enabled);
 +                //LanguagesManager.recordAction(enabled ? LanguagesManager.LanguageSettingsActionType
 +                                                                //.ENABLE_TRANSLATE_GLOBALLY
 +                                                      //: LanguagesManager.LanguageSettingsActionType
@@ -70,16 +73,17 @@ index 8325886f3637..92878d9d0845 100644
 +                //return true;
 +            //}
 +        //});
-+        //translateSwitch.setManagedPreferenceDelegate(
-+                //preference -> PrefServiceBridge.getInstance().isTranslateManaged());
++        //translateSwitch.setManagedPreferenceDelegate(preference
++                //-> PrefServiceBridge.getInstance().isManagedPreference(
++                        //Pref.OFFER_TRANSLATE_ENABLED));
          LanguagesManager.recordImpression(LanguagesManager.LanguageSettingsPageType.PAGE_MAIN);
      }
  
-diff --git a/chrome/android/java/strings/android_chrome_strings.grd b/chrome/android/java/strings/android_chrome_strings.grd
-index c0c69950125c..b0dea6c587ad 100644
---- a/chrome/android/java/strings/android_chrome_strings.grd
-+++ b/chrome/android/java/strings/android_chrome_strings.grd
-@@ -1182,9 +1182,9 @@ Your Google account may have other forms of browsing history like searches and a
+diff --git a/chrome/browser/ui/android/strings/android_chrome_strings.grd b/chrome/browser/ui/android/strings/android_chrome_strings.grd
+index 87660d47a2a9..57e5e776724e 100644
+--- a/chrome/browser/ui/android/strings/android_chrome_strings.grd
++++ b/chrome/browser/ui/android/strings/android_chrome_strings.grd
+@@ -1211,9 +1211,9 @@ Your Google account may have other forms of browsing history like searches and a
        <message name="IDS_LANGUAGES_LIST_PREFS_DESCRIPTION" desc="Description on the Languages settings screen. Appears above a list of one or more languages that the user selects, to tell Vanadium which languages they prefer to use to read website content.">
          Websites will show text in your preferred language, when possible.
        </message>
@@ -93,5 +97,5 @@ index c0c69950125c..b0dea6c587ad 100644
          Offer to translate
        </message>
 -- 
-2.24.0
+2.25.0
 

--- a/0039-remove-sync-preferences.patch
+++ b/0039-remove-sync-preferences.patch
@@ -1,16 +1,16 @@
-From 3f22f9c288dcd5495476523f9850e6d9a6d940dc Mon Sep 17 00:00:00 2001
+From dbf1309293472c87f2020062bacdf3386e436907 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Fri, 2 Aug 2019 21:12:28 -0400
 Subject: [PATCH 39/49] remove sync preferences
 
 ---
  .../res/xml/sync_and_services_preferences.xml |  56 +++----
- .../sync/SyncAndServicesPreferences.java      | 146 +++++++++---------
- .../java/strings/android_chrome_strings.grd   |  24 +--
- 3 files changed, 113 insertions(+), 113 deletions(-)
+ .../sync/SyncAndServicesPreferences.java      | 140 +++++++++---------
+ .../strings/android_chrome_strings.grd        |  24 +--
+ 3 files changed, 110 insertions(+), 110 deletions(-)
 
 diff --git a/chrome/android/java/res/xml/sync_and_services_preferences.xml b/chrome/android/java/res/xml/sync_and_services_preferences.xml
-index dceeecf020fb..fce27cd3753d 100644
+index c082183dd914..aa474e94d150 100644
 --- a/chrome/android/java/res/xml/sync_and_services_preferences.xml
 +++ b/chrome/android/java/res/xml/sync_and_services_preferences.xml
 @@ -8,38 +8,38 @@
@@ -20,20 +20,20 @@ index dceeecf020fb..fce27cd3753d 100644
 -    <PreferenceCategory
 -        android:key="user_category"
 -        android:title="@string/user"/>
--    <org.chromium.chrome.browser.preferences.sync.SignInPreference
+-    <org.chromium.chrome.browser.settings.sync.SignInPreference
 -        android:key="sign_in"
 -        android:title="@string/sign_in_to_chrome"/>
 +    <!--<PreferenceCategory-->
 +        <!--android:key="user_category"-->
 +        <!--android:title="@string/user"/>-->
-+    <!--<org.chromium.chrome.browser.preferences.sync.SignInPreference-->
++    <!--<org.chromium.chrome.browser.settings.sync.SignInPreference-->
 +        <!--android:key="sign_in"-->
 +        <!--android:title="@string/sign_in_to_chrome"/>-->
  
--    <org.chromium.chrome.browser.preferences.ChromeBasePreference
+-    <org.chromium.chrome.browser.settings.ChromeBasePreference
 -        android:key="manage_your_google_account"
 -        android:title="@string/manage_your_google_account"/>
-+    <!--<org.chromium.chrome.browser.preferences.ChromeBasePreference-->
++    <!--<org.chromium.chrome.browser.settings.ChromeBasePreference-->
 +        <!--android:key="manage_your_google_account"-->
 +        <!--android:title="@string/manage_your_google_account"/>-->
  
@@ -51,7 +51,7 @@ index dceeecf020fb..fce27cd3753d 100644
 -            android:key="sync_disabled_by_administrator"
 -            android:layout="@layout/account_management_account_row"
 -            android:title="@string/sync_is_disabled_by_administrator"/>
--        <org.chromium.chrome.browser.preferences.ChromeSwitchPreference
+-        <org.chromium.chrome.browser.settings.ChromeSwitchPreference
 -            android:key="sync_requested"
 -            android:title="@string/sync_switch_title"
 -            android:persistent="false"/>
@@ -62,29 +62,29 @@ index dceeecf020fb..fce27cd3753d 100644
 +            <!--android:key="sync_disabled_by_administrator"-->
 +            <!--android:layout="@layout/account_management_account_row"-->
 +            <!--android:title="@string/sync_is_disabled_by_administrator"/>-->
-+        <!--<org.chromium.chrome.browser.preferences.ChromeSwitchPreference-->
++        <!--<org.chromium.chrome.browser.settings.ChromeSwitchPreference-->
 +            <!--android:key="sync_requested"-->
 +            <!--android:title="@string/sync_switch_title"-->
 +            <!--android:persistent="false"/>-->
  
--        <org.chromium.chrome.browser.preferences.ChromeBasePreference
+-        <org.chromium.chrome.browser.settings.ChromeBasePreference
 -            android:key="manage_sync"
 -            android:title="@string/manage_sync_title"
--            android:fragment="org.chromium.chrome.browser.preferences.sync.ManageSyncPreferences"/>
+-            android:fragment="org.chromium.chrome.browser.settings.sync.ManageSyncPreferences"/>
 -    </PreferenceCategory>
-+        <!--<org.chromium.chrome.browser.preferences.ChromeBasePreference-->
++        <!--<org.chromium.chrome.browser.settings.ChromeBasePreference-->
 +            <!--android:key="manage_sync"-->
 +            <!--android:title="@string/manage_sync_title"-->
-+            <!--android:fragment="org.chromium.chrome.browser.preferences.sync.ManageSyncPreferences"/>-->
++            <!--android:fragment="org.chromium.chrome.browser.settings.sync.ManageSyncPreferences"/>-->
 +    <!--</PreferenceCategory>-->
  
      <PreferenceCategory
          android:key="services_category"
-diff --git a/chrome/android/java/src/org/chromium/chrome/browser/preferences/sync/SyncAndServicesPreferences.java b/chrome/android/java/src/org/chromium/chrome/browser/preferences/sync/SyncAndServicesPreferences.java
-index 6f7b0e78f74a..95d7e897c32d 100644
---- a/chrome/android/java/src/org/chromium/chrome/browser/preferences/sync/SyncAndServicesPreferences.java
-+++ b/chrome/android/java/src/org/chromium/chrome/browser/preferences/sync/SyncAndServicesPreferences.java
-@@ -128,14 +128,14 @@ public class SyncAndServicesPreferences extends PreferenceFragmentCompat
+diff --git a/chrome/android/java/src/org/chromium/chrome/browser/settings/sync/SyncAndServicesPreferences.java b/chrome/android/java/src/org/chromium/chrome/browser/settings/sync/SyncAndServicesPreferences.java
+index 13ed23dfe62c..f25f9332c2cf 100644
+--- a/chrome/android/java/src/org/chromium/chrome/browser/settings/sync/SyncAndServicesPreferences.java
++++ b/chrome/android/java/src/org/chromium/chrome/browser/settings/sync/SyncAndServicesPreferences.java
+@@ -137,14 +137,14 @@ public class SyncAndServicesPreferences extends PreferenceFragmentCompat
  
      private boolean mIsFromSigninScreen;
  
@@ -106,13 +106,10 @@ index 6f7b0e78f74a..95d7e897c32d 100644
  
      private ChromeSwitchPreference mSearchSuggestions;
      private ChromeSwitchPreference mNavigationError;
-@@ -179,27 +179,27 @@ public class SyncAndServicesPreferences extends PreferenceFragmentCompat
+@@ -188,24 +188,24 @@ public class SyncAndServicesPreferences extends PreferenceFragmentCompat
  
-         PreferenceUtils.addPreferencesFromResource(this, R.xml.sync_and_services_preferences);
+         SettingsUtils.addPreferencesFromResource(this, R.xml.sync_and_services_preferences);
  
--        if (!ChromeFeatureList.isEnabled(ChromeFeatureList.IDENTITY_DISC)) {
--            getPreferenceScreen().removePreference(findPreference(PREF_USER_CATEGORY));
--        }
 -        mSigninPreference = (SignInPreference) findPreference(PREF_SIGNIN);
 -        mSigninPreference.setPersonalizedPromoEnabled(false);
 -        mManageYourGoogleAccount = findPreference(PREF_MANAGE_YOUR_GOOGLE_ACCOUNT);
@@ -131,9 +128,6 @@ index 6f7b0e78f74a..95d7e897c32d 100644
 -        mSyncRequested = (ChromeSwitchPreference) findPreference(PREF_SYNC_REQUESTED);
 -        mSyncRequested.setOnPreferenceChangeListener(this);
 -        mManageSync = (ChromeBasePreference) findPreference(PREF_MANAGE_SYNC);
-+        //if (!ChromeFeatureList.isEnabled(ChromeFeatureList.IDENTITY_DISC)) {
-+            //getPreferenceScreen().removePreference(findPreference(PREF_USER_CATEGORY));
-+        //}
 +        //mSigninPreference = (SignInPreference) findPreference(PREF_SIGNIN);
 +        //mSigninPreference.setPersonalizedPromoEnabled(false);
 +        //mManageYourGoogleAccount = findPreference(PREF_MANAGE_YOUR_GOOGLE_ACCOUNT);
@@ -155,7 +149,16 @@ index 6f7b0e78f74a..95d7e897c32d 100644
  
          mSearchSuggestions = (ChromeSwitchPreference) findPreference(PREF_SEARCH_SUGGESTIONS);
          mSearchSuggestions.setOnPreferenceChangeListener(this);
-@@ -300,7 +300,7 @@ public class SyncAndServicesPreferences extends PreferenceFragmentCompat
+@@ -266,7 +266,7 @@ public class SyncAndServicesPreferences extends PreferenceFragmentCompat
+             // If the setup flow was previously interrupted, and now the user dismissed the page
+             // without turning sync on, then mark first setup as complete (so that we won't show the
+             // error again), but turn sync off.
+-            assert !mSyncRequested.isChecked();
++            //assert !mSyncRequested.isChecked();
+             SyncPreferenceUtils.enableSync(false);
+             mProfileSyncService.setFirstSetupComplete(
+                     SyncFirstSetupCompleteSource.ADVANCED_FLOW_INTERRUPTED_LEAVE_SYNC_OFF);
+@@ -316,7 +316,7 @@ public class SyncAndServicesPreferences extends PreferenceFragmentCompat
      public void onStart() {
          super.onStart();
          mProfileSyncService.addSyncStateChangedListener(this);
@@ -164,7 +167,7 @@ index 6f7b0e78f74a..95d7e897c32d 100644
  
          if (!mIsFromSigninScreen || ChromeSigninController.get().isSignedIn()) {
              return;
-@@ -323,7 +323,7 @@ public class SyncAndServicesPreferences extends PreferenceFragmentCompat
+@@ -339,7 +339,7 @@ public class SyncAndServicesPreferences extends PreferenceFragmentCompat
      public void onStop() {
          super.onStop();
  
@@ -173,16 +176,16 @@ index 6f7b0e78f74a..95d7e897c32d 100644
          mProfileSyncService.removeSyncStateChangedListener(this);
      }
  
-@@ -557,7 +557,7 @@ public class SyncAndServicesPreferences extends PreferenceFragmentCompat
+@@ -596,7 +596,7 @@ public class SyncAndServicesPreferences extends PreferenceFragmentCompat
      }
  
      private void updatePreferences() {
 -        updateSyncPreferences();
 +        //updateSyncPreferences();
  
-         mSearchSuggestions.setChecked(mPrefServiceBridge.isSearchSuggestEnabled());
-         mNavigationError.setChecked(mPrefServiceBridge.isResolveNavigationErrorEnabled());
-@@ -577,49 +577,49 @@ public class SyncAndServicesPreferences extends PreferenceFragmentCompat
+         mSearchSuggestions.setChecked(mPrefServiceBridge.getBoolean(Pref.SEARCH_SUGGEST_ENABLED));
+         mNavigationError.setChecked(
+@@ -618,49 +618,49 @@ public class SyncAndServicesPreferences extends PreferenceFragmentCompat
          }
      }
  
@@ -273,20 +276,11 @@ index 6f7b0e78f74a..95d7e897c32d 100644
  
      /**
       * If password leak detection is off and cannot be toggled while safe browsing is disabled, so
-@@ -685,7 +685,7 @@ public class SyncAndServicesPreferences extends PreferenceFragmentCompat
-             // If the setup flow was previously interrupted, and now the user dismissed the page
-             // without turning sync on, then mark first setup as complete (so that we won't show the
-             // error again), but turn sync off.
--            assert !mSyncRequested.isChecked();
-+            //assert !mSyncRequested.isChecked();
-             SyncPreferenceUtils.enableSync(false);
-             mProfileSyncService.setFirstSetupComplete(
-                     SyncFirstSetupCompleteSource.ADVANCED_FLOW_INTERRUPTED_LEAVE_SYNC_OFF);
-diff --git a/chrome/android/java/strings/android_chrome_strings.grd b/chrome/android/java/strings/android_chrome_strings.grd
-index b0dea6c587ad..f06a453c2c8d 100644
---- a/chrome/android/java/strings/android_chrome_strings.grd
-+++ b/chrome/android/java/strings/android_chrome_strings.grd
-@@ -254,9 +254,9 @@ CHAR-LIMIT guidelines:
+diff --git a/chrome/browser/ui/android/strings/android_chrome_strings.grd b/chrome/browser/ui/android/strings/android_chrome_strings.grd
+index 57e5e776724e..b16ae9403ae1 100644
+--- a/chrome/browser/ui/android/strings/android_chrome_strings.grd
++++ b/chrome/browser/ui/android/strings/android_chrome_strings.grd
+@@ -281,9 +281,9 @@ CHAR-LIMIT guidelines:
        <message name="IDS_SHOW" desc="Label for a show button. Used in multiple contexts. [CHAR-LIMIT=20]">
          Show
        </message>
@@ -299,7 +293,7 @@ index b0dea6c587ad..f06a453c2c8d 100644
        <message name="IDS_MENU_ITEM_MOVE_UP" desc="Option in item menu. User can click the 'Move up' option to move the item up by one position in its list. [CHAR-LIMIT=24]">
          Move up
        </message>
-@@ -373,15 +373,15 @@ CHAR-LIMIT guidelines:
+@@ -403,15 +403,15 @@ CHAR-LIMIT guidelines:
        <message name="IDS_SIGN_OUT_AND_TURN_OFF_SYNC" desc="The text for a preferences row that for signs out the user and turns off sync.">
          Sign out and turn off sync
        </message>
@@ -325,5 +319,5 @@ index b0dea6c587ad..f06a453c2c8d 100644
          Manage sync
        </message>
 -- 
-2.24.0
+2.25.0
 

--- a/0040-remove-navigation-error-preference.patch
+++ b/0040-remove-navigation-error-preference.patch
@@ -1,40 +1,40 @@
-From b2606883189594aec7ed767c37d8d1f3d65d1caf Mon Sep 17 00:00:00 2001
+From 9c94d15834941833001c82ce85954da1a7ac6ddf Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Fri, 2 Aug 2019 23:46:41 -0400
 Subject: [PATCH 40/49] remove navigation error preference
 
 ---
- .../res/xml/sync_and_services_preferences.xml | 10 ++++-----
- .../sync/SyncAndServicesPreferences.java      | 22 +++++++++----------
- .../java/strings/android_chrome_strings.grd   | 12 +++++-----
- 3 files changed, 22 insertions(+), 22 deletions(-)
+ .../res/xml/sync_and_services_preferences.xml | 10 ++++----
+ .../sync/SyncAndServicesPreferences.java      | 24 +++++++++----------
+ .../strings/android_chrome_strings.grd        | 12 +++++-----
+ 3 files changed, 23 insertions(+), 23 deletions(-)
 
 diff --git a/chrome/android/java/res/xml/sync_and_services_preferences.xml b/chrome/android/java/res/xml/sync_and_services_preferences.xml
-index fce27cd3753d..9ae13669be47 100644
+index aa474e94d150..4899eb53a137 100644
 --- a/chrome/android/java/res/xml/sync_and_services_preferences.xml
 +++ b/chrome/android/java/res/xml/sync_and_services_preferences.xml
 @@ -50,11 +50,11 @@
              android:title="@string/autocomplete_searches_and_urls_title"
              android:summary="@string/autocomplete_searches_and_urls_summary"
              android:persistent="false"/>
--        <org.chromium.chrome.browser.preferences.ChromeSwitchPreference
+-        <org.chromium.chrome.browser.settings.ChromeSwitchPreference
 -            android:key="navigation_error"
 -            android:title="@string/navigation_error_suggestions_title"
 -            android:summary="@string/navigation_error_suggestions_summary"
 -            android:persistent="false"/>
-+        <!--<org.chromium.chrome.browser.preferences.ChromeSwitchPreference-->
++        <!--<org.chromium.chrome.browser.settings.ChromeSwitchPreference-->
 +            <!--android:key="navigation_error"-->
 +            <!--android:title="@string/navigation_error_suggestions_title"-->
 +            <!--android:summary="@string/navigation_error_suggestions_summary"-->
 +            <!--android:persistent="false"/>-->
-         <org.chromium.chrome.browser.preferences.ChromeSwitchPreference
+         <org.chromium.chrome.browser.settings.ChromeSwitchPreference
              android:key="safe_browsing"
              android:title="@string/safe_browsing_title"
-diff --git a/chrome/android/java/src/org/chromium/chrome/browser/preferences/sync/SyncAndServicesPreferences.java b/chrome/android/java/src/org/chromium/chrome/browser/preferences/sync/SyncAndServicesPreferences.java
-index 95d7e897c32d..8d12ddbcadb6 100644
---- a/chrome/android/java/src/org/chromium/chrome/browser/preferences/sync/SyncAndServicesPreferences.java
-+++ b/chrome/android/java/src/org/chromium/chrome/browser/preferences/sync/SyncAndServicesPreferences.java
-@@ -96,7 +96,7 @@ public class SyncAndServicesPreferences extends PreferenceFragmentCompat
+diff --git a/chrome/android/java/src/org/chromium/chrome/browser/settings/sync/SyncAndServicesPreferences.java b/chrome/android/java/src/org/chromium/chrome/browser/settings/sync/SyncAndServicesPreferences.java
+index f25f9332c2cf..d733a4d0fb28 100644
+--- a/chrome/android/java/src/org/chromium/chrome/browser/settings/sync/SyncAndServicesPreferences.java
++++ b/chrome/android/java/src/org/chromium/chrome/browser/settings/sync/SyncAndServicesPreferences.java
+@@ -103,7 +103,7 @@ public class SyncAndServicesPreferences extends PreferenceFragmentCompat
  
      private static final String PREF_SERVICES_CATEGORY = "services_category";
      private static final String PREF_SEARCH_SUGGESTIONS = "search_suggestions";
@@ -43,7 +43,7 @@ index 95d7e897c32d..8d12ddbcadb6 100644
      private static final String PREF_SAFE_BROWSING = "safe_browsing";
      private static final String PREF_PASSWORD_LEAK_DETECTION = "password_leak_detection";
      private static final String PREF_SAFE_BROWSING_SCOUT_REPORTING =
-@@ -138,7 +138,7 @@ public class SyncAndServicesPreferences extends PreferenceFragmentCompat
+@@ -147,7 +147,7 @@ public class SyncAndServicesPreferences extends PreferenceFragmentCompat
      //private ChromeSwitchPreference mSyncRequested;
  
      private ChromeSwitchPreference mSearchSuggestions;
@@ -52,7 +52,7 @@ index 95d7e897c32d..8d12ddbcadb6 100644
      private ChromeSwitchPreference mSafeBrowsing;
      private @Nullable ChromeSwitchPreference mPasswordLeakDetection;
      private ChromeSwitchPreference mSafeBrowsingReporting;
-@@ -205,9 +205,9 @@ public class SyncAndServicesPreferences extends PreferenceFragmentCompat
+@@ -211,9 +211,9 @@ public class SyncAndServicesPreferences extends PreferenceFragmentCompat
          mSearchSuggestions.setOnPreferenceChangeListener(this);
          mSearchSuggestions.setManagedPreferenceDelegate(mManagedPreferenceDelegate);
  
@@ -65,44 +65,46 @@ index 95d7e897c32d..8d12ddbcadb6 100644
  
          mSafeBrowsing = (ChromeSwitchPreference) findPreference(PREF_SAFE_BROWSING);
          mSafeBrowsing.setOnPreferenceChangeListener(this);
-@@ -360,8 +360,8 @@ public class SyncAndServicesPreferences extends PreferenceFragmentCompat
+@@ -376,8 +376,8 @@ public class SyncAndServicesPreferences extends PreferenceFragmentCompat
                      Pref.PASSWORD_MANAGER_LEAK_DETECTION_ENABLED, (boolean) newValue);
          } else if (PREF_SAFE_BROWSING_SCOUT_REPORTING.equals(key)) {
-             mPrefServiceBridge.setSafeBrowsingExtendedReportingEnabled((boolean) newValue);
+             SafeBrowsingBridge.setSafeBrowsingExtendedReportingEnabled((boolean) newValue);
 -        } else if (PREF_NAVIGATION_ERROR.equals(key)) {
--            mPrefServiceBridge.setResolveNavigationErrorEnabled((boolean) newValue);
+-            mPrefServiceBridge.setBoolean(Pref.ALTERNATE_ERROR_PAGES_ENABLED, (boolean) newValue);
 +        //} else if (PREF_NAVIGATION_ERROR.equals(key)) {
-+            //mPrefServiceBridge.setResolveNavigationErrorEnabled((boolean) newValue);
++            //mPrefServiceBridge.setBoolean(Pref.ALTERNATE_ERROR_PAGES_ENABLED, (boolean) newValue);
          } else if (PREF_USAGE_AND_CRASH_REPORTING.equals(key)) {
              UmaSessionStats.changeMetricsReportingConsent((boolean) newValue);
          } else if (PREF_URL_KEYED_ANONYMIZED_DATA.equals(key)) {
-@@ -560,7 +560,7 @@ public class SyncAndServicesPreferences extends PreferenceFragmentCompat
+@@ -599,8 +599,8 @@ public class SyncAndServicesPreferences extends PreferenceFragmentCompat
          //updateSyncPreferences();
  
-         mSearchSuggestions.setChecked(mPrefServiceBridge.isSearchSuggestEnabled());
--        mNavigationError.setChecked(mPrefServiceBridge.isResolveNavigationErrorEnabled());
-+        //mNavigationError.setChecked(mPrefServiceBridge.isResolveNavigationErrorEnabled());
-         mSafeBrowsing.setChecked(mPrefServiceBridge.isSafeBrowsingEnabled());
+         mSearchSuggestions.setChecked(mPrefServiceBridge.getBoolean(Pref.SEARCH_SUGGEST_ENABLED));
+-        mNavigationError.setChecked(
+-                mPrefServiceBridge.getBoolean(Pref.ALTERNATE_ERROR_PAGES_ENABLED));
++        //mNavigationError.setChecked(
++                //mPrefServiceBridge.getBoolean(Pref.ALTERNATE_ERROR_PAGES_ENABLED));
+         mSafeBrowsing.setChecked(mPrefServiceBridge.getBoolean(Pref.SAFE_BROWSING_ENABLED));
  
          updateLeakDetectionAndSafeBrowsingReportingPreferences();
-@@ -652,9 +652,9 @@ public class SyncAndServicesPreferences extends PreferenceFragmentCompat
+@@ -693,9 +693,9 @@ public class SyncAndServicesPreferences extends PreferenceFragmentCompat
      private ManagedPreferenceDelegate createManagedPreferenceDelegate() {
          return preference -> {
              String key = preference.getKey();
 -            if (PREF_NAVIGATION_ERROR.equals(key)) {
--                return mPrefServiceBridge.isResolveNavigationErrorManaged();
+-                return mPrefServiceBridge.isManagedPreference(Pref.ALTERNATE_ERROR_PAGES_ENABLED);
 -            }
 +            //if (PREF_NAVIGATION_ERROR.equals(key)) {
-+                //return mPrefServiceBridge.isResolveNavigationErrorManaged();
++                //return mPrefServiceBridge.isManagedPreference(Pref.ALTERNATE_ERROR_PAGES_ENABLED);
 +            //}
              if (PREF_SEARCH_SUGGESTIONS.equals(key)) {
-                 return mPrefServiceBridge.isSearchSuggestManaged();
+                 return mPrefServiceBridge.isManagedPreference(Pref.SEARCH_SUGGEST_ENABLED);
              }
-diff --git a/chrome/android/java/strings/android_chrome_strings.grd b/chrome/android/java/strings/android_chrome_strings.grd
-index f06a453c2c8d..e70c97cca1f3 100644
---- a/chrome/android/java/strings/android_chrome_strings.grd
-+++ b/chrome/android/java/strings/android_chrome_strings.grd
-@@ -400,12 +400,12 @@ CHAR-LIMIT guidelines:
+diff --git a/chrome/browser/ui/android/strings/android_chrome_strings.grd b/chrome/browser/ui/android/strings/android_chrome_strings.grd
+index b16ae9403ae1..fbf454517d95 100644
+--- a/chrome/browser/ui/android/strings/android_chrome_strings.grd
++++ b/chrome/browser/ui/android/strings/android_chrome_strings.grd
+@@ -430,12 +430,12 @@ CHAR-LIMIT guidelines:
        <message name="IDS_PRELOAD_PAGES_SUMMARY" desc="Summary for a checkbox in Settings that controls pages preloading and informs the user about the data shared by this feature.">
          Uses cookies to remember your preferences, even if you don't visit those pages
        </message>
@@ -122,5 +124,5 @@ index f06a453c2c8d..e70c97cca1f3 100644
          Make searches and browsing better
        </message>
 -- 
-2.24.0
+2.25.0
 

--- a/0041-remove-safe-browsing-reporting-preference.patch
+++ b/0041-remove-safe-browsing-reporting-preference.patch
@@ -1,4 +1,4 @@
-From 9549c5d1903d6f44cc74d01e61f98c0b4bcd36bf Mon Sep 17 00:00:00 2001
+From 5955ce0195b0d870c924de4bdd2f3f0197dab721 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Fri, 2 Aug 2019 23:48:41 -0400
 Subject: [PATCH 41/49] remove safe browsing reporting preference
@@ -6,35 +6,35 @@ Subject: [PATCH 41/49] remove safe browsing reporting preference
 ---
  .../res/xml/sync_and_services_preferences.xml | 10 +++----
  .../sync/SyncAndServicesPreferences.java      | 30 +++++++++----------
- .../java/strings/android_chrome_strings.grd   |  6 ----
+ .../strings/android_chrome_strings.grd        |  6 ----
  3 files changed, 20 insertions(+), 26 deletions(-)
 
 diff --git a/chrome/android/java/res/xml/sync_and_services_preferences.xml b/chrome/android/java/res/xml/sync_and_services_preferences.xml
-index 9ae13669be47..84dd60f1b7b8 100644
+index 4899eb53a137..791de37cd2c6 100644
 --- a/chrome/android/java/res/xml/sync_and_services_preferences.xml
 +++ b/chrome/android/java/res/xml/sync_and_services_preferences.xml
 @@ -64,11 +64,11 @@
              android:key="password_leak_detection"
              android:title="@string/passwords_leak_detection_switch_title"
              android:persistent="false"/>
--        <org.chromium.chrome.browser.preferences.ChromeSwitchPreference
+-        <org.chromium.chrome.browser.settings.ChromeSwitchPreference
 -            android:key="safe_browsing_scout_reporting"
 -            android:title="@string/safe_browsing_scout_reporting_title"
 -            android:summary="@string/safe_browsing_scout_reporting_summary"
 -            android:persistent="false"/>
-+        <!--<org.chromium.chrome.browser.preferences.ChromeSwitchPreference-->
++        <!--<org.chromium.chrome.browser.settings.ChromeSwitchPreference-->
 +            <!--android:key="safe_browsing_scout_reporting"-->
 +            <!--android:title="@string/safe_browsing_scout_reporting_title"-->
 +            <!--android:summary="@string/safe_browsing_scout_reporting_summary"-->
 +            <!--android:persistent="false"/>-->
-         <org.chromium.chrome.browser.preferences.ChromeSwitchPreference
+         <org.chromium.chrome.browser.settings.ChromeSwitchPreference
              android:key="usage_and_crash_reports"
              android:title="@string/usage_and_crash_reports_title"
-diff --git a/chrome/android/java/src/org/chromium/chrome/browser/preferences/sync/SyncAndServicesPreferences.java b/chrome/android/java/src/org/chromium/chrome/browser/preferences/sync/SyncAndServicesPreferences.java
-index 8d12ddbcadb6..dc6361c4ea0d 100644
---- a/chrome/android/java/src/org/chromium/chrome/browser/preferences/sync/SyncAndServicesPreferences.java
-+++ b/chrome/android/java/src/org/chromium/chrome/browser/preferences/sync/SyncAndServicesPreferences.java
-@@ -99,8 +99,8 @@ public class SyncAndServicesPreferences extends PreferenceFragmentCompat
+diff --git a/chrome/android/java/src/org/chromium/chrome/browser/settings/sync/SyncAndServicesPreferences.java b/chrome/android/java/src/org/chromium/chrome/browser/settings/sync/SyncAndServicesPreferences.java
+index d733a4d0fb28..744917161c9d 100644
+--- a/chrome/android/java/src/org/chromium/chrome/browser/settings/sync/SyncAndServicesPreferences.java
++++ b/chrome/android/java/src/org/chromium/chrome/browser/settings/sync/SyncAndServicesPreferences.java
+@@ -106,8 +106,8 @@ public class SyncAndServicesPreferences extends PreferenceFragmentCompat
      //private static final String PREF_NAVIGATION_ERROR = "navigation_error";
      private static final String PREF_SAFE_BROWSING = "safe_browsing";
      private static final String PREF_PASSWORD_LEAK_DETECTION = "password_leak_detection";
@@ -45,7 +45,7 @@ index 8d12ddbcadb6..dc6361c4ea0d 100644
      private static final String PREF_USAGE_AND_CRASH_REPORTING = "usage_and_crash_reports";
      private static final String PREF_URL_KEYED_ANONYMIZED_DATA = "url_keyed_anonymized_data";
      private static final String PREF_CONTEXTUAL_SEARCH = "contextual_search";
-@@ -141,7 +141,7 @@ public class SyncAndServicesPreferences extends PreferenceFragmentCompat
+@@ -150,7 +150,7 @@ public class SyncAndServicesPreferences extends PreferenceFragmentCompat
      //private ChromeSwitchPreference mNavigationError;
      private ChromeSwitchPreference mSafeBrowsing;
      private @Nullable ChromeSwitchPreference mPasswordLeakDetection;
@@ -54,7 +54,7 @@ index 8d12ddbcadb6..dc6361c4ea0d 100644
      private ChromeSwitchPreference mUsageAndCrashReporting;
      private ChromeSwitchPreference mUrlKeyedAnonymizedData;
      private @Nullable Preference mContextualSearch;
-@@ -225,10 +225,10 @@ public class SyncAndServicesPreferences extends PreferenceFragmentCompat
+@@ -231,10 +231,10 @@ public class SyncAndServicesPreferences extends PreferenceFragmentCompat
              mPasswordLeakDetection = null;
          }
  
@@ -69,48 +69,48 @@ index 8d12ddbcadb6..dc6361c4ea0d 100644
  
          mUsageAndCrashReporting =
                  (ChromeSwitchPreference) findPreference(PREF_USAGE_AND_CRASH_REPORTING);
-@@ -358,8 +358,8 @@ public class SyncAndServicesPreferences extends PreferenceFragmentCompat
+@@ -374,8 +374,8 @@ public class SyncAndServicesPreferences extends PreferenceFragmentCompat
          } else if (PREF_PASSWORD_LEAK_DETECTION.equals(key)) {
              mPrefServiceBridge.setBoolean(
                      Pref.PASSWORD_MANAGER_LEAK_DETECTION_ENABLED, (boolean) newValue);
 -        } else if (PREF_SAFE_BROWSING_SCOUT_REPORTING.equals(key)) {
--            mPrefServiceBridge.setSafeBrowsingExtendedReportingEnabled((boolean) newValue);
+-            SafeBrowsingBridge.setSafeBrowsingExtendedReportingEnabled((boolean) newValue);
 +        //} else if (PREF_SAFE_BROWSING_SCOUT_REPORTING.equals(key)) {
-+            //mPrefServiceBridge.setSafeBrowsingExtendedReportingEnabled((boolean) newValue);
++            //SafeBrowsingBridge.setSafeBrowsingExtendedReportingEnabled((boolean) newValue);
          //} else if (PREF_NAVIGATION_ERROR.equals(key)) {
-             //mPrefServiceBridge.setResolveNavigationErrorEnabled((boolean) newValue);
+             //mPrefServiceBridge.setBoolean(Pref.ALTERNATE_ERROR_PAGES_ENABLED, (boolean) newValue);
          } else if (PREF_USAGE_AND_CRASH_REPORTING.equals(key)) {
-@@ -627,9 +627,9 @@ public class SyncAndServicesPreferences extends PreferenceFragmentCompat
+@@ -668,9 +668,9 @@ public class SyncAndServicesPreferences extends PreferenceFragmentCompat
       */
      private void updateLeakDetectionAndSafeBrowsingReportingPreferences() {
          boolean safe_browsing_enabled = mPrefServiceBridge.getBoolean(Pref.SAFE_BROWSING_ENABLED);
 -        mSafeBrowsingReporting.setEnabled(safe_browsing_enabled);
 -        mSafeBrowsingReporting.setChecked(safe_browsing_enabled
--                && mPrefServiceBridge.isSafeBrowsingExtendedReportingEnabled());
+-                && SafeBrowsingBridge.isSafeBrowsingExtendedReportingEnabled());
 +        //mSafeBrowsingReporting.setEnabled(safe_browsing_enabled);
 +        //mSafeBrowsingReporting.setChecked(safe_browsing_enabled
-+                //&& mPrefServiceBridge.isSafeBrowsingExtendedReportingEnabled());
++                //&& SafeBrowsingBridge.isSafeBrowsingExtendedReportingEnabled());
  
          if (mPasswordLeakDetection == null) return; // Early exit without leak detection to update.
  
-@@ -658,9 +658,9 @@ public class SyncAndServicesPreferences extends PreferenceFragmentCompat
+@@ -699,9 +699,9 @@ public class SyncAndServicesPreferences extends PreferenceFragmentCompat
              if (PREF_SEARCH_SUGGESTIONS.equals(key)) {
-                 return mPrefServiceBridge.isSearchSuggestManaged();
+                 return mPrefServiceBridge.isManagedPreference(Pref.SEARCH_SUGGEST_ENABLED);
              }
 -            if (PREF_SAFE_BROWSING_SCOUT_REPORTING.equals(key)) {
--                return mPrefServiceBridge.isSafeBrowsingExtendedReportingManaged();
+-                return SafeBrowsingBridge.isSafeBrowsingExtendedReportingManaged();
 -            }
 +            //if (PREF_SAFE_BROWSING_SCOUT_REPORTING.equals(key)) {
-+                //return mPrefServiceBridge.isSafeBrowsingExtendedReportingManaged();
++                //return SafeBrowsingBridge.isSafeBrowsingExtendedReportingManaged();
 +            //}
              if (PREF_SAFE_BROWSING.equals(key)) {
-                 return mPrefServiceBridge.isSafeBrowsingManaged();
+                 return mPrefServiceBridge.isManagedPreference(Pref.SAFE_BROWSING_ENABLED);
              }
-diff --git a/chrome/android/java/strings/android_chrome_strings.grd b/chrome/android/java/strings/android_chrome_strings.grd
-index e70c97cca1f3..5700b086be76 100644
---- a/chrome/android/java/strings/android_chrome_strings.grd
-+++ b/chrome/android/java/strings/android_chrome_strings.grd
-@@ -711,12 +711,6 @@ CHAR-LIMIT guidelines:
+diff --git a/chrome/browser/ui/android/strings/android_chrome_strings.grd b/chrome/browser/ui/android/strings/android_chrome_strings.grd
+index fbf454517d95..6430e6bc8013 100644
+--- a/chrome/browser/ui/android/strings/android_chrome_strings.grd
++++ b/chrome/browser/ui/android/strings/android_chrome_strings.grd
+@@ -741,12 +741,6 @@ CHAR-LIMIT guidelines:
        <message name="IDS_PREFS_PRIVACY" desc="Title for the Privacy preferences. [CHAR-LIMIT=32]">
          Privacy
        </message>
@@ -124,5 +124,5 @@ index e70c97cca1f3..5700b086be76 100644
          Safe Browsing (protects you and your device from dangerous sites)
        </message>
 -- 
-2.24.0
+2.25.0
 

--- a/0042-remove-usage-and-crash-reports-preference.patch
+++ b/0042-remove-usage-and-crash-reports-preference.patch
@@ -1,4 +1,4 @@
-From 5953ec9244d12ff1de3185b0d1e0c355babea73d Mon Sep 17 00:00:00 2001
+From a7dc1d57ef74efd62a1d448e458281373275c14d Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Fri, 2 Aug 2019 23:49:13 -0400
 Subject: [PATCH 42/49] remove usage and crash reports preference
@@ -6,35 +6,35 @@ Subject: [PATCH 42/49] remove usage and crash reports preference
 ---
  .../res/xml/sync_and_services_preferences.xml | 10 +++----
  .../sync/SyncAndServicesPreferences.java      | 26 +++++++++----------
- .../java/strings/android_chrome_strings.grd   | 12 ++++-----
+ .../strings/android_chrome_strings.grd        | 12 ++++-----
  3 files changed, 24 insertions(+), 24 deletions(-)
 
 diff --git a/chrome/android/java/res/xml/sync_and_services_preferences.xml b/chrome/android/java/res/xml/sync_and_services_preferences.xml
-index 84dd60f1b7b8..f354e994e436 100644
+index 791de37cd2c6..039a0c06630b 100644
 --- a/chrome/android/java/res/xml/sync_and_services_preferences.xml
 +++ b/chrome/android/java/res/xml/sync_and_services_preferences.xml
 @@ -69,11 +69,11 @@
              <!--android:title="@string/safe_browsing_scout_reporting_title"-->
              <!--android:summary="@string/safe_browsing_scout_reporting_summary"-->
              <!--android:persistent="false"/>-->
--        <org.chromium.chrome.browser.preferences.ChromeSwitchPreference
+-        <org.chromium.chrome.browser.settings.ChromeSwitchPreference
 -            android:key="usage_and_crash_reports"
 -            android:title="@string/usage_and_crash_reports_title"
 -            android:summary="@string/usage_and_crash_reports_summary"
 -            android:persistent="false"/>
-+        <!--<org.chromium.chrome.browser.preferences.ChromeSwitchPreference-->
++        <!--<org.chromium.chrome.browser.settings.ChromeSwitchPreference-->
 +            <!--android:key="usage_and_crash_reports"-->
 +            <!--android:title="@string/usage_and_crash_reports_title"-->
 +            <!--android:summary="@string/usage_and_crash_reports_summary"-->
 +            <!--android:persistent="false"/>-->
-         <org.chromium.chrome.browser.preferences.ChromeSwitchPreference
+         <org.chromium.chrome.browser.settings.ChromeSwitchPreference
              android:key="url_keyed_anonymized_data"
              android:title="@string/url_keyed_anonymized_data_title"
-diff --git a/chrome/android/java/src/org/chromium/chrome/browser/preferences/sync/SyncAndServicesPreferences.java b/chrome/android/java/src/org/chromium/chrome/browser/preferences/sync/SyncAndServicesPreferences.java
-index dc6361c4ea0d..1c1886c2f312 100644
---- a/chrome/android/java/src/org/chromium/chrome/browser/preferences/sync/SyncAndServicesPreferences.java
-+++ b/chrome/android/java/src/org/chromium/chrome/browser/preferences/sync/SyncAndServicesPreferences.java
-@@ -101,7 +101,7 @@ public class SyncAndServicesPreferences extends PreferenceFragmentCompat
+diff --git a/chrome/android/java/src/org/chromium/chrome/browser/settings/sync/SyncAndServicesPreferences.java b/chrome/android/java/src/org/chromium/chrome/browser/settings/sync/SyncAndServicesPreferences.java
+index 744917161c9d..30f19ebfd915 100644
+--- a/chrome/android/java/src/org/chromium/chrome/browser/settings/sync/SyncAndServicesPreferences.java
++++ b/chrome/android/java/src/org/chromium/chrome/browser/settings/sync/SyncAndServicesPreferences.java
+@@ -108,7 +108,7 @@ public class SyncAndServicesPreferences extends PreferenceFragmentCompat
      private static final String PREF_PASSWORD_LEAK_DETECTION = "password_leak_detection";
      //private static final String PREF_SAFE_BROWSING_SCOUT_REPORTING =
              //"safe_browsing_scout_reporting";
@@ -43,7 +43,7 @@ index dc6361c4ea0d..1c1886c2f312 100644
      private static final String PREF_URL_KEYED_ANONYMIZED_DATA = "url_keyed_anonymized_data";
      private static final String PREF_CONTEXTUAL_SEARCH = "contextual_search";
  
-@@ -142,7 +142,7 @@ public class SyncAndServicesPreferences extends PreferenceFragmentCompat
+@@ -151,7 +151,7 @@ public class SyncAndServicesPreferences extends PreferenceFragmentCompat
      private ChromeSwitchPreference mSafeBrowsing;
      private @Nullable ChromeSwitchPreference mPasswordLeakDetection;
      //private ChromeSwitchPreference mSafeBrowsingReporting;
@@ -52,7 +52,7 @@ index dc6361c4ea0d..1c1886c2f312 100644
      private ChromeSwitchPreference mUrlKeyedAnonymizedData;
      private @Nullable Preference mContextualSearch;
  
-@@ -230,10 +230,10 @@ public class SyncAndServicesPreferences extends PreferenceFragmentCompat
+@@ -236,10 +236,10 @@ public class SyncAndServicesPreferences extends PreferenceFragmentCompat
          //mSafeBrowsingReporting.setOnPreferenceChangeListener(this);
          //mSafeBrowsingReporting.setManagedPreferenceDelegate(mManagedPreferenceDelegate);
  
@@ -67,10 +67,10 @@ index dc6361c4ea0d..1c1886c2f312 100644
  
          mUrlKeyedAnonymizedData =
                  (ChromeSwitchPreference) findPreference(PREF_URL_KEYED_ANONYMIZED_DATA);
-@@ -362,8 +362,8 @@ public class SyncAndServicesPreferences extends PreferenceFragmentCompat
-             //mPrefServiceBridge.setSafeBrowsingExtendedReportingEnabled((boolean) newValue);
+@@ -378,8 +378,8 @@ public class SyncAndServicesPreferences extends PreferenceFragmentCompat
+             //SafeBrowsingBridge.setSafeBrowsingExtendedReportingEnabled((boolean) newValue);
          //} else if (PREF_NAVIGATION_ERROR.equals(key)) {
-             //mPrefServiceBridge.setResolveNavigationErrorEnabled((boolean) newValue);
+             //mPrefServiceBridge.setBoolean(Pref.ALTERNATE_ERROR_PAGES_ENABLED, (boolean) newValue);
 -        } else if (PREF_USAGE_AND_CRASH_REPORTING.equals(key)) {
 -            UmaSessionStats.changeMetricsReportingConsent((boolean) newValue);
 +        //} else if (PREF_USAGE_AND_CRASH_REPORTING.equals(key)) {
@@ -78,7 +78,7 @@ index dc6361c4ea0d..1c1886c2f312 100644
          } else if (PREF_URL_KEYED_ANONYMIZED_DATA.equals(key)) {
              UnifiedConsentServiceBridge.setUrlKeyedAnonymizedDataCollectionEnabled(
                      (boolean) newValue);
-@@ -565,8 +565,8 @@ public class SyncAndServicesPreferences extends PreferenceFragmentCompat
+@@ -605,8 +605,8 @@ public class SyncAndServicesPreferences extends PreferenceFragmentCompat
  
          updateLeakDetectionAndSafeBrowsingReportingPreferences();
  
@@ -89,24 +89,24 @@ index dc6361c4ea0d..1c1886c2f312 100644
          mUrlKeyedAnonymizedData.setChecked(
                  UnifiedConsentServiceBridge.isUrlKeyedAnonymizedDataCollectionEnabled());
  
-@@ -668,9 +668,9 @@ public class SyncAndServicesPreferences extends PreferenceFragmentCompat
+@@ -709,9 +709,9 @@ public class SyncAndServicesPreferences extends PreferenceFragmentCompat
                  return mPrefServiceBridge.isManagedPreference(
                          Pref.PASSWORD_MANAGER_LEAK_DETECTION_ENABLED);
              }
 -            if (PREF_USAGE_AND_CRASH_REPORTING.equals(key)) {
--                return mPrefServiceBridge.isMetricsReportingManaged();
+-                return PrivacyPreferencesManager.getInstance().isMetricsReportingManaged();
 -            }
 +            //if (PREF_USAGE_AND_CRASH_REPORTING.equals(key)) {
-+                //return mPrefServiceBridge.isMetricsReportingManaged();
++                //return PrivacyPreferencesManager.getInstance().isMetricsReportingManaged();
 +            //}
              if (PREF_URL_KEYED_ANONYMIZED_DATA.equals(key)) {
                  return UnifiedConsentServiceBridge.isUrlKeyedAnonymizedDataCollectionManaged();
              }
-diff --git a/chrome/android/java/strings/android_chrome_strings.grd b/chrome/android/java/strings/android_chrome_strings.grd
-index 5700b086be76..0ef603c42e43 100644
---- a/chrome/android/java/strings/android_chrome_strings.grd
-+++ b/chrome/android/java/strings/android_chrome_strings.grd
-@@ -415,12 +415,12 @@ CHAR-LIMIT guidelines:
+diff --git a/chrome/browser/ui/android/strings/android_chrome_strings.grd b/chrome/browser/ui/android/strings/android_chrome_strings.grd
+index 6430e6bc8013..64569d8dde6c 100644
+--- a/chrome/browser/ui/android/strings/android_chrome_strings.grd
++++ b/chrome/browser/ui/android/strings/android_chrome_strings.grd
+@@ -445,12 +445,12 @@ CHAR-LIMIT guidelines:
        <message name="IDS_PRIVACY_SYNC_AND_SERVICES_LINK" desc="The text for Privacy preferences that is shown after all preference rows.">
          For more settings that relate to privacy, security, and data collection, see <ph name="BEGIN_LINK">&lt;link&gt;</ph>Services<ph name="END_LINK">&lt;/link&gt;</ph>
        </message>
@@ -126,5 +126,5 @@ index 5700b086be76..0ef603c42e43 100644
          Cancel sync?
        </message>
 -- 
-2.24.0
+2.25.0
 

--- a/0043-remove-url-keyed-anonymized-data-preference.patch
+++ b/0043-remove-url-keyed-anonymized-data-preference.patch
@@ -1,4 +1,4 @@
-From bb5fd0f44e8835f3e7c5a0a7363975161bd5f5f8 Mon Sep 17 00:00:00 2001
+From d22b821d7d689646158db29297201bf0e529f08d Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Fri, 2 Aug 2019 23:50:03 -0400
 Subject: [PATCH 43/49] remove url keyed anonymized data preference
@@ -6,35 +6,35 @@ Subject: [PATCH 43/49] remove url keyed anonymized data preference
 ---
  .../res/xml/sync_and_services_preferences.xml | 10 +++----
  .../sync/SyncAndServicesPreferences.java      | 28 +++++++++----------
- .../java/strings/android_chrome_strings.grd   | 12 ++++----
+ .../strings/android_chrome_strings.grd        | 12 ++++----
  3 files changed, 25 insertions(+), 25 deletions(-)
 
 diff --git a/chrome/android/java/res/xml/sync_and_services_preferences.xml b/chrome/android/java/res/xml/sync_and_services_preferences.xml
-index f354e994e436..e9bfb5d668e1 100644
+index 039a0c06630b..d9eafcc0dd55 100644
 --- a/chrome/android/java/res/xml/sync_and_services_preferences.xml
 +++ b/chrome/android/java/res/xml/sync_and_services_preferences.xml
 @@ -74,11 +74,11 @@
              <!--android:title="@string/usage_and_crash_reports_title"-->
              <!--android:summary="@string/usage_and_crash_reports_summary"-->
              <!--android:persistent="false"/>-->
--        <org.chromium.chrome.browser.preferences.ChromeSwitchPreference
+-        <org.chromium.chrome.browser.settings.ChromeSwitchPreference
 -            android:key="url_keyed_anonymized_data"
 -            android:title="@string/url_keyed_anonymized_data_title"
 -            android:summary="@string/url_keyed_anonymized_data_summary"
 -            android:persistent="false"/>
-+        <!--<org.chromium.chrome.browser.preferences.ChromeSwitchPreference-->
++        <!--<org.chromium.chrome.browser.settings.ChromeSwitchPreference-->
 +            <!--android:key="url_keyed_anonymized_data"-->
 +            <!--android:title="@string/url_keyed_anonymized_data_title"-->
 +            <!--android:summary="@string/url_keyed_anonymized_data_summary"-->
 +            <!--android:persistent="false"/>-->
-         <org.chromium.chrome.browser.preferences.ChromeBasePreference
+         <org.chromium.chrome.browser.settings.ChromeBasePreference
              android:key="contextual_search"
              android:title="@string/contextual_search_title"
-diff --git a/chrome/android/java/src/org/chromium/chrome/browser/preferences/sync/SyncAndServicesPreferences.java b/chrome/android/java/src/org/chromium/chrome/browser/preferences/sync/SyncAndServicesPreferences.java
-index 1c1886c2f312..7bcb741b7d9d 100644
---- a/chrome/android/java/src/org/chromium/chrome/browser/preferences/sync/SyncAndServicesPreferences.java
-+++ b/chrome/android/java/src/org/chromium/chrome/browser/preferences/sync/SyncAndServicesPreferences.java
-@@ -102,7 +102,7 @@ public class SyncAndServicesPreferences extends PreferenceFragmentCompat
+diff --git a/chrome/android/java/src/org/chromium/chrome/browser/settings/sync/SyncAndServicesPreferences.java b/chrome/android/java/src/org/chromium/chrome/browser/settings/sync/SyncAndServicesPreferences.java
+index 30f19ebfd915..8d7be584ab7e 100644
+--- a/chrome/android/java/src/org/chromium/chrome/browser/settings/sync/SyncAndServicesPreferences.java
++++ b/chrome/android/java/src/org/chromium/chrome/browser/settings/sync/SyncAndServicesPreferences.java
+@@ -109,7 +109,7 @@ public class SyncAndServicesPreferences extends PreferenceFragmentCompat
      //private static final String PREF_SAFE_BROWSING_SCOUT_REPORTING =
              //"safe_browsing_scout_reporting";
      //private static final String PREF_USAGE_AND_CRASH_REPORTING = "usage_and_crash_reports";
@@ -43,7 +43,7 @@ index 1c1886c2f312..7bcb741b7d9d 100644
      private static final String PREF_CONTEXTUAL_SEARCH = "contextual_search";
  
      @IntDef({SyncError.NO_ERROR, SyncError.ANDROID_SYNC_DISABLED, SyncError.AUTH_ERROR,
-@@ -143,7 +143,7 @@ public class SyncAndServicesPreferences extends PreferenceFragmentCompat
+@@ -152,7 +152,7 @@ public class SyncAndServicesPreferences extends PreferenceFragmentCompat
      private @Nullable ChromeSwitchPreference mPasswordLeakDetection;
      //private ChromeSwitchPreference mSafeBrowsingReporting;
      //private ChromeSwitchPreference mUsageAndCrashReporting;
@@ -52,7 +52,7 @@ index 1c1886c2f312..7bcb741b7d9d 100644
      private @Nullable Preference mContextualSearch;
  
      private ProfileSyncService.SyncSetupInProgressHandle mSyncSetupInProgressHandle;
-@@ -235,10 +235,10 @@ public class SyncAndServicesPreferences extends PreferenceFragmentCompat
+@@ -241,10 +241,10 @@ public class SyncAndServicesPreferences extends PreferenceFragmentCompat
          //mUsageAndCrashReporting.setOnPreferenceChangeListener(this);
          //mUsageAndCrashReporting.setManagedPreferenceDelegate(mManagedPreferenceDelegate);
  
@@ -67,8 +67,8 @@ index 1c1886c2f312..7bcb741b7d9d 100644
  
          mContextualSearch = findPreference(PREF_CONTEXTUAL_SEARCH);
          if (!ContextualSearchFieldTrial.isEnabled()) {
-@@ -364,9 +364,9 @@ public class SyncAndServicesPreferences extends PreferenceFragmentCompat
-             //mPrefServiceBridge.setResolveNavigationErrorEnabled((boolean) newValue);
+@@ -380,9 +380,9 @@ public class SyncAndServicesPreferences extends PreferenceFragmentCompat
+             //mPrefServiceBridge.setBoolean(Pref.ALTERNATE_ERROR_PAGES_ENABLED, (boolean) newValue);
          //} else if (PREF_USAGE_AND_CRASH_REPORTING.equals(key)) {
              //UmaSessionStats.changeMetricsReportingConsent((boolean) newValue);
 -        } else if (PREF_URL_KEYED_ANONYMIZED_DATA.equals(key)) {
@@ -80,7 +80,7 @@ index 1c1886c2f312..7bcb741b7d9d 100644
          }
          return true;
      }
-@@ -567,8 +567,8 @@ public class SyncAndServicesPreferences extends PreferenceFragmentCompat
+@@ -607,8 +607,8 @@ public class SyncAndServicesPreferences extends PreferenceFragmentCompat
  
          //mUsageAndCrashReporting.setChecked(
                  //mPrivacyPrefManager.isUsageAndCrashReportingPermittedByUser());
@@ -90,10 +90,10 @@ index 1c1886c2f312..7bcb741b7d9d 100644
 +                //UnifiedConsentServiceBridge.isUrlKeyedAnonymizedDataCollectionEnabled());
  
          if (mContextualSearch != null) {
-             boolean isContextualSearchEnabled = !mPrefServiceBridge.isContextualSearchDisabled();
-@@ -671,9 +671,9 @@ public class SyncAndServicesPreferences extends PreferenceFragmentCompat
+             boolean isContextualSearchEnabled =
+@@ -712,9 +712,9 @@ public class SyncAndServicesPreferences extends PreferenceFragmentCompat
              //if (PREF_USAGE_AND_CRASH_REPORTING.equals(key)) {
-                 //return mPrefServiceBridge.isMetricsReportingManaged();
+                 //return PrivacyPreferencesManager.getInstance().isMetricsReportingManaged();
              //}
 -            if (PREF_URL_KEYED_ANONYMIZED_DATA.equals(key)) {
 -                return UnifiedConsentServiceBridge.isUrlKeyedAnonymizedDataCollectionManaged();
@@ -104,11 +104,11 @@ index 1c1886c2f312..7bcb741b7d9d 100644
              return false;
          };
      }
-diff --git a/chrome/android/java/strings/android_chrome_strings.grd b/chrome/android/java/strings/android_chrome_strings.grd
-index 0ef603c42e43..4b52516670e3 100644
---- a/chrome/android/java/strings/android_chrome_strings.grd
-+++ b/chrome/android/java/strings/android_chrome_strings.grd
-@@ -406,12 +406,12 @@ CHAR-LIMIT guidelines:
+diff --git a/chrome/browser/ui/android/strings/android_chrome_strings.grd b/chrome/browser/ui/android/strings/android_chrome_strings.grd
+index 64569d8dde6c..15cd2a991366 100644
+--- a/chrome/browser/ui/android/strings/android_chrome_strings.grd
++++ b/chrome/browser/ui/android/strings/android_chrome_strings.grd
+@@ -436,12 +436,12 @@ CHAR-LIMIT guidelines:
        <!--<message name="IDS_NAVIGATION_ERROR_SUGGESTIONS_SUMMARY" desc="Summary for a checkbox in Settings that controls pages suggestions on navigation errors and informs the user about the data shared by this feature.">-->
          <!--Sends the URL of a page you're trying to reach to Google-->
        <!--</message>-->
@@ -128,5 +128,5 @@ index 0ef603c42e43..4b52516670e3 100644
          For more settings that relate to privacy, security, and data collection, see <ph name="BEGIN_LINK">&lt;link&gt;</ph>Services<ph name="END_LINK">&lt;/link&gt;</ph>
        </message>
 -- 
-2.24.0
+2.25.0
 

--- a/0044-disable-contextual-search-by-default.patch
+++ b/0044-disable-contextual-search-by-default.patch
@@ -1,4 +1,4 @@
-From 112b5f1b608d02aa49775299af73d98a23e5154b Mon Sep 17 00:00:00 2001
+From ddaf9bc272b567152b51e261f62e3d577db8b779 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Sat, 3 Aug 2019 00:28:49 -0400
 Subject: [PATCH 44/49] disable contextual search by default
@@ -8,7 +8,7 @@ Subject: [PATCH 44/49] disable contextual search by default
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/chrome/android/java/src/org/chromium/chrome/browser/contextualsearch/ContextualSearchFieldTrial.java b/chrome/android/java/src/org/chromium/chrome/browser/contextualsearch/ContextualSearchFieldTrial.java
-index 44061ca06a1e..49eb617d49f6 100644
+index 340408510b90..521b4f3bc565 100644
 --- a/chrome/android/java/src/org/chromium/chrome/browser/contextualsearch/ContextualSearchFieldTrial.java
 +++ b/chrome/android/java/src/org/chromium/chrome/browser/contextualsearch/ContextualSearchFieldTrial.java
 @@ -286,7 +286,7 @@ public class ContextualSearchFieldTrial {
@@ -21,5 +21,5 @@ index 44061ca06a1e..49eb617d49f6 100644
  
      /**
 -- 
-2.24.0
+2.25.0
 

--- a/0045-remove-redundant-services-preference-category.patch
+++ b/0045-remove-redundant-services-preference-category.patch
@@ -1,20 +1,20 @@
-From f07d86e02205719e1d7c9a121ca55ba0c0000aa4 Mon Sep 17 00:00:00 2001
+From b5c3b0cbc76804d4552967b4cefdd01b2a183fb1 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Sat, 3 Aug 2019 00:34:43 -0400
 Subject: [PATCH 45/49] remove redundant services preference category
 
 ---
  .../java/res/xml/sync_and_services_preferences.xml     |  8 ++++----
- .../preferences/sync/SyncAndServicesPreferences.java   | 10 +++++-----
- chrome/android/java/strings/android_chrome_strings.grd |  6 +++---
+ .../settings/sync/SyncAndServicesPreferences.java      | 10 +++++-----
+ .../ui/android/strings/android_chrome_strings.grd      |  6 +++---
  3 files changed, 12 insertions(+), 12 deletions(-)
 
 diff --git a/chrome/android/java/res/xml/sync_and_services_preferences.xml b/chrome/android/java/res/xml/sync_and_services_preferences.xml
-index e9bfb5d668e1..6925a5226075 100644
+index d9eafcc0dd55..cdb348c4cdf1 100644
 --- a/chrome/android/java/res/xml/sync_and_services_preferences.xml
 +++ b/chrome/android/java/res/xml/sync_and_services_preferences.xml
 @@ -41,9 +41,9 @@
-             <!--android:fragment="org.chromium.chrome.browser.preferences.sync.ManageSyncPreferences"/>-->
+             <!--android:fragment="org.chromium.chrome.browser.settings.sync.ManageSyncPreferences"/>-->
      <!--</PreferenceCategory>-->
  
 -    <PreferenceCategory
@@ -24,20 +24,20 @@ index e9bfb5d668e1..6925a5226075 100644
 +        <!--android:key="services_category"-->
 +        <!--android:title="@string/services_category_title">-->
  
-         <org.chromium.chrome.browser.preferences.ChromeSwitchPreference
+         <org.chromium.chrome.browser.settings.ChromeSwitchPreference
              android:key="search_suggestions"
 @@ -83,5 +83,5 @@
              android:key="contextual_search"
              android:title="@string/contextual_search_title"
-             android:fragment="org.chromium.chrome.browser.preferences.privacy.ContextualSearchPreferenceFragment"/>
+             android:fragment="org.chromium.chrome.browser.settings.privacy.ContextualSearchPreferenceFragment"/>
 -    </PreferenceCategory>
 +    <!--</PreferenceCategory>-->
  </PreferenceScreen>
-diff --git a/chrome/android/java/src/org/chromium/chrome/browser/preferences/sync/SyncAndServicesPreferences.java b/chrome/android/java/src/org/chromium/chrome/browser/preferences/sync/SyncAndServicesPreferences.java
-index 7bcb741b7d9d..7033f45c4095 100644
---- a/chrome/android/java/src/org/chromium/chrome/browser/preferences/sync/SyncAndServicesPreferences.java
-+++ b/chrome/android/java/src/org/chromium/chrome/browser/preferences/sync/SyncAndServicesPreferences.java
-@@ -94,7 +94,7 @@ public class SyncAndServicesPreferences extends PreferenceFragmentCompat
+diff --git a/chrome/android/java/src/org/chromium/chrome/browser/settings/sync/SyncAndServicesPreferences.java b/chrome/android/java/src/org/chromium/chrome/browser/settings/sync/SyncAndServicesPreferences.java
+index 8d7be584ab7e..04fd311b2f08 100644
+--- a/chrome/android/java/src/org/chromium/chrome/browser/settings/sync/SyncAndServicesPreferences.java
++++ b/chrome/android/java/src/org/chromium/chrome/browser/settings/sync/SyncAndServicesPreferences.java
+@@ -101,7 +101,7 @@ public class SyncAndServicesPreferences extends PreferenceFragmentCompat
      public static final String PREF_SYNC_REQUESTED = "sync_requested";
      private static final String PREF_MANAGE_SYNC = "manage_sync";
  
@@ -46,7 +46,7 @@ index 7bcb741b7d9d..7033f45c4095 100644
      private static final String PREF_SEARCH_SUGGESTIONS = "search_suggestions";
      //private static final String PREF_NAVIGATION_ERROR = "navigation_error";
      private static final String PREF_SAFE_BROWSING = "safe_browsing";
-@@ -213,15 +213,15 @@ public class SyncAndServicesPreferences extends PreferenceFragmentCompat
+@@ -219,15 +219,15 @@ public class SyncAndServicesPreferences extends PreferenceFragmentCompat
          mSafeBrowsing.setOnPreferenceChangeListener(this);
          mSafeBrowsing.setManagedPreferenceDelegate(mManagedPreferenceDelegate);
  
@@ -65,7 +65,7 @@ index 7bcb741b7d9d..7033f45c4095 100644
              mPasswordLeakDetection = null;
          }
  
-@@ -242,7 +242,7 @@ public class SyncAndServicesPreferences extends PreferenceFragmentCompat
+@@ -248,7 +248,7 @@ public class SyncAndServicesPreferences extends PreferenceFragmentCompat
  
          mContextualSearch = findPreference(PREF_CONTEXTUAL_SEARCH);
          if (!ContextualSearchFieldTrial.isEnabled()) {
@@ -74,11 +74,11 @@ index 7bcb741b7d9d..7033f45c4095 100644
              mContextualSearch = null;
          }
  
-diff --git a/chrome/android/java/strings/android_chrome_strings.grd b/chrome/android/java/strings/android_chrome_strings.grd
-index 4b52516670e3..2bc64ad41436 100644
---- a/chrome/android/java/strings/android_chrome_strings.grd
-+++ b/chrome/android/java/strings/android_chrome_strings.grd
-@@ -385,9 +385,9 @@ CHAR-LIMIT guidelines:
+diff --git a/chrome/browser/ui/android/strings/android_chrome_strings.grd b/chrome/browser/ui/android/strings/android_chrome_strings.grd
+index 15cd2a991366..c54507754503 100644
+--- a/chrome/browser/ui/android/strings/android_chrome_strings.grd
++++ b/chrome/browser/ui/android/strings/android_chrome_strings.grd
+@@ -415,9 +415,9 @@ CHAR-LIMIT guidelines:
        <message name="IDS_MANAGE_SYNC_TITLE" desc="Title for the preference row that opens the screen that allows configuring separate data types. Displayed in 'Sync and Google services' screen.">
          Manage sync
        </message>
@@ -92,5 +92,5 @@ index 4b52516670e3..2bc64ad41436 100644
          Autocomplete searches and URLs
        </message>
 -- 
-2.24.0
+2.25.0
 

--- a/0046-redirect-settings-help-icon.patch
+++ b/0046-redirect-settings-help-icon.patch
@@ -1,4 +1,4 @@
-From 52a4c307bf0340dc5bc3e909e8ed6a4717238585 Mon Sep 17 00:00:00 2001
+From 373f9db8bdf77b1edc2e0fbed42eb29ef7a5d578 Mon Sep 17 00:00:00 2001
 From: Zoraver Kang <zkang@wpi.edu>
 Date: Fri, 16 Aug 2019 02:03:45 -0400
 Subject: [PATCH 46/49] redirect settings help icon
@@ -8,7 +8,7 @@ Subject: [PATCH 46/49] redirect settings help icon
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/chrome/android/java/src/org/chromium/chrome/browser/help/HelpAndFeedback.java b/chrome/android/java/src/org/chromium/chrome/browser/help/HelpAndFeedback.java
-index 348ead6d3720..dec619094844 100644
+index 9f884f349f90..222ffa38af8d 100644
 --- a/chrome/android/java/src/org/chromium/chrome/browser/help/HelpAndFeedback.java
 +++ b/chrome/android/java/src/org/chromium/chrome/browser/help/HelpAndFeedback.java
 @@ -30,7 +30,7 @@ import javax.annotation.Nonnull;
@@ -17,9 +17,9 @@ index 348ead6d3720..dec619094844 100644
      protected static final String FALLBACK_SUPPORT_URL =
 -            "https://support.google.com/chrome/topic/6069782";
 +            "https://grapheneos.org/usage#web-browsing";
-     private static final String TAG = "cr_HelpAndFeedback";
+     private static final String TAG = "HelpAndFeedback";
  
      private static HelpAndFeedback sInstance;
 -- 
-2.24.0
+2.25.0
 

--- a/0047-set-default-search-engine-to-DuckDuckGo.patch
+++ b/0047-set-default-search-engine-to-DuckDuckGo.patch
@@ -1,4 +1,4 @@
-From 03897a43fdb0d241c69d12b3081d6c623d7bfb31 Mon Sep 17 00:00:00 2001
+From d9d8b3c78c09a206eeae245d08efbb43dfa10423 Mon Sep 17 00:00:00 2001
 From: Zoraver Kang <zkang@wpi.edu>
 Date: Sat, 17 Aug 2019 15:53:50 -0400
 Subject: [PATCH 47/49] set default search engine to DuckDuckGo
@@ -8,7 +8,7 @@ Subject: [PATCH 47/49] set default search engine to DuckDuckGo
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/components/search_engines/template_url_prepopulate_data.cc b/components/search_engines/template_url_prepopulate_data.cc
-index 52dd123a9294..d0a06bb2cae5 100644
+index afd8d81a177b..e4a2960869e6 100644
 --- a/components/search_engines/template_url_prepopulate_data.cc
 +++ b/components/search_engines/template_url_prepopulate_data.cc
 @@ -1280,7 +1280,7 @@ std::vector<std::unique_ptr<TemplateURLData>> GetPrepopulatedEngines(
@@ -21,5 +21,5 @@ index 52dd123a9294..d0a06bb2cae5 100644
          itr == t_urls.end() ? 0 : std::distance(t_urls.begin(), itr);
    }
 -- 
-2.24.0
+2.25.0
 

--- a/0048-temporarily-disable-AImageReader-support.patch
+++ b/0048-temporarily-disable-AImageReader-support.patch
@@ -1,4 +1,4 @@
-From 376452a5ea0066e0f89f75aa49e933c5dd829de8 Mon Sep 17 00:00:00 2001
+From 40b27e717c7a5e3c998d71660898c114f7b6515d Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Sat, 26 Oct 2019 00:16:58 -0400
 Subject: [PATCH 48/49] temporarily disable AImageReader support
@@ -12,10 +12,10 @@ https://bugs.chromium.org/p/chromium/issues/detail?id=977583
  2 files changed, 5 insertions(+), 5 deletions(-)
 
 diff --git a/gpu/ipc/service/gpu_init.cc b/gpu/ipc/service/gpu_init.cc
-index 0aa6832893e7..f76131050d93 100644
+index 1aeba67edd48..b8b7d22daed8 100644
 --- a/gpu/ipc/service/gpu_init.cc
 +++ b/gpu/ipc/service/gpu_init.cc
-@@ -493,9 +493,9 @@ bool GpuInit::InitializeAndStartSandbox(base::CommandLine* command_line,
+@@ -491,9 +491,9 @@ bool GpuInit::InitializeAndStartSandbox(base::CommandLine* command_line,
  
  #if defined(OS_ANDROID)
    // Disable AImageReader if the workaround is enabled.
@@ -27,7 +27,7 @@ index 0aa6832893e7..f76131050d93 100644
  #endif
  #if defined(USE_OZONE)
    gpu_feature_info_.supported_buffer_formats_for_allocation_and_texturing =
-@@ -523,9 +523,9 @@ void GpuInit::InitializeInProcess(base::CommandLine* command_line,
+@@ -522,9 +522,9 @@ void GpuInit::InitializeInProcess(base::CommandLine* command_line,
    default_offscreen_surface_ = gl::init::CreateOffscreenGLSurface(gfx::Size());
  
    // Disable AImageReader if the workaround is enabled.
@@ -40,10 +40,10 @@ index 0aa6832893e7..f76131050d93 100644
    UMA_HISTOGRAM_ENUMERATION("GPU.GLImplementation", gl::GetGLImplementation());
  }
 diff --git a/media/base/media_switches.cc b/media/base/media_switches.cc
-index e7c7c5374c04..c805afbec9b6 100644
+index 5f33919f151f..bdb8c75840a2 100644
 --- a/media/base/media_switches.cc
 +++ b/media/base/media_switches.cc
-@@ -457,7 +457,7 @@ const base::Feature kMediaDrmPreprovisioningAtStartup{
+@@ -491,7 +491,7 @@ const base::Feature kMediaDrmPreprovisioningAtStartup{
  
  // Enables the Android Image Reader path for Video decoding(for AVDA and MCVD)
  const base::Feature kAImageReaderVideoOutput{"AImageReaderVideoOutput",
@@ -53,5 +53,5 @@ index e7c7c5374c04..c805afbec9b6 100644
  // Prevents using SurfaceLayer for videos. This is meant to be used by embedders
  // that cannot support SurfaceLayer at the moment.
 -- 
-2.24.1
+2.25.0
 

--- a/0049-disable-trivial-subdomain-hiding.patch
+++ b/0049-disable-trivial-subdomain-hiding.patch
@@ -1,4 +1,4 @@
-From 86226fa015173fa56177607f7fbdebcc3bf221a2 Mon Sep 17 00:00:00 2001
+From 7a913d056265ca2b22ed6bc0c4f22ee1456b33aa Mon Sep 17 00:00:00 2001
 From: JTL <jtl@teamclassified.ca>
 Date: Sat, 21 Dec 2019 04:04:24 +0000
 Subject: [PATCH 49/49] disable trivial subdomain hiding
@@ -8,10 +8,10 @@ Subject: [PATCH 49/49] disable trivial subdomain hiding
  1 file changed, 1 insertion(+), 2 deletions(-)
 
 diff --git a/components/url_formatter/url_formatter.cc b/components/url_formatter/url_formatter.cc
-index 8ca7fdf58e5c..9f29d2fef21b 100644
+index 58cadb980bb8..afae1ebcda5f 100644
 --- a/components/url_formatter/url_formatter.cc
 +++ b/components/url_formatter/url_formatter.cc
-@@ -559,8 +559,7 @@ base::string16 FormatUrlWithAdjustments(
+@@ -586,8 +586,7 @@ base::string16 FormatUrlWithAdjustments(
      *prefix_end = static_cast<size_t>(url_string.length());
  
    // Host.
@@ -22,5 +22,5 @@ index 8ca7fdf58e5c..9f29d2fef21b 100644
                             HostComponentTransform(trim_trivial_subdomains),
                             &url_string, &new_parsed->host, adjustments);
 -- 
-2.24.0
+2.25.0
 

--- a/args.gn
+++ b/args.gn
@@ -3,8 +3,8 @@ target_os = "android"
 target_cpu = "arm64"
 
 android_channel = "stable"
-android_default_version_name = "79.0.3945.136"
-android_default_version_code = "394513600"
+android_default_version_name = "80.0.3987.87"
+android_default_version_code = "398708700"
 
 is_component_build = false
 is_debug = false


### PR DESCRIPTION
This PR updates the Vanadium patch set to 80.0.3987.87, the latest stable Chromium release as of today. This should hopefully close #43 as webview built from chromium sources should be working again as of chromium 80.

Note that I'm currently building and testing this branch to make sure nothing broke. There was some refactoring upstream, particularly in the preference settings code, so there were a good deal of merge conflicts that had to be resolved manually. I'll update this thread once I've had a chance to finish the build and do some testing.