### PR TITLE
Disable V8 JIT

### DIFF
--- a/0001-use-64-bit-WebView-processes.patch
+++ b/0001-use-64-bit-WebView-processes.patch
@@ -1,7 +1,7 @@
-From 9872d110973e844464e5087bc35f80a67a263933 Mon Sep 17 00:00:00 2001
+From 9b6197e508dcdc3ecbf64bb02e9f6a2ac4965e59 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Thu, 26 Jan 2017 01:30:12 -0500
-Subject: [PATCH 01/52] use 64-bit WebView processes
+Subject: [PATCH 01/53] use 64-bit WebView processes
 
 ---
  android_webview/nonembedded/java/AndroidManifest.xml | 1 -
@@ -20,5 +20,5 @@ index c9dea7bfb8c7..c6cdceed002d 100644
          {# This part is shared between stand-alone WebView and Monochrome #}
          {% macro common(manifest_package, webview_lib) %}
 -- 
-2.25.1
+2.21.1
 

--- a/0002-switch-to-fstack-protector-strong.patch
+++ b/0002-switch-to-fstack-protector-strong.patch
@@ -1,7 +1,7 @@
-From 4088a6b5a639aa208ebbaad12fbfcb3343e4601a Mon Sep 17 00:00:00 2001
+From 06b6456ad465e310686582c8b6d24dcfedcd5862 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Wed, 26 Dec 2018 10:20:24 -0500
-Subject: [PATCH 02/52] switch to -fstack-protector-strong
+Subject: [PATCH 02/53] switch to -fstack-protector-strong
 
 ---
  build/config/compiler/BUILD.gn | 6 +-----
@@ -30,5 +30,5 @@ index fbf8335f11ba..63eb5c03701e 100644
      }
  
 -- 
-2.25.1
+2.21.1
 

--- a/0003-enable-fwrapv-in-Clang-for-non-UBSan-builds.patch
+++ b/0003-enable-fwrapv-in-Clang-for-non-UBSan-builds.patch
@@ -1,7 +1,7 @@
-From 03831c72cd47831db32f042b37abb2d195b4ebf7 Mon Sep 17 00:00:00 2001
+From b91bc52cb38cdd65ffa08c4286b96bb6187ffa1c Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Thu, 22 Dec 2016 07:15:34 -0500
-Subject: [PATCH 03/52] enable -fwrapv in Clang for non-UBSan builds
+Subject: [PATCH 03/53] enable -fwrapv in Clang for non-UBSan builds
 
 ---
  build/config/compiler/BUILD.gn | 4 ++++
@@ -23,5 +23,5 @@ index 63eb5c03701e..e9f7a8cfdfca 100644
      if (fatal_linker_warnings && !(is_chromeos && current_cpu == "arm") &&
          !is_mac && !is_ios && current_os != "aix") {
 -- 
-2.25.1
+2.21.1
 

--- a/0004-Vanadium-branding.patch
+++ b/0004-Vanadium-branding.patch
@@ -1,7 +1,7 @@
-From 0467c43a2db39e616604821f21b4bb276273d130 Mon Sep 17 00:00:00 2001
+From 3925e5aa29545a31ee77df5c3419fca0aeef3a47 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Sun, 6 Aug 2017 12:45:14 -0400
-Subject: [PATCH 04/52] Vanadium branding
+Subject: [PATCH 04/53] Vanadium branding
 
 Current incantation of the recolor command:
 
@@ -105,7 +105,7 @@ new file mode 100644
 index 0000000000000000000000000000000000000000..d9d6661c938b2907e30da3ae87cdb2894db5592d
 GIT binary patch
 literal 11327
-zc-jF!EWp!=P)<h;3K|Lk000e1NJLTq006@P006@X1ONa4m3D0*00002VoOIv0RM-N
+zcmV-FEWp!=P)<h;3K|Lk000e1NJLTq006@P006@X1ONa4m3D0*00002VoOIv0RM-N
 z%)bBtEBHx7K~#9!?VWj)99MnsKlfJkKKmk#mXTyhSd#Y*%Ra`5ZCUog#tV)yF&KC+
 z<|GDU90K9Jge8O+2<PDNut@^%ybwqX4mOD~#x|Rm=jGuAZ?Y}P+NBwdW}lwvwYsb7
 zzCWs$s-B*i?&)QO$#0HE)79N|Z~eaax7^?T-QN}0Q9VgAq==9~B1y1@DNLZ1EKwAS
@@ -326,14 +326,14 @@ zJ0a3!Go$*HoHB+u);$m(um^Pmpo6HZ%F^*i{~yS0JYSiOkN*Gw002ovPDHLkV1iRV
 Bx8MK(
 
 literal 0
-Hc-jL100001
+HcmV?d00001
 
 diff --git a/chrome/android/java/res_vanadium/drawable-hdpi/product_logo_name.png b/chrome/android/java/res_vanadium/drawable-hdpi/product_logo_name.png
 new file mode 100644
 index 0000000000000000000000000000000000000000..8678cbbb730de9c3ff9d3dba7d928d60f28bd550
 GIT binary patch
 literal 1998
-zc-jHZ2Qm1GP)<h;3K|Lk000e1NJLTq005f+001Be1ONa4uVuoq00002VoOIv0RM-N
+zcmV;<2Qm1GP)<h;3K|Lk000e1NJLTq005f+001Be1ONa4uVuoq00002VoOIv0RM-N
 z%)bBt2Zu>SK~!ko<=J0sWOWq>@Xx*Tue$}h(?xgL^$(e{1YKD$ttiGof~^Vx9)MOu
 zG$zJ$V+<<#(2`(G2$D7sv-n`r`s9OR+7Oj!jP4K>9x$+jvMdlpCd<G5<L-9a?Y7g-
 zOlN%PbUM?eP`V|f@STVG{k!LP&i9^kf9KpA+yX)cp|aCLam8fei-l{8d&(cGTp%zN
@@ -374,14 +374,14 @@ zza1|{8eS^B9}!%))KF3pS28cMJ#j<i+Hm*uwq56aHaKx+;rQJ1`Nz)uvHbcbt!9+#
 gs)YxeZ9!A;U++Vmx7pctfdBvi07*qoM6N<$g5_ZC5&!@I
 
 literal 0
-Hc-jL100001
+HcmV?d00001
 
 diff --git a/chrome/android/java/res_vanadium/drawable-mdpi/fre_product_logo.png b/chrome/android/java/res_vanadium/drawable-mdpi/fre_product_logo.png
 new file mode 100644
 index 0000000000000000000000000000000000000000..40b88b5225ddff2fb47116a99a38999218e744ec
 GIT binary patch
 literal 6794
-zc-jGq8g=D~P)<h;3K|Lk000e1NJLTq004pj004pr1ONa4APU%a00002VoOIv0RM-N
+zcmV;58g=D~P)<h;3K|Lk000e1NJLTq004pj004pr1ONa4APU%a00002VoOIv0RM-N
 z%)bBt8be7$K~#9!)tz~iB*lH_KM{G<)z|bjJ@>)D%!mO-Fw7-DAPmTokc7~a^mM>3
 zZzcS8pLT_9R@Sb(&)T)*U3n#2eztCw(_%quSrW30g+~aD#AO%`F)++9!yMhycU9M2
 zm6esTe`IDI-BsOnwFSR?U7eMc85!}--xa_3MWpxuOOYgpLdU@%#5jW(oWUeO8V!Yp
@@ -514,14 +514,14 @@ zhj>D$5MmkU-7e!>Q2kdIXfIhW74NXI16-hOVT5&Tll`hE8(I@M7MRpEgsm*{#hgm!
 s;^t9aPfn=Q!52i_!lZI+YPsnD1F3svQs!l<l>h($07*qoM6N<$g1%n2wg3PC
 
 literal 0
-Hc-jL100001
+HcmV?d00001
 
 diff --git a/chrome/android/java/res_vanadium/drawable-mdpi/product_logo_name.png b/chrome/android/java/res_vanadium/drawable-mdpi/product_logo_name.png
 new file mode 100644
 index 0000000000000000000000000000000000000000..5f92063170520afa34dd48fa6610ea122439e916
 GIT binary patch
 literal 1200
-zc-jH51W)^kP)<h;3K|Lk000e1NJLTq003tI000#T1ONa4@uE1m00002VoOIv0RM-N
+zcmV;h1W)^kP)<h;3K|Lk000e1NJLTq003tI000#T1ONa4@uE1m00002VoOIv0RM-N
 z%)bBt1Zhb`K~z}7&DURyTy+%(@Xx(>_FsX@O}84i3U(VMgzx}UVwc9o;1FXpBtoWy
 z2j6rWUf_X*Ex|`ac1+~Kw;kh?hR6=+gBnd1V-!O{cS$sAG|)-^n3k4yW}(~d?#%4H
 zJk0Ig(t_M=8p?UO_x{fBob&yjbAEqr@Ss2<(bv_zXSLeh+uv!6mFS39qGs}1Psy+Z
@@ -547,14 +547,14 @@ z^+sAqN|1`A|9R&d!QRnoG_`We?y>N~$>SGZU49|`b6{BT;s2taFnJGY>5Ee&#m%|^
 O0000<MNUMnLSTZ4d0|-q
 
 literal 0
-Hc-jL100001
+HcmV?d00001
 
 diff --git a/chrome/android/java/res_vanadium/drawable-xhdpi/fre_product_logo.png b/chrome/android/java/res_vanadium/drawable-xhdpi/fre_product_logo.png
 new file mode 100644
 index 0000000000000000000000000000000000000000..07ecccb90a3786c3c3d7ac33a3f8cb2d2ee555b2
 GIT binary patch
 literal 16100
-zc-jHvJ{!S_P)<h;3K|Lk000e1NJLTq009I5009ID1ONa4WC4PK00002VoOIv0RM-N
+zcmV<AJ{!S_P)<h;3K|Lk000e1NJLTq009I5009ID1ONa4WC4PK00002VoOIv0RM-N
 z%)bBtKAlNKK~#9!?Y()N9A|y!|9+mT>T52|jP6^OWZ9N1VOvH9-zHeb#!fgw4%lQv
 z$ijkcSV%%nLjpgJCFC%egaq>2WV4%1AUFXM8<TL^1|O0SNyfU5(Tp@#&(+g+RXzJh
 zbx&7!Rrhqy^fjzM^HOW3y6UOt_&(q3`99xAyqU#AATUW`(?ymf-K5CSOD`ws#wNu|
@@ -866,14 +866,14 @@ zHcQ#BHdrh4<*AJ_B6{r&$*>;S8h$!F714vru|u<1B12pyR4S0QllFOiQcu_e_IP%D
 q!#O!IXc-t}kqB(e_H@WD3jY_Ejr#a36nZuQ0000<MNUMnLSTZIDYe}I
 
 literal 0
-Hc-jL100001
+HcmV?d00001
 
 diff --git a/chrome/android/java/res_vanadium/drawable-xhdpi/product_logo_name.png b/chrome/android/java/res_vanadium/drawable-xhdpi/product_logo_name.png
 new file mode 100644
 index 0000000000000000000000000000000000000000..ee268c83d97f8d6b73eac0dbe25a204dcc91d4da
 GIT binary patch
 literal 2609
-zc-jFm3eNS3P)<h;3K|Lk000e1NJLTq007Pa001fo1ONa4QNyg;00002VoOIv0RM-N
+zcmV-13eNS3P)<h;3K|Lk000e1NJLTq007Pa001fo1ONa4QNyg;00002VoOIv0RM-N
 z%)bBt3F=8iK~#9!?VEp$9Az2DKl9G)>|MKe?OY3KEzmHhZ7oJh_b?bl5q6Cl$`8$6
 zVyeMtyrsqjL?Wkupu|7C13_#I&?Eea{E9vN5hVoEGmQ!{$}OUR0>T#Bv=rLj-0j}p
 z?#}Mc_{YxP?flr@59Y4e+;@|^n`hsd?>o=)KF|BS&-<SA1?mt~siI;sg@r%{tPPb<
@@ -926,14 +926,14 @@ zR{4SA1I10^GC3}7F0I#ApB+75niI9R&DV<0m-ZK5R*5d?U#*rgcSy_XegEQref)de
 TPbPHy00000NkvXXu0mjf*Ld(I
 
 literal 0
-Hc-jL100001
+HcmV?d00001
 
 diff --git a/chrome/android/java/res_vanadium/drawable-xxhdpi/fre_product_logo.png b/chrome/android/java/res_vanadium/drawable-xxhdpi/fre_product_logo.png
 new file mode 100644
 index 0000000000000000000000000000000000000000..4f300d7f849b005ba63163d63a643f3aeb737aea
 GIT binary patch
 literal 26693
-zc-jCpK+3;~P)<h;3K|Lk000e1NJLTq00D*o00D*w1ONa4)rszI00002VoOIv0RM-N
+zcmV)WK(4=uP)<h;3K|Lk000e1NJLTq00D*o00D*w1ONa4)rszI00002VoOIv0RM-N
 z%)bBtXZ}e<K~#9!?Y(!LBu9Ps|E}tuxOs2)a#YSbC6rMH1Ok&yFg9R#z!)AIunpLL
 z%wufxke!VaVEiK*3?>O1Bmol20R<$TPP(+WySF*bPV7*>KYC`TXQroTW_M<HW_CaQ
 zy4&5E>h9|5`qVenx4tD_$?8A=kjBJDrvsA(Bz>49u+a!}I!}@z!wwdh;UrRoh%-qC
@@ -1249,7 +1249,7 @@ zdcKKqUq4ciB!{qTmJ6-Wr*uL*_0Tg2KpGerq@K0fPBJ*qNO3#8zT<uz$-B{8IEHn3
 z5G2ug55gx)5<nM6+b~wufriD%p(7mSsG}z7$fu09GoisrTOZ*OCh77ir8C53+`>W=
 zkzqAfmrLe(DVH+jn;lOl#X&6e8Z#xe261c>!<(Mk&NjB?#DU0|Pqs$oYlT2#m^;{1
 zK?R!U{p?|;N#x^dybFzK_VRna>lZ-L&9j^!*y2l}ydlV7{<7cbp@$x1m@r|YaDTh3
-zcPoBe8^Jv+(B;#`0T3wf*90>}crP?X+R4?Rf+UIHeT13ued0h?E@(BTlWdKlRiKF9
+zcPoBe8^Jv+(B;#`1T#c<FEmBk$<?5OB#GdCgqiVu;y_j|Xf>vj0rV#e*ldlVRiKF9
 zzd)QAF{Fisg^lsB*(9T4{U12UP(|6GGsHFgDzj_+8dobLmCYQl<C+R8l1(=UnIKeS
 z{=C+pg0lxv`oY}h?#>J}7UE&M3C6_6;YUo+U*RQ9^M1}{x^BBzHZL@$Igj@-U7=i*
 zMSh7u)-+JI3Kc*jsgl3QkS0w!_ly!XY&^QwRcjOkL5}l%)#Lk`1Pd5^jQ$FN%#Fip
@@ -1449,14 +1449,14 @@ zmdO6dLevV2PCKFk1e8tyg&_<~Vak+T6mgOyRl46yrqzfT&dhB~rQ@;TuHku8A=pF*
 gCy1=|1GgRie-#m>m)v0)5&!@I07*qoM6N<$f-sBn4*&oF
 
 literal 0
-Hc-jL100001
+HcmV?d00001
 
 diff --git a/chrome/android/java/res_vanadium/drawable-xxhdpi/product_logo_name.png b/chrome/android/java/res_vanadium/drawable-xxhdpi/product_logo_name.png
 new file mode 100644
 index 0000000000000000000000000000000000000000..fc327262fd9479d15200e5ebca3f5335a1ce12c4
 GIT binary patch
 literal 4270
-zc-jH35K-@mP)<h;3K|Lk000e1NJLTq00A`s002J-1ONa4EBcpR00002VoOIv0RM-N
+zcmV;f5K-@mP)<h;3K|Lk000e1NJLTq00A`s002J-1ONa4EBcpR00002VoOIv0RM-N
 z%)bBt5NAn5K~#9!?VVe28`pWqe`j}b;Y}oD-6h)*Bwyq{=mJ@mRC}5zU^<Q`Gqz+Z
 zeTeH!(@;q|(_}iGkvxslNj>RMO&_Z1q%mnH(^#G+rXu^L^(CS+aZ^=^B}kQ%Sh6F*
 zvUQ^rkst|@xGb>S2P_r~VlR*kg0O`@W(W{x&+fOoe|+aV-{q{>jujFrDn4X#q|wQs
@@ -1541,14 +1541,14 @@ z*2`;HlJ4qiTN*q=E}fs&#<Ev(?_^F){hCug1Ockg5ozLPfoK}+P1Fbf4>8lX6)B~&
 QLI3~&07*qoM6N<$f)Jt_fB*mh
 
 literal 0
-Hc-jL100001
+HcmV?d00001
 
 diff --git a/chrome/android/java/res_vanadium/drawable-xxxhdpi/fre_product_logo.png b/chrome/android/java/res_vanadium/drawable-xxxhdpi/fre_product_logo.png
 new file mode 100644
 index 0000000000000000000000000000000000000000..52abcdfc19c13770971730c8bd4d8267a633ac22
 GIT binary patch
 literal 39011
-zc-jC^K(D`vP)<h;3K|Lk000e1NJLTq00IaA00IaI1ONa4q4nPA00002VoOIv0RM-N
+zcmV)xK$E|TP)<h;3K|Lk000e1NJLTq00IaA00IaI1ONa4q4nPA00002VoOIv0RM-N
 z%)bBtfB;EEK~#9!?45U<Bu9Dozg686H{RY}4!S!@r;~KbIR}u)29a!IW57g%jcpvk
 z*v7^YkWF#`1I9MI7>j5yK}Z5cKmiFPp?tcy;WqD1?ojU^J+qT~W_o64cEa{=KGN+>
 zcXd})S3UjYN4%U)f<TbQL}8<$6GAeJKr%ppX#$u?G&IiV3C4(GBH78~gpi!VA)*ZN
@@ -1864,8 +1864,8 @@ zAtnhgKOCs$P3V5aDezV6u~v$0uvy^wynth#$$`xf0p8CnqrUc_F4zn*#b5GChFJ2r
 z5hb(i=REEqMHn5c!e*%UTlq2X-i@Ux&b;~)*1AtUB%suzu^jo8u(a1K;J{=qAA117
 z!d2dV!`cB!f;4BKm+9y$SJ-pk0t(y1o7z1i&Jz9n36_gjL?sA@`8W?U($2}F`^bTV
 z^*q4G8L4AsDl%NlAW4$cryp=XCOmKGVtYX)jYXxF-uwru!(BsBK0`UJ2P|A3BeDFE
-zIs2oD-DjQFsTzblrrE-d0)GVe?1;5;Ce}w1@(@6b=d!PkgkKf_P(ZK0JNPkQAX1Y2
-z)rS{2RiwYbee9^i+Az-!&Lu+z1Kopup!8T}iM?7oQTE-texSSu)rnT+D|xwRPGr^q
+zIs2oD-DjQFsTzblrrE-d0)GVe?1;5;Ce}w1@(@6b=d!PkgkKgr_%UA~Qj+}DhZi_i
+zq`$y@?5M-qFwYLoB|`=P(m*Z01Kopup!8T}iM?7oQTE-texSSu)rnT+D|xwRPGr^q
 z`z$M*w=~KW&L>Us;`GKAKG~)~Vz9s&L|t5z>Vtp^9`EkwI?z~Rh~FcD>5+l8Sx1}?
 zVbJG`3k~+WAA=8)tRsnx%@UU}LNaTnZj>J=wL>V^mhRuZ^8;>%L~kO3C~N8M%tG>J
 zYzkl0znn2?c~vXqS%%i>{DG6baFD%D{YlEziPbrW{PZ~RW^pJyKhBHT$FxTkmqIeg
@@ -2181,10 +2181,10 @@ zNnf2<2ZGFV7&#Sq5%Z!T1<mSWRjmw#kO+8If0gm=neZqf49^qbZ}*j=R=9KSn<z@G
 zn)^McHOPA^sDi&u5(K#pjhLToy$*y};u&O8e^us?f!Vg1)8lQqts>(H3O~?ZpZV_@
 zMhPtE{r9o@a93U_SF><=;`KaiOfp=|8F8xs02mNSL_t)@9;S%-$<jO{M3Mu<xaf5!
 z-X6znqawCtY1penWNDyH=!?M(v5(C%+R<JKy$m;Z<=nSYfkBm!j$*;VNtQOkb4ZaS
-z?ehm75hTqs81((-@J*wvbGYX=VO3)p0mBzO=nCPyI~0n*$AjxL@0;;S!YZM1cI8q%
-zfsHB>2nzEmmb);6MFxY**vc63wl3>#LJ*5*h%xx*)<0!XB-+}Wjv(UVFZ9nRne#2y
-ztANVy_tM|hvca+Nh${Ji;W3jqTe*w{;w`C6+=~ccbAWk5pHqL?2_kbx5Cn_J>xRD;
-zV-Bq|I<zKHsS-owY>LIdTVx1uEkPFiQm!7M0|%I9*H=bg-x=}09kTzV6?l#OVUjtY
+z?ehm75hTqs81((-@J*wvbGYX=VO3)p3gNsv6pFydgX=TzoAF7)Dxq?A<x)L?jVcld
+z3iB$KyD)=A27}Ak${6vsF6(YW5Q}GsG5F`!KV?uP+S;3rAmZXL^v@@m^DWk^fXeUp
+z(%;px!Ljg&D*1omF_So3xr_zkEvZc0iwIzIfO$fnQ-9eBB6CL&1dGV)hQAhL4y`jf
+zv?fuh5<}%|ip9TMWC(CAK^FW{t{$NS2bcjR7ux7%*H=bg-x=}09kTzV6?l#OVUjtY
 z(OfkYyCYTdGH^RytVYcJ>X;kPWuBx9Z{edH8j?dy(|7mo*VtAk@CO}35EOP&T&Ld|
 zXBOEho$5K1O8)Mag~H>i2H%iBYLXzrbAXtiJJAy~bPh6&cBi`DN_R>QF}>Y%Dd&PA
 zu;cox)E)7?lHs;TIIIO!^OJYe5#)a_hhuKMlwC}b@Xd`LprLb!DMC-CUZoOxR(Tsh
@@ -2301,14 +2301,14 @@ z_ovCc>JVL~6Nel*qf8EkA(UZKq##1!Qp6RmDdR~WZ@xb2TgT;pb#Gjxe1+ay)NW^0
 f`ch_Jq&DIIbfZ@m$+<~>00000NkvXXu0mjf!$8AO
 
 literal 0
-Hc-jL100001
+HcmV?d00001
 
 diff --git a/chrome/android/java/res_vanadium/drawable-xxxhdpi/product_logo_name.png b/chrome/android/java/res_vanadium/drawable-xxxhdpi/product_logo_name.png
 new file mode 100644
 index 0000000000000000000000000000000000000000..5f16990a7eb67c441bfc62d50a4e92f95c0f4f22
 GIT binary patch
 literal 5925
-zc-jFa7ux8FP)<h;3K|Lk000e1NJLTq00Eo;002}71ONa49E3^V00002VoOIv0RM-N
+zcmV+=7ux8FP)<h;3K|Lk000e1NJLTq00Eo;002}71ONa49E3^V00002VoOIv0RM-N
 z%)bBt7T!rjK~#9!?VW3I99NZqzuVpO(9<5-ma!dTYwU!O1cx9c1V|NBN`~dR6d=Qr
 z;9Wu?k?a=B0u`Gjfm)z~9jXYhOTeO*uml3JYO~8D0oK~=BfOGWu#f~N!5-W3Te4>)
 zjYgVh_x_lkQTI&G^c`g+&6xhCT<%dn=AQ0*`kZ_3x#x;^P>w=|ETAD!nMOe;4fx2R
@@ -2425,14 +2425,14 @@ zntO)Bsb@2f>)9Xy)CEPqd3ZD)!gH8BJZeXNYNm&WN0I*rsl^JT&aD`J00000NkvXX
 Hu0mjf>GD|)
 
 literal 0
-Hc-jL100001
+HcmV?d00001
 
 diff --git a/chrome/android/java/res_vanadium/mipmap-hdpi/app_icon.png b/chrome/android/java/res_vanadium/mipmap-hdpi/app_icon.png
 new file mode 100644
 index 0000000000000000000000000000000000000000..9533ce927dbb3f4d3849d9a2c062ff31850ae454
 GIT binary patch
 literal 2578
-zc-jFH3hniYP)<h;3K|Lk000e1NJLTq002k;002k`1ONa4|Kxkj00002VoOIv0RM-N
+zcmV+t3hniYP)<h;3K|Lk000e1NJLTq002k;002k`1ONa4|Kxkj00002VoOIv0RM-N
 z%)bBt3Cl@DK~!ko&6;g&9K{*Oe>1yxw$JbO8P_4Po#2Ed#34XHNoYhVQYlDKP@zf@
 zQc+t$^PyEskqT=10YutL<)xL{(l30d1VJe&MXDf_hLlDD6d<%Nae@tbabi31OJdIN
 zcelIK4?BCeciy|(%Zu9QboTA+?#yrg^UO0dI}873CN6Rw>VE|!0D;tB_gDcA3Wb9@
@@ -2484,14 +2484,14 @@ zXXB@sW|~>%NnwTFPc9S4yIy9tcp`dZ$9=x*cD58r()wd%HYdv}pnUV*K$DqAt8PAy
 o?sU%izlC<8Z|MbZHC}-I7X>G&nZLZnpa1{>07*qoM6N<$f{)wb@Bjb+
 
 literal 0
-Hc-jL100001
+HcmV?d00001
 
 diff --git a/chrome/android/java/res_vanadium/mipmap-hdpi/app_shortcut_icon.png b/chrome/android/java/res_vanadium/mipmap-hdpi/app_shortcut_icon.png
 new file mode 100644
 index 0000000000000000000000000000000000000000..b054450f1534f806b8b28213b33778e75c450725
 GIT binary patch
 literal 2574
-zc-jFD3i0)cP)<h;3K|Lk000e1NJLTq002k;002k`1ONa4|Kxkj00002VoOIv0RM-N
+zcmV+p3i0)cP)<h;3K|Lk000e1NJLTq002k;002k`1ONa4|Kxkj00002VoOIv0RM-N
 z%)bBt3CBr9K~!ko&6;^^9Mu`XfA7uguD!lC_PS1-!*(tL*pNUdN+2abRSqc#R6!}C
 z1qrp3KPpiQYAPrK)F9MC)k+AYs>dH(IRMd0B|r(ZB&j$|m6XIzq6Fe3Hu%V4d$YE8
 zXXf>fdAmEip4r1m)PAcy=FOY;{pNe$eDC-c{?A05<u=s+3P=C~i9jIru>u?v3I{b)
@@ -2543,14 +2543,14 @@ zWRetC+4<xOfim?aW;T@*Axuc;4IC`eq?jVDU+y1ID%#<iS;{$+naiXqGASO%Gw9Fo
 kUub9gFFpTM;~B_*0oNUsuT)Zgn*aa+07*qoM6N<$f)V!8^8f$<
 
 literal 0
-Hc-jL100001
+HcmV?d00001
 
 diff --git a/chrome/android/java/res_vanadium/mipmap-hdpi/app_single_page_icon.png b/chrome/android/java/res_vanadium/mipmap-hdpi/app_single_page_icon.png
 new file mode 100644
 index 0000000000000000000000000000000000000000..c544d46ce870ad2efc9984da57d853df5f28c3e4
 GIT binary patch
 literal 1496
-zc-jHj1t<E6P)<h;3K|Lk000e1NJLTq002k;002k`1ONa4|Kxkj00002VoOIv0RM-N
+zcmV;}1t<E6P)<h;3K|Lk000e1NJLTq002k;002k`1ONa4|Kxkj00002VoOIv0RM-N
 z%)bBt1(8WaK~!ko?b`2e6LlQG@%P=W?K))Z24hoTs|p6?$Lh2BfG~M5;$Pr1Wj^x}
 z{sW36K3pQk7!uKpghWvzBqkV8%rM|G!+wOx07D$pzyfq^D_w8x*53Kx?%Hd6cfD(`
 z3nqS>w9DOn?_T}>xX<T%9sFPZV@0sraU-UFob9vTrvM^~<B3DpIk;!RH_(k}ZZZ?G
@@ -2581,14 +2581,14 @@ zb9Vz0S$6R(3Mwlk<(uP|zFE1&9p;Jypy25m-peMs=@i;G#UkAzy<H3QPvlf;W_s}!
 yNoJTUbk%x+03vLpg;t=E9BZr*C&^Md2H;<$gf3O<DB$=20000<MNUMnLSTXr)4V<a
 
 literal 0
-Hc-jL100001
+HcmV?d00001
 
 diff --git a/chrome/android/java/res_vanadium/mipmap-mdpi/app_icon.png b/chrome/android/java/res_vanadium/mipmap-mdpi/app_icon.png
 new file mode 100644
 index 0000000000000000000000000000000000000000..5c340f7a0936223c14d858784e18e38443264df5
 GIT binary patch
 literal 1532
-zc-jH{1q1qtP)<h;3K|Lk000e1NJLTq001xm001xu1ONa4{R=S+00002VoOIv0RM-N
+zcmV<Y1q1qtP)<h;3K|Lk000e1NJLTq001xm001xu1ONa4{R=S+00002VoOIv0RM-N
 z%)bBt1+_^;K~z}7wU}LO6jc<*fAhK9FSj4Gl@^fFmXCf&_%0<7pdv9*FyTp!k%UB(
 zB1RJR!53qA-~}{B5jF7z2vK}6qQ*dCNDwS7U<+0QrBIr*wA609Eo^tUyEEg%%<SjP
 zwqQIrnPl#q^Z(y_&bjxVJMce?FiS17nfeA`SnWR(2#82ki_~VRNmwpc;R9nrzZ>h+
@@ -2620,14 +2620,14 @@ zm1+;i!}o^%y8HLd?$8i^0)&aWZc4NGS7FwHIpmUy2MLG~A;c6RqC~U(MwktOtz}*V
 i?5f^Os2P5PnDQ@s4<gB_=JK-u0000<MNUMnLSTa0>e?Ux
 
 literal 0
-Hc-jL100001
+HcmV?d00001
 
 diff --git a/chrome/android/java/res_vanadium/mipmap-mdpi/app_shortcut_icon.png b/chrome/android/java/res_vanadium/mipmap-mdpi/app_shortcut_icon.png
 new file mode 100644
 index 0000000000000000000000000000000000000000..8723f01f61d163b947af43af0c871695ed25ee6a
 GIT binary patch
 literal 1534
-zc-jH}1p)erP)<h;3K|Lk000e1NJLTq001xm001xu1ONa4{R=S+00002VoOIv0RM-N
+zcmV<a1p)erP)<h;3K|Lk000e1NJLTq001xm001xu1ONa4{R=S+00002VoOIv0RM-N
 z%)bBt1-D5=K~z}7wU}9KR8<(qf9Gy9okFLDLWP3Tg~gVtY*J7NNWhp7jKL)amniWC
 z2*yNt@Ie!NASNs-1PGB3aUp^)LP!)f1~h5dAp)`#DN-m@pbN~_nR|~9_uiSgGk4m8
 z@w>^)+_U`t=X~F}=X`hIe>Tz2R`zALmw<Gx|12O7Xf>mPjWmjhREbiM9cBy1<iTXq
@@ -2659,14 +2659,14 @@ zvaW21dAB2et?hKnnRBONZQP=hI7xqaUjlZ$y$ci(B7}hkq(~4WN{l4Q-u_1DkAU0C
 kebcbBdV4`xeI`u6zY8!J8&ZgeVgLXD07*qoM6N<$f-H)~aR2}S
 
 literal 0
-Hc-jL100001
+HcmV?d00001
 
 diff --git a/chrome/android/java/res_vanadium/mipmap-mdpi/app_single_page_icon.png b/chrome/android/java/res_vanadium/mipmap-mdpi/app_single_page_icon.png
 new file mode 100644
 index 0000000000000000000000000000000000000000..2ef668f35442a8681129f3db24c6fed504d61ae4
 GIT binary patch
 literal 1206
-zc-jHB1WEgeP)<h;3K|Lk000e1NJLTq001xm001xu1ONa4{R=S+00002VoOIv0RM-N
+zcmV;n1WEgeP)<h;3K|Lk000e1NJLTq001xm001xu1ONa4{R=S+00002VoOIv0RM-N
 z%)bBt1aC=1K~z}7)s|amTtyhie>3OI*-M&DlQt=(ZPKKrTErVsP(iB{eW(a(B2=qr
 zrTA8T$+I`a7HI|XLBt39V5Fo~RPaGjOG~8?YM@}129uQZlBBV1ZkyfgIcLU)J>6ta
 zb~l^Ty!g%2&VKX%4gdM(I|Kjs5aEdfZ|rz`W_2}7En2_t+WT#8S%AY&Jar`798NL_
@@ -2692,14 +2692,14 @@ z`4MAz0~f`Crd?apPTtB&j}wQ>e3|OqR`bB7hf<qU+=t8bTz_xh>7irvlg?-T2X2kH
 Ud&;davH$=807*qoM6N<$g0vVglK=n!
 
 literal 0
-Hc-jL100001
+HcmV?d00001
 
 diff --git a/chrome/android/java/res_vanadium/mipmap-xhdpi/app_icon.png b/chrome/android/java/res_vanadium/mipmap-xhdpi/app_icon.png
 new file mode 100644
 index 0000000000000000000000000000000000000000..2110d524c9c403b80301dd34709d4f6fcc430f28
 GIT binary patch
 literal 3727
-zc-jGv4sh{_P)<h;3K|Lk000e1NJLTq003YB003YJ1ONa4NRhv@00002VoOIv0RM-N
+zcmV;A4sh{_P)<h;3K|Lk000e1NJLTq003YB003YJ1ONa4NRhv@00002VoOIv0RM-N
 z%)bBt4oFEvK~#9!?VM?BT-SBSe{Y!?awu{rky<E9q83w|B}<lV$yH+4ixMM+<2Y^|
 zApX!GY10O^fueDP26ciKU4p_6)EGe>%L$UY1q@{Y?80_qYqjHgk+Nu`EZGz#$|NO{
 z5*KkB&b)c=_QShx8@`!&Z%Ety&@+(c&0FsM|Ia<=-gD2pm+=4c@rv@Hl~`P|DEj_C
@@ -2773,14 +2773,14 @@ z9k%K%AG1#Yxqn*%9UWbMYjPp9L%?(fLrhE;_#FIcjJeuX<!lB}<Wj@nvNy-CEq8V~
 tXMdbzt~W?J>%)T!-Glpw=5&Y9{{mHf#%w_K>9PO-002ovPDHLkV1nv5AYT9g
 
 literal 0
-Hc-jL100001
+HcmV?d00001
 
 diff --git a/chrome/android/java/res_vanadium/mipmap-xhdpi/app_shortcut_icon.png b/chrome/android/java/res_vanadium/mipmap-xhdpi/app_shortcut_icon.png
 new file mode 100644
 index 0000000000000000000000000000000000000000..dce04b58684dd6c7ee265ddf332facaf9d4073e9
 GIT binary patch
 literal 3664
-zc-jF_4zKZvP)<h;3K|Lk000e1NJLTq003YB003YJ1ONa4NRhv@00002VoOIv0RM-N
+zcmV-W4zKZvP)<h;3K|Lk000e1NJLTq003YB003YJ1ONa4NRhv@00002VoOIv0RM-N
 z%)bBt4hcy_K~#9!?VNd#99MnEKd-xIW@m4$q&=k7v9edPBnw@(1oDA|%@LO&#)UBz
 zl2o8b{ve@J_8-KQ9qg(EFiAy<330F?6fPXa2tpC;U?dDeaj+v|qcgT-tye2)SI25E
 z?KL|y-Tm@MzdmNRXQpR%WaSTjU8<e#cYVLV_j~XC-X-|0Tw4)WEyw(vW!~TacLW3=
@@ -2853,14 +2853,14 @@ zdH=Tr1_p-utE+?1E&<CO46(30;8pmqF{*W|%D;jUT;B07eYjnd<+buEolUFu1xf#?
 ie=zsl`$JVdRQG?1!InhXyR7v90000<MNUMnLSTaK4EbIF
 
 literal 0
-Hc-jL100001
+HcmV?d00001
 
 diff --git a/chrome/android/java/res_vanadium/mipmap-xhdpi/app_single_page_icon.png b/chrome/android/java/res_vanadium/mipmap-xhdpi/app_single_page_icon.png
 new file mode 100644
 index 0000000000000000000000000000000000000000..a0a80433631765f9bd91707fffb16cffe7160a95
 GIT binary patch
 literal 2639
-zc-jF^3b6HwP)<h;3K|Lk000e1NJLTq003YB003YJ1ONa4NRhv@00002VoOIv0RM-N
+zcmV-V3b6HwP)<h;3K|Lk000e1NJLTq003YB003YJ1ONa4NRhv@00002VoOIv0RM-N
 z%)bBt3J6I=K~#9!?VEXQ9Mu`XfA7t)-nAW{I0=q%oTN}eI76V9L^;$WC<Roh6jeRd
 zmi|+<DkZ9D)gm<kK|u)70}1u7LPbi7qN-4pMh#a{A);y$jwGgd?f8z*wb#e)%zOP~
 zXHT#9w8yT>H?n5eGyCTIz4yIuzVDki@PT|F|KB2tpYqTZH~utoBUYhv6aX^ysjx`Y
@@ -2913,14 +2913,14 @@ z>F6ur*vMv@X{p`OzN_g&bz5Xzh>x;>gX2z&4E3CO>p%Z?hMD9XgGBN*v9<sJ7Hzb$
 xfm(tDkkqtonVp;KM-pR!IcAt*l<DPu{$JS7*jWIpcGUm?002ovPDHLkV1jo9>>B_8
 
 literal 0
-Hc-jL100001
+HcmV?d00001
 
 diff --git a/chrome/android/java/res_vanadium/mipmap-xxhdpi/app_icon.png b/chrome/android/java/res_vanadium/mipmap-xxhdpi/app_icon.png
 new file mode 100644
 index 0000000000000000000000000000000000000000..f4894e5b5b5047708bad46853f06c3bd68e54aa0
 GIT binary patch
 literal 6160
-zc-jFF81LtaP)<h;3K|Lk000e1NJLTq0058x0058(1ONa4O;0K_00002VoOIv0RM-N
+zcmV+r81LtaP)<h;3K|Lk000e1NJLTq0058x0058(1ONa4O;0K_00002VoOIv0RM-N
 z%)bBt7s*LPK~#9!?VWj$9MyTif89OTUfN4qUAvM%Vzo#}kw8e`00IoMAyC-Zv11cE
 z#ARa2c9khRNmU%jE?jneRKQ1U2OQsb0CQs(64)FD34sBFBqRhvNGt6n?Xv9LGu@p(
 z`g%RnJ<~JOqr>HIYIgg4{oZfB?|b)a_>25S{vu5j=_Gi*exgUPS<jU0zmn^?14Vaj
@@ -3041,14 +3041,14 @@ ze;qSGZcNx~(z;hnFCCERG|Xu(gX37CIo5#0=as%T&i%$B5IZ^CZx(=KhUWMH@_Mq@
 iy8!i)|Hl}MBmWOUsYCM~E)RwP0000<MNUMnLSTZfrRkLb
 
 literal 0
-Hc-jL100001
+HcmV?d00001
 
 diff --git a/chrome/android/java/res_vanadium/mipmap-xxhdpi/app_shortcut_icon.png b/chrome/android/java/res_vanadium/mipmap-xxhdpi/app_shortcut_icon.png
 new file mode 100644
 index 0000000000000000000000000000000000000000..ddde3d59f00d5eb17564a8214ad9cdcffa38a299
 GIT binary patch
 literal 6046
-zc-jG;7h&j$P)<h;3K|Lk000e1NJLTq0058x0058(1ONa4O;0K_00002VoOIv0RM-N
+zcmV;P7h&j$P)<h;3K|Lk000e1NJLTq0058x0058(1ONa4O;0K_00002VoOIv0RM-N
 z%)bBt7gtF{K~#9!?VWj)TveICe{ZR!_a&VUounJGbs9nffg}(V64^#n#2FDs85vv{
 zopGC^cpM$^3>;>hGc%%&3JT~jxE|RD)G@3IgCrn<glvRBmJZ!XC+Q?zUF%!skGI`d
 z>#M3)oy6l;C!KoRefR$A`@Z|#`|iCD{v>~rKS={cIsxu)9`6}!)IBBlujJeBK{0*b
@@ -3167,14 +3167,14 @@ zV!CK#q7I3sCI;VAG`@7|0Ezd@e}SC;jYZ&J8rI(@JH^YuPBoxnca{qFhz~g^_%@~T
 Y|1QPj5%LR(VE_OC07*qoM6N<$f_t{1X8-^I
 
 literal 0
-Hc-jL100001
+HcmV?d00001
 
 diff --git a/chrome/android/java/res_vanadium/mipmap-xxhdpi/app_single_page_icon.png b/chrome/android/java/res_vanadium/mipmap-xxhdpi/app_single_page_icon.png
 new file mode 100644
 index 0000000000000000000000000000000000000000..a18ac214a3cbcd93fd5722bdc4da33de245e68bf
 GIT binary patch
 literal 3485
-zc-jG-4Px?%P)<h;3K|Lk000e1NJLTq0058x0058(1ONa4O;0K_00002VoOIv0RM-N
+zcmV;O4Px?%P)<h;3K|Lk000e1NJLTq0058x0058(1ONa4O;0K_00002VoOIv0RM-N
 z%)bBt4OU4+K~#9!?VVd}9Mv6%znxusv+LNqu^kL)LYxaC2~=@_(pC`3B`AqXD<Pyl
 zqME)IDe&5tC{k5beQ1COS`pd+53SO2DHR}62uU%}HW$Lpae&;M*h%cHowZ}H?cJT3
 zKFnojc4u~Xc4u~H?fgdZ&gIOUbH4n~WzKEjrf%w{ZtA9Ps!<iF<fgB><y|}~b=M`t
@@ -3244,14 +3244,14 @@ zgb5-t4~Wb$j|ikmGVW|ei-iG5Q8TSXi4+uUY37+F#f@U6m7V?%zd0TLfLr+m00000
 LNkvXXu0mjf=__DT
 
 literal 0
-Hc-jL100001
+HcmV?d00001
 
 diff --git a/chrome/android/java/res_vanadium/mipmap-xxxhdpi/app_icon.png b/chrome/android/java/res_vanadium/mipmap-xxxhdpi/app_icon.png
 new file mode 100644
 index 0000000000000000000000000000000000000000..1e02f37a1a940619f19cb73eb3605e14e8b0cfef
 GIT binary patch
 literal 9104
-zc-jGwBX8V^P)<h;3K|Lk000e1NJLTq006)M006)U1ONa4_|>G000002VoOIv0RM-N
+zcmV;BBX8V^P)<h;3K|Lk000e1NJLTq006)M006)U1ONa4_|>G000002VoOIv0RM-N
 z%)bBtBS}d_K~#9!?VWd&9MzrgKNY%rva)7I5-1QPB!UbAga|emY{2&6*v9dAkKb7z
 zN1ns_t?_y9t@rKPn>hB`hPAy8Zygq6!ai)+0}j{(BQi(`fk8+JWsPP=(nu3JR(O9@
 zPTf`ARXqdCZ_b3O>AH36`@O$#e>W7oA#cbV@`k)2|5Zhp?h0g7SADuG8&~A%u0UN8
@@ -3429,14 +3429,14 @@ z&TnT3ZAJm_ecYKSLdb8y_m^AzAbV#p&N$%xk2#Y?sB;t)z0T1Ll>ZM}!uj~k+35iQ
 O0000<MNUMnLSTY_yT{`I
 
 literal 0
-Hc-jL100001
+HcmV?d00001
 
 diff --git a/chrome/android/java/res_vanadium/mipmap-xxxhdpi/app_shortcut_icon.png b/chrome/android/java/res_vanadium/mipmap-xxxhdpi/app_shortcut_icon.png
 new file mode 100644
 index 0000000000000000000000000000000000000000..462b433a801f6fcea98599426cb227a3849dccd0
 GIT binary patch
 literal 8910
-zc-jHZA~D^GP)<h;3K|Lk000e1NJLTq006)M006)U1ONa4_|>G000002VoOIv0RM-N
+zcmV;<A~D^GP)<h;3K|Lk000e1NJLTq006)M006)U1ONa4_|>G000002VoOIv0RM-N
 z%)bBtB8N#tK~#9!?VWkN9aWX@zg2aHd+v~%fh0HcL=r+6LP&%Jh$12ZMOsDM0bl!h
 zDk6NaZTs1_KJAZ<s2}X6ecIAW<In;R@W~{Kq9C9UkRb^K2r(oiWWJemhcnjj{-}94
 z=Tz0HI`=}e&gTwQr)t-(-*4}=)?RypH|0%vQ{I#}<-e;4Bb|Yi@~Vw=X2VKmq%+V^
@@ -3610,14 +3610,14 @@ zXcEEoJ9rftXX!V^9j|uw-*{Iq7*#U*2=M02`B(7#=M*o<n(O?i1K#_ZqgjLoM}E;7
 c9F0Qx|B}Q+Z=dlMDF6Tf07*qoM6N<$f|_$^VgLXD
 
 literal 0
-Hc-jL100001
+HcmV?d00001
 
 diff --git a/chrome/android/java/res_vanadium/mipmap-xxxhdpi/app_single_page_icon.png b/chrome/android/java/res_vanadium/mipmap-xxxhdpi/app_single_page_icon.png
 new file mode 100644
 index 0000000000000000000000000000000000000000..ee550d2496b8ee610665e0973b6c1009bdec18bb
 GIT binary patch
 literal 6162
-zc-jFH813hYP)<h;3K|Lk000e1NJLTq006)M006)U1ONa4_|>G000002VoOIv0RM-N
+zcmV+t813hYP)<h;3K|Lk000e1NJLTq006)M006)U1ONa4_|>G000002VoOIv0RM-N
 z%)bBt7t2XRK~#9!?VWj$99MnEKd+~!XJ$|BuJ(|1uCQfn3uANmEDMNbT$DrEMTH|V
 zMJiOPph75;0*XKKN0P!fBos~+kUx?lIHnLbm>AnQK#Z_ui^CwxGD2(J(ysQ@&fatM
 z@$yIa+&$O!%+73UzFQhi_sqP0{r$f8d%ySI@4bc=T4<q#7FuYbg%(<9;ZlRBRYDJ5
@@ -3738,7 +3738,7 @@ z4=n*~D0DMGYE(<3jW9uiIZ-V(EMl0%i4%8ROr2S#S@mO;TLNUD(nALwgmP#XXsB2P
 kGn<knmRQIH8Lkfh4<#z;WpdrDCIA2c07*qoM6N<$g5lVO)Bpeg
 
 literal 0
-Hc-jL100001
+HcmV?d00001
 
 diff --git a/chrome/android/java/res_vanadium/values/channel_constants.xml b/chrome/android/java/res_vanadium/values/channel_constants.xml
 new file mode 100644
@@ -3755,5 +3755,5 @@ index 000000000000..934572cd12f2
 +    <string name="search_widget_title" translatable="false">Vanadium search</string>
 +</resources>
 -- 
-2.25.1
+2.21.1
 

--- a/0005-Vanadium-branding-for-WebView.patch
+++ b/0005-Vanadium-branding-for-WebView.patch
@@ -1,7 +1,7 @@
-From 1fab04a10ec319b551f4b9cc2d1be78ffef0f0fb Mon Sep 17 00:00:00 2001
+From d4e4616a19533a47d60dc138ab3362aea1723c43 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Sun, 16 Feb 2020 13:40:14 -0500
-Subject: [PATCH 05/52] Vanadium branding for WebView
+Subject: [PATCH 05/53] Vanadium branding for WebView
 
 ---
  android_webview/nonembedded/java/AndroidManifest.xml | 2 +-
@@ -21,5 +21,5 @@ index c6cdceed002d..2549f8b2e103 100644
                   android:name="{{ application_name|default('org.chromium.android_webview.nonembedded.WebViewApkApplication') }}"
                   android:multiArch="true"
 -- 
-2.25.1
+2.21.1
 

--- a/0007-remove-Help-feedback-menu-entry.patch
+++ b/0007-remove-Help-feedback-menu-entry.patch
@@ -1,7 +1,7 @@
-From 3d89dc92e7468ab8ef6cb9cac6a9e093fd355ca2 Mon Sep 17 00:00:00 2001
+From 2ac33ede27394ed75769e4f2001b9c5f911549d2 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Sat, 6 Jul 2019 05:56:45 -0400
-Subject: [PATCH 07/52] remove Help & feedback menu entry
+Subject: [PATCH 07/53] remove Help & feedback menu entry
 
 ---
  .../java/src/org/chromium/chrome/browser/vr/VrShell.java | 2 +-
@@ -106,5 +106,5 @@ index 77387b08a5d9..46cd9af4429a 100644
          availableItemIds.add(R.id.preferences_id);
  
 -- 
-2.25.1
+2.21.1
 

--- a/0008-hide-passwords.google.com-link-when-not-supported.patch
+++ b/0008-hide-passwords.google.com-link-when-not-supported.patch
@@ -1,7 +1,7 @@
-From 756f3324312e2754a12f8f9afb7aa316fe652c6b Mon Sep 17 00:00:00 2001
+From f17eb78f9a4698d2fedda45f88d58186b516a28d Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Sun, 13 Aug 2017 19:33:04 -0400
-Subject: [PATCH 08/52] hide passwords.google.com link when not supported
+Subject: [PATCH 08/53] hide passwords.google.com link when not supported
 
 ---
  .../browser/settings/password/SavePasswordsPreferences.java   | 4 ++++
@@ -30,5 +30,5 @@ index a33fee3890c8..17bf177e96ea 100644
              return; // Don't add the Manage Account link if it's present.
          }
 -- 
-2.25.1
+2.21.1
 

--- a/0009-disable-first-run-welcome-page.patch
+++ b/0009-disable-first-run-welcome-page.patch
@@ -1,7 +1,7 @@
-From b47af7172c7d98155823ee1b3f39e948ac5fabab Mon Sep 17 00:00:00 2001
+From 0b61cdc03237e6d15d4887a06b4a4887149fd114 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Thu, 24 Nov 2016 08:19:03 -0500
-Subject: [PATCH 09/52] disable first run welcome page
+Subject: [PATCH 09/53] disable first run welcome page
 
 ---
  .../chromium/chrome/browser/firstrun/FirstRunActivity.java    | 4 ++--
@@ -30,5 +30,5 @@ index 7d3e6d41afa0..e33a93c4f17a 100644
                      mResultSignInAccountName = mFreProperties.getString(
                              SigninFirstRunFragment.FORCE_SIGNIN_ACCOUNT_TO);
 -- 
-2.25.1
+2.21.1
 

--- a/0010-disable-seed-based-field-trials.patch
+++ b/0010-disable-seed-based-field-trials.patch
@@ -1,7 +1,7 @@
-From 062e619524d5dab46608bb0bb17f85b61a5014fb Mon Sep 17 00:00:00 2001
+From f80eb82cf6b1875c13b69d3f38a2763f433939dd Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Tue, 25 Dec 2018 16:19:51 -0500
-Subject: [PATCH 10/52] disable seed-based field trials
+Subject: [PATCH 10/53] disable seed-based field trials
 
 ---
  components/variations/service/variations_field_trial_creator.cc | 2 ++
@@ -23,5 +23,5 @@ index e9bb5a78a51c..3cb9a5a50e31 100644
  
    platform_field_trials->SetupFeatureControllingFieldTrials(used_seed,
 -- 
-2.25.1
+2.21.1
 

--- a/0011-disable-navigation-error-correction-by-default.patch
+++ b/0011-disable-navigation-error-correction-by-default.patch
@@ -1,7 +1,7 @@
-From 9d573df1545d8ecf78b1ea8bf663d24938a10bce Mon Sep 17 00:00:00 2001
+From 392ba58a49285845a3b40abbf21b1f9b25dbff77 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Wed, 23 Nov 2016 08:29:58 -0500
-Subject: [PATCH 11/52] disable navigation error correction by default
+Subject: [PATCH 11/53] disable navigation error correction by default
 
 ---
  chrome/browser/ui/navigation_correction_tab_observer.cc | 2 +-
@@ -21,5 +21,5 @@ index 1b0287989406..f2aa068efdc3 100644
  }
  
 -- 
-2.25.1
+2.21.1
 

--- a/0012-disable-contextual-search-by-default.patch
+++ b/0012-disable-contextual-search-by-default.patch
@@ -1,7 +1,7 @@
-From 741ca9e70b17a729a8687783761d66a90a6ed445 Mon Sep 17 00:00:00 2001
+From 8c673c308d2a6fe61212607e2df7c06f83296cfd Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Wed, 23 Nov 2016 09:26:51 -0500
-Subject: [PATCH 12/52] disable contextual search by default
+Subject: [PATCH 12/53] disable contextual search by default
 
 ---
  .../browser/contextualsearch/ContextualSearchFieldTrial.java    | 2 +-
@@ -35,5 +35,5 @@ index 2b1140fdd27e..85020f22f7fa 100644
  #endif  // defined(OS_ANDROID)
    registry->RegisterBooleanPref(prefs::kSessionExitedCleanly, true);
 -- 
-2.25.1
+2.21.1
 

--- a/0013-disable-network-prediction-by-default.patch
+++ b/0013-disable-network-prediction-by-default.patch
@@ -1,7 +1,7 @@
-From 95e1138582d20701704e41be3888cb210120b6b7 Mon Sep 17 00:00:00 2001
+From 552a185623d64a2367ac281436a34e298a434a20 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Wed, 23 Nov 2016 08:31:44 -0500
-Subject: [PATCH 13/52] disable network prediction by default
+Subject: [PATCH 13/53] disable network prediction by default
 
 ---
  chrome/browser/net/prediction_options.h | 2 +-
@@ -21,5 +21,5 @@ index 2ae6a1093090..7fc83de1aa0f 100644
  
  enum class NetworkPredictionStatus {
 -- 
-2.25.1
+2.21.1
 

--- a/0014-disable-metrics-by-default.patch
+++ b/0014-disable-metrics-by-default.patch
@@ -1,7 +1,7 @@
-From 99ca1d5a99995e0740b705b9d5c6a83cb9dd661b Mon Sep 17 00:00:00 2001
+From 2d9f7af0a60d56c4d96171c221c3275860b013e9 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Thu, 24 Nov 2016 11:41:00 -0500
-Subject: [PATCH 14/52] disable metrics by default
+Subject: [PATCH 14/53] disable metrics by default
 
 ---
  .../chromium/chrome/browser/firstrun/FirstRunActivityBase.java  | 2 +-
@@ -21,5 +21,5 @@ index 9c69e1071c79..70ef53e01211 100644
      private boolean mNativeInitialized;
  
 -- 
-2.25.1
+2.21.1
 

--- a/0015-disable-hyperlink-auditing-by-default.patch
+++ b/0015-disable-hyperlink-auditing-by-default.patch
@@ -1,7 +1,7 @@
-From a10eb569c4c57df1f03df1849ec62c0962e9b9a4 Mon Sep 17 00:00:00 2001
+From 910902ec5cde72f6abaeb42187b9b2646419a983 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Sat, 26 Nov 2016 14:57:22 -0500
-Subject: [PATCH 15/52] disable hyperlink auditing by default
+Subject: [PATCH 15/53] disable hyperlink auditing by default
 
 ---
  chrome/browser/chrome_content_browser_client.cc | 2 +-
@@ -21,5 +21,5 @@ index 5cdfec3a834b..d356e4f381ea 100644
    // Register user prefs for mapping SitePerProcess and IsolateOrigins in
    // user policy in addition to the same named ones in Local State (which are
 -- 
-2.25.1
+2.21.1
 

--- a/0016-disable-showing-popular-sites-by-default.patch
+++ b/0016-disable-showing-popular-sites-by-default.patch
@@ -1,7 +1,7 @@
-From 0d682a55bdd76002a86eca26bd739650af327a96 Mon Sep 17 00:00:00 2001
+From 679df0d6dd187ca2659707cf367ea75d740b94a4 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Tue, 6 Mar 2018 00:27:41 -0500
-Subject: [PATCH 16/52] disable showing popular sites by default
+Subject: [PATCH 16/53] disable showing popular sites by default
 
 ---
  components/ntp_tiles/features.cc | 4 ++--
@@ -28,5 +28,5 @@ index 6096def69b70..97ca547cdbb0 100644
  const base::FeatureState kDisplaySuggestionsServiceTilesDefaultState =
  #if defined(OS_ANDROID) || defined(OS_IOS)
 -- 
-2.25.1
+2.21.1
 

--- a/0017-disable-article-suggestions-feature-by-default.patch
+++ b/0017-disable-article-suggestions-feature-by-default.patch
@@ -1,7 +1,7 @@
-From f381c38dd59e3a7740fe4604755a7bbad26991fa Mon Sep 17 00:00:00 2001
+From 6de1b17098caf42f7d7cde41e76b9f9e59f92deb Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Thu, 8 Mar 2018 22:43:12 -0500
-Subject: [PATCH 17/52] disable article suggestions feature by default
+Subject: [PATCH 17/53] disable article suggestions feature by default
 
 ---
  components/ntp_snippets/features.cc                           | 2 +-
@@ -37,5 +37,5 @@ index 6d2c34d2a74c..f002d0c0336d 100644
  
  void RemoteSuggestionsStatusServiceImpl::Init(
 -- 
-2.25.1
+2.21.1
 

--- a/0018-disable-prefetching-suggested-pages-by-default.patch
+++ b/0018-disable-prefetching-suggested-pages-by-default.patch
@@ -1,7 +1,7 @@
-From afbb6aebaf7806867f9ee8dc4457587d3c4290cd Mon Sep 17 00:00:00 2001
+From 83caa2573aeb3cf34076c247cac2a3e589ff9512 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Fri, 12 Jul 2019 04:10:21 -0400
-Subject: [PATCH 18/52] disable prefetching suggested pages by default
+Subject: [PATCH 18/53] disable prefetching suggested pages by default
 
 ---
  components/offline_pages/core/offline_page_feature.cc | 2 +-
@@ -21,5 +21,5 @@ index a21206a255ba..a2f1e95ad01a 100644
  const base::Feature kOfflinePagesCTV2Feature{"OfflinePagesCTV2",
                                               base::FEATURE_DISABLED_BY_DEFAULT};
 -- 
-2.25.1
+2.21.1
 

--- a/0019-disable-sensors-access-by-default.patch
+++ b/0019-disable-sensors-access-by-default.patch
@@ -1,7 +1,7 @@
-From 482e6125c4063e623e7c50beba119fb20be436de Mon Sep 17 00:00:00 2001
+From 756da70a58f008a46f7fa74460b5a5241a0bd510 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Sun, 16 Jun 2019 15:57:29 -0400
-Subject: [PATCH 19/52] disable sensors access by default
+Subject: [PATCH 19/53] disable sensors access by default
 
 ---
  .../content_settings/core/browser/content_settings_registry.cc  | 2 +-
@@ -21,5 +21,5 @@ index 63282bda6285..922b681985b4 100644
             ValidSettings(CONTENT_SETTING_ALLOW, CONTENT_SETTING_BLOCK),
             WebsiteSettingsInfo::SINGLE_ORIGIN_ONLY_SCOPE,
 -- 
-2.25.1
+2.21.1
 

--- a/0020-disable-third-party-cookies-by-default.patch
+++ b/0020-disable-third-party-cookies-by-default.patch
@@ -1,7 +1,7 @@
-From 9b24ccc718637f00e3b00a66733fe502f6bb436d Mon Sep 17 00:00:00 2001
+From 3e15ea67ab1e39da27722ab7a52a9fc72b7f347d Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Sun, 16 Jun 2019 16:01:31 -0400
-Subject: [PATCH 20/52] disable third party cookies by default
+Subject: [PATCH 20/53] disable third party cookies by default
 
 ---
  components/content_settings/core/browser/cookie_settings.cc | 2 +-
@@ -21,5 +21,5 @@ index 84d150c6bb34..63ff054a3070 100644
    registry->RegisterIntegerPref(
        prefs::kCookieControlsMode,
 -- 
-2.25.1
+2.21.1
 

--- a/0021-disable-background-sync-by-default.patch
+++ b/0021-disable-background-sync-by-default.patch
@@ -1,7 +1,7 @@
-From 9df84409f9fb4717937c85cda15fa0c696fd7b28 Mon Sep 17 00:00:00 2001
+From b98dba769018d56fb27205258d1531a12a667db9 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Sun, 16 Jun 2019 21:57:26 -0400
-Subject: [PATCH 21/52] disable background sync by default
+Subject: [PATCH 21/53] disable background sync by default
 
 ---
  .../content_settings/core/browser/content_settings_registry.cc  | 2 +-
@@ -21,5 +21,5 @@ index 922b681985b4..24f2bb66a927 100644
             ValidSettings(CONTENT_SETTING_ALLOW, CONTENT_SETTING_BLOCK),
             WebsiteSettingsInfo::SINGLE_ORIGIN_ONLY_SCOPE,
 -- 
-2.25.1
+2.21.1
 

--- a/0022-disable-payment-support-by-default.patch
+++ b/0022-disable-payment-support-by-default.patch
@@ -1,7 +1,7 @@
-From fe7b1adb7bd7e36aa404ab51ee263de30265ec07 Mon Sep 17 00:00:00 2001
+From 2caee81f1bd69695c3c7512e250d1b8f1baf6237 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Tue, 18 Jun 2019 22:28:53 -0400
-Subject: [PATCH 22/52] disable payment support by default
+Subject: [PATCH 22/53] disable payment support by default
 
 ---
  components/payments/core/payment_prefs.cc | 2 +-
@@ -21,5 +21,5 @@ index 9590d9494ed1..787ff68af12a 100644
  }
  
 -- 
-2.25.1
+2.21.1
 

--- a/0023-disable-media-router-media-remoting-by-default.patch
+++ b/0023-disable-media-router-media-remoting-by-default.patch
@@ -1,7 +1,7 @@
-From 45f463779f24427d58a7e43475f2415662e8b8e9 Mon Sep 17 00:00:00 2001
+From a3e33954de8abde710f3f0ce97796d920287efc4 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Thu, 4 Jul 2019 18:11:27 -0400
-Subject: [PATCH 23/52] disable media router media remoting by default
+Subject: [PATCH 23/53] disable media router media remoting by default
 
 ---
  chrome/browser/profiles/profile.cc | 2 +-
@@ -21,5 +21,5 @@ index 85020f22f7fa..fc01e015d02e 100644
  
    registry->RegisterDictionaryPref(prefs::kWebShareVisitedTargets);
 -- 
-2.25.1
+2.21.1
 

--- a/0024-disable-media-router-by-default.patch
+++ b/0024-disable-media-router-by-default.patch
@@ -1,7 +1,7 @@
-From 2108b0adaa314019dd66d4c2dc4d4449f2edfeb3 Mon Sep 17 00:00:00 2001
+From 771c1d7c7e9ffd01f91d9eefce654e4cfa698250 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Thu, 4 Jul 2019 19:08:52 -0400
-Subject: [PATCH 24/52] disable media router by default
+Subject: [PATCH 24/53] disable media router by default
 
 ---
  .../media/router/media_router_feature.cc      | 19 +++++++++----------
@@ -59,5 +59,5 @@ index 4dd1e8f42ea7..b80f0adef318 100644
    registry->RegisterBooleanPref(
        prefs::kOobeMarketingOptInScreenFinished, false,
 -- 
-2.25.1
+2.21.1
 

--- a/0025-disable-offering-translations-by-default.patch
+++ b/0025-disable-offering-translations-by-default.patch
@@ -1,7 +1,7 @@
-From 7c60cbcbf7b52c867888fcf6986ccbfbf0b26470 Mon Sep 17 00:00:00 2001
+From 3c0e674a18b11d61cc147096056a9aa625d0eba3 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Fri, 12 Jul 2019 03:58:01 -0400
-Subject: [PATCH 25/52] disable offering translations by default
+Subject: [PATCH 25/53] disable offering translations by default
 
 ---
  chrome/browser/ui/browser_ui_prefs.cc | 2 +-
@@ -21,5 +21,5 @@ index fa9ec80a9755..c97c1327ab58 100644
    registry->RegisterStringPref(prefs::kCloudPrintEmail, std::string());
    registry->RegisterBooleanPref(prefs::kCloudPrintProxyEnabled, true);
 -- 
-2.25.1
+2.21.1
 

--- a/0026-disable-browser-sign-in-feature-by-default.patch
+++ b/0026-disable-browser-sign-in-feature-by-default.patch
@@ -1,7 +1,7 @@
-From a67b8e7b16de14ad5fcb449c80162aa2304d216c Mon Sep 17 00:00:00 2001
+From bde4294221a74645e3ca0670377e9519e013064f Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Fri, 12 Jul 2019 04:23:18 -0400
-Subject: [PATCH 26/52] disable browser sign in feature by default
+Subject: [PATCH 26/53] disable browser sign in feature by default
 
 ---
  .../signin/internal/identity_manager/primary_account_manager.cc | 2 +-
@@ -21,5 +21,5 @@ index aebcdb1d75a1..96bf00085f9c 100644
  }
  
 -- 
-2.25.1
+2.21.1
 

--- a/0027-disable-safe-browsing-reporting-opt-in-by-default.patch
+++ b/0027-disable-safe-browsing-reporting-opt-in-by-default.patch
@@ -1,7 +1,7 @@
-From 244bdfaa146fb9408607a25d685e86c4fc73d52d Mon Sep 17 00:00:00 2001
+From 80e9f82f3ccca569cc4a4f97b83c4b4dfa9e187f Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Fri, 12 Jul 2019 05:22:11 -0400
-Subject: [PATCH 27/52] disable safe browsing reporting opt-in by default
+Subject: [PATCH 27/53] disable safe browsing reporting opt-in by default
 
 ---
  components/safe_browsing/common/safe_browsing_prefs.cc | 2 +-
@@ -21,5 +21,5 @@ index 6e5781005cf7..b7a7797a037d 100644
        prefs::kSafeBrowsingEnabled, true,
        user_prefs::PrefRegistrySyncable::SYNCABLE_PREF);
 -- 
-2.25.1
+2.21.1
 

--- a/0028-enable-dubious-Do-Not-Track-feature-by-default.patch
+++ b/0028-enable-dubious-Do-Not-Track-feature-by-default.patch
@@ -1,7 +1,7 @@
-From 5b667636731c07d6e988b12cf9b15e238459c617 Mon Sep 17 00:00:00 2001
+From 38ba8c2e138c0aff2a54be49425e478af77a0da9 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Tue, 1 Aug 2017 11:16:11 -0400
-Subject: [PATCH 28/52] enable dubious Do Not Track feature by default
+Subject: [PATCH 28/53] enable dubious Do Not Track feature by default
 
 ---
  chrome/browser/ui/browser_ui_prefs.cc | 2 +-
@@ -21,5 +21,5 @@ index c97c1327ab58..6b499cdb35df 100644
  #if !defined(OS_CHROMEOS) && !defined(OS_ANDROID)
    registry->RegisterBooleanPref(prefs::kPrintPreviewUseSystemDefaultPrinter,
 -- 
-2.25.1
+2.21.1
 

--- a/0029-mark-non-secure-origins-as-non-secure-by-default.patch
+++ b/0029-mark-non-secure-origins-as-non-secure-by-default.patch
@@ -1,7 +1,7 @@
-From 21bb993c0f7d09473d7218a59c71b9f14ed2ac55 Mon Sep 17 00:00:00 2001
+From d3617ad13448526ec6e5bc94ae6bf3f8ed54e239 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Fri, 20 Oct 2017 21:20:50 -0400
-Subject: [PATCH 29/52] mark non-secure origins as non-secure by default
+Subject: [PATCH 29/53] mark non-secure origins as non-secure by default
 
 ---
  components/security_state/core/security_state.cc | 8 +++-----
@@ -33,5 +33,5 @@ index f674cc925dfb..09a1127597b2 100644
  
  SecurityLevel GetSecurityLevelForDisplayedMixedContent(bool suppress_warning) {
 -- 
-2.25.1
+2.21.1
 

--- a/0030-enable-strict-site-isolation-by-default-on-Android.patch
+++ b/0030-enable-strict-site-isolation-by-default-on-Android.patch
@@ -1,7 +1,7 @@
-From 32d4f5f108bc4f738a5b44ffb884deba90366607 Mon Sep 17 00:00:00 2001
+From f134eadbdc0c914e8c9fdcffaa710c6a7de89c34 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Thu, 2 May 2019 07:15:32 -0400
-Subject: [PATCH 30/52] enable strict site isolation by default on Android
+Subject: [PATCH 30/53] enable strict site isolation by default on Android
 
 ---
  chrome/browser/about_flags.cc    | 19 -------------------
@@ -57,5 +57,5 @@ index 92da6a9b69af..41915d080bec 100644
  
  // Controls a mode for dynamically process-isolating sites where the user has
 -- 
-2.25.1
+2.21.1
 

--- a/0031-disable-search-engine-permissions-by-default.patch
+++ b/0031-disable-search-engine-permissions-by-default.patch
@@ -1,7 +1,7 @@
-From 7f2430d70d556a463d45a4bcf78c6a71fd3e7acd Mon Sep 17 00:00:00 2001
+From 02138f62deab7975ecd71af1ae6292660cc361cb Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Tue, 1 Aug 2017 20:29:56 -0400
-Subject: [PATCH 31/52] disable search engine permissions by default
+Subject: [PATCH 31/53] disable search engine permissions by default
 
 Disable the geolocation and notification permissions for the default
 search engine by default.
@@ -63,5 +63,5 @@ index 918e5963b62e..e31afcf7939b 100644
  
      // Update the content setting with the auto-grants for the DSE.
 -- 
-2.25.1
+2.21.1
 

--- a/0032-stub-out-the-battery-status-API.patch
+++ b/0032-stub-out-the-battery-status-API.patch
@@ -1,7 +1,7 @@
-From 044ebb2b6dc441cd2dac13828b30a2d96dd97a9c Mon Sep 17 00:00:00 2001
+From 5522f32937bd16774303f188ef1e39c104d5e86a Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Mon, 17 Jun 2019 11:29:21 -0400
-Subject: [PATCH 32/52] stub out the battery status API
+Subject: [PATCH 32/53] stub out the battery status API
 
 Pretend that the device is always plugged in and fully charged.
 ---
@@ -63,5 +63,5 @@ index ca87910880bc..74009ec7b021 100644
  
  void BatteryManager::RegisterWithDispatcher() {
 -- 
-2.25.1
+2.21.1
 

--- a/0033-always-use-local-new-tab-page.patch
+++ b/0033-always-use-local-new-tab-page.patch
@@ -1,7 +1,7 @@
-From 7335ea26c94f16d73557a546adf45e2429537e35 Mon Sep 17 00:00:00 2001
+From ca6c2865926229934242973dffba1f60d74af510 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Mon, 17 Jun 2019 13:14:22 -0400
-Subject: [PATCH 33/52] always use local new tab page
+Subject: [PATCH 33/53] always use local new tab page
 
 ---
  chrome/browser/search/search.cc | 2 +-
@@ -21,5 +21,5 @@ index c3a68e4d757a..f2a418605154 100644
  
  // Used to look up the URL to use for the New Tab page. Also tracks how we
 -- 
-2.25.1
+2.21.1
 

--- a/0034-disable-search-provider-logo.patch
+++ b/0034-disable-search-provider-logo.patch
@@ -1,7 +1,7 @@
-From c54bd9e45ecb4122654a241be61ee2b803db5b31 Mon Sep 17 00:00:00 2001
+From c3ba54cf50de6f166c96cc6290dea7d84a261c17 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Mon, 17 Jun 2019 12:03:52 -0400
-Subject: [PATCH 34/52] disable search provider logo
+Subject: [PATCH 34/53] disable search provider logo
 
 ---
  .../template_url_service_factory_android.cc   | 31 +------------------
@@ -50,5 +50,5 @@ index 58aef45b461a..c27be5575d17 100644
 +  return false;
  }
 -- 
-2.25.1
+2.21.1
 

--- a/0035-stop-ignoring-download-location-prompt-setting.patch
+++ b/0035-stop-ignoring-download-location-prompt-setting.patch
@@ -1,7 +1,7 @@
-From c8273d05406ec058aaf0b6d6911b61753c378996 Mon Sep 17 00:00:00 2001
+From 495a4d3defeef458c845ce7dcee179d9e3fe8f79 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Fri, 28 Jun 2019 16:56:37 -0400
-Subject: [PATCH 35/52] stop ignoring download location prompt setting
+Subject: [PATCH 35/53] stop ignoring download location prompt setting
 
 ---
  .../download/DownloadLocationDialogBridge.java    | 15 ---------------
@@ -34,5 +34,5 @@ index 92513b019c76..44373ec4a963 100644
          if (mDialogModel != null) return;
  
 -- 
-2.25.1
+2.21.1
 

--- a/0036-show-download-prompt-again-by-default.patch
+++ b/0036-show-download-prompt-again-by-default.patch
@@ -1,7 +1,7 @@
-From 68c2b84abe914350b35f7c4f1c62139807705562 Mon Sep 17 00:00:00 2001
+From 18f1a2d6722962bea022e16a5c57f41091b91a16 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Fri, 28 Jun 2019 17:48:49 -0400
-Subject: [PATCH 36/52] show download prompt again by default
+Subject: [PATCH 36/53] show download prompt again by default
 
 ---
  .../chrome/browser/download/DownloadLocationCustomView.java   | 4 ----
@@ -23,5 +23,5 @@ index 8288d3b1fad7..a9af1beb0eae 100644
  
          mFileName.setText(suggestedPath.getName());
 -- 
-2.25.1
+2.21.1
 

--- a/0037-rename-Sync-and-Google-services-Services.patch
+++ b/0037-rename-Sync-and-Google-services-Services.patch
@@ -1,7 +1,7 @@
-From f16fc19546031605727a757cd215357cc1a2827e Mon Sep 17 00:00:00 2001
+From ba95e3b7f3f2c4b21b2947b4bc4482d8d15cfc79 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Fri, 2 Aug 2019 23:28:06 -0400
-Subject: [PATCH 37/52] rename Sync and Google services -> Services
+Subject: [PATCH 37/53] rename Sync and Google services -> Services
 
 ---
  .../browser/ui/android/strings/android_chrome_strings.grd   | 6 +++---
@@ -34,5 +34,5 @@ index 31ac2482cc2c..cde01a4d80c3 100644
        <message name="IDS_USAGE_AND_CRASH_REPORTS_TITLE" desc="Title for a preference that enables sending usage statistics and crash reports.">
          Help improve Vanadium's features and performance
 -- 
-2.25.1
+2.21.1
 

--- a/0038-remove-data-reduction-preference.patch
+++ b/0038-remove-data-reduction-preference.patch
@@ -1,7 +1,7 @@
-From 50bfa6d882b2710f87a501e9a4cab1823512a621 Mon Sep 17 00:00:00 2001
+From d7faa004ed81fbed629ec32ec68db3b7535b3614 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Fri, 2 Aug 2019 22:06:31 -0400
-Subject: [PATCH 38/52] remove data reduction preference
+Subject: [PATCH 38/53] remove data reduction preference
 
 ---
  chrome/android/java/res/xml/main_preferences.xml          | 4 ++--
@@ -53,5 +53,5 @@ index 32213f862d26..1d8c27faab28 100644
  
      private Preference addPreferenceIfAbsent(String key) {
 -- 
-2.25.1
+2.21.1
 

--- a/0039-remove-translate-offer-preference.patch
+++ b/0039-remove-translate-offer-preference.patch
@@ -1,7 +1,7 @@
-From 7229faa8478cb7eefada86dcf722d6c7c0b60474 Mon Sep 17 00:00:00 2001
+From 49b0087e6efb0ef8784a93d1c1b7ce4d134cb0bf Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Fri, 2 Aug 2019 21:11:17 -0400
-Subject: [PATCH 39/52] remove translate offer preference
+Subject: [PATCH 39/53] remove translate offer preference
 
 ---
  .../java/res/xml/languages_preferences.xml    |  8 ++--
@@ -97,5 +97,5 @@ index cde01a4d80c3..4ac7460c69c9 100644
          Offer to translate
        </message>
 -- 
-2.25.1
+2.21.1
 

--- a/0040-remove-sync-preferences.patch
+++ b/0040-remove-sync-preferences.patch
@@ -1,7 +1,7 @@
-From 898e971205ba04fc56ca12fa5f0f6ae962e87892 Mon Sep 17 00:00:00 2001
+From 3b31f0a4363d4db75a079f520da5f4d2c06ad31e Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Fri, 2 Aug 2019 21:12:28 -0400
-Subject: [PATCH 40/52] remove sync preferences
+Subject: [PATCH 40/53] remove sync preferences
 
 ---
  .../res/xml/sync_and_services_preferences.xml |  56 +++----
@@ -319,5 +319,5 @@ index 4ac7460c69c9..ab01b4244d54 100644
          Manage sync
        </message>
 -- 
-2.25.1
+2.21.1
 

--- a/0041-remove-navigation-error-preference.patch
+++ b/0041-remove-navigation-error-preference.patch
@@ -1,7 +1,7 @@
-From 955d5736a89691d56d534a9d858c6746b8538cbb Mon Sep 17 00:00:00 2001
+From 6949eaf510a97b7245dc2a99f5f41a8eaa74c4d6 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Fri, 2 Aug 2019 23:46:41 -0400
-Subject: [PATCH 41/52] remove navigation error preference
+Subject: [PATCH 41/53] remove navigation error preference
 
 ---
  .../res/xml/sync_and_services_preferences.xml | 10 ++++----
@@ -124,5 +124,5 @@ index ab01b4244d54..75909a107956 100644
          Make searches and browsing better
        </message>
 -- 
-2.25.1
+2.21.1
 

--- a/0042-remove-safe-browsing-reporting-preference.patch
+++ b/0042-remove-safe-browsing-reporting-preference.patch
@@ -1,7 +1,7 @@
-From dcb773b301eec7e4abf225db12814306f4926eff Mon Sep 17 00:00:00 2001
+From 6311cc7ef9d0e1917e95bb28ab81797b40348952 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Fri, 2 Aug 2019 23:48:41 -0400
-Subject: [PATCH 42/52] remove safe browsing reporting preference
+Subject: [PATCH 42/53] remove safe browsing reporting preference
 
 ---
  .../res/xml/sync_and_services_preferences.xml | 10 +++----
@@ -124,5 +124,5 @@ index 75909a107956..7a74e8a825af 100644
          Safe Browsing (protects you and your device from dangerous sites)
        </message>
 -- 
-2.25.1
+2.21.1
 

--- a/0043-remove-usage-and-crash-reports-preference.patch
+++ b/0043-remove-usage-and-crash-reports-preference.patch
@@ -1,7 +1,7 @@
-From 6ff6bd5c136d0d50af2a5469c542eaa3795e1446 Mon Sep 17 00:00:00 2001
+From f6f5ab9b09056cfe071f37861efc3b3a12f1fbdf Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Fri, 2 Aug 2019 23:49:13 -0400
-Subject: [PATCH 43/52] remove usage and crash reports preference
+Subject: [PATCH 43/53] remove usage and crash reports preference
 
 ---
  .../res/xml/sync_and_services_preferences.xml | 10 +++----
@@ -126,5 +126,5 @@ index 7a74e8a825af..051959ce0cbd 100644
          Cancel sync?
        </message>
 -- 
-2.25.1
+2.21.1
 

--- a/0044-remove-url-keyed-anonymized-data-preference.patch
+++ b/0044-remove-url-keyed-anonymized-data-preference.patch
@@ -1,7 +1,7 @@
-From b9edba102c42ea846dc7f10bcd2f1653f5c72127 Mon Sep 17 00:00:00 2001
+From 010064b4b38d055de1779865660253f1efcbe1ac Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Fri, 2 Aug 2019 23:50:03 -0400
-Subject: [PATCH 44/52] remove url keyed anonymized data preference
+Subject: [PATCH 44/53] remove url keyed anonymized data preference
 
 ---
  .../res/xml/sync_and_services_preferences.xml | 10 +++----
@@ -128,5 +128,5 @@ index 051959ce0cbd..f7c8ffaaf105 100644
          For more settings that relate to privacy, security, and data collection, see <ph name="BEGIN_LINK">&lt;link&gt;</ph>Services<ph name="END_LINK">&lt;/link&gt;</ph>
        </message>
 -- 
-2.25.1
+2.21.1
 

--- a/0045-remove-redundant-services-preference-category.patch
+++ b/0045-remove-redundant-services-preference-category.patch
@@ -1,7 +1,7 @@
-From 82ce7a595901b16bcbb92f67da5f5a01e24910c5 Mon Sep 17 00:00:00 2001
+From 0d0d59f306f970deda79f49312a3a84a26e8f691 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Sat, 3 Aug 2019 00:34:43 -0400
-Subject: [PATCH 45/52] remove redundant services preference category
+Subject: [PATCH 45/53] remove redundant services preference category
 
 ---
  .../java/res/xml/sync_and_services_preferences.xml     |  8 ++++----
@@ -92,5 +92,5 @@ index f7c8ffaaf105..12602eb7a28e 100644
          Autocomplete searches and URLs
        </message>
 -- 
-2.25.1
+2.21.1
 

--- a/0046-redirect-settings-help-icon.patch
+++ b/0046-redirect-settings-help-icon.patch
@@ -1,7 +1,7 @@
-From 61c328bf854cf3262cfc340add637720375a3f0f Mon Sep 17 00:00:00 2001
+From 2bf90e37095e40b58071d299e9575073d44230fb Mon Sep 17 00:00:00 2001
 From: Zoraver Kang <zkang@wpi.edu>
 Date: Fri, 16 Aug 2019 02:03:45 -0400
-Subject: [PATCH 46/52] redirect settings help icon
+Subject: [PATCH 46/53] redirect settings help icon
 
 ---
  .../src/org/chromium/chrome/browser/help/HelpAndFeedback.java   | 2 +-
@@ -21,5 +21,5 @@ index 9f884f349f90..222ffa38af8d 100644
  
      private static HelpAndFeedback sInstance;
 -- 
-2.25.1
+2.21.1
 

--- a/0047-set-default-search-engine-to-DuckDuckGo.patch
+++ b/0047-set-default-search-engine-to-DuckDuckGo.patch
@@ -1,7 +1,7 @@
-From 60779b4023dceb91a63c4d0158320a60eb1fc745 Mon Sep 17 00:00:00 2001
+From bcfd73e27739c1225b50c523fb7fe1a4582eac20 Mon Sep 17 00:00:00 2001
 From: Zoraver Kang <zkang@wpi.edu>
 Date: Sat, 17 Aug 2019 15:53:50 -0400
-Subject: [PATCH 47/52] set default search engine to DuckDuckGo
+Subject: [PATCH 47/53] set default search engine to DuckDuckGo
 
 ---
  components/search_engines/template_url_prepopulate_data.cc | 2 +-
@@ -21,5 +21,5 @@ index afd8d81a177b..e4a2960869e6 100644
          itr == t_urls.end() ? 0 : std::distance(t_urls.begin(), itr);
    }
 -- 
-2.25.1
+2.21.1
 

--- a/0048-disable-trivial-subdomain-hiding.patch
+++ b/0048-disable-trivial-subdomain-hiding.patch
@@ -1,7 +1,7 @@
-From 40e236464b5fd70d631cb51584204d9add01cb13 Mon Sep 17 00:00:00 2001
+From 1fcd35767241012f0500701cfbf6e710a44766ee Mon Sep 17 00:00:00 2001
 From: JTL <jtl@teamclassified.ca>
 Date: Sat, 21 Dec 2019 04:04:24 +0000
-Subject: [PATCH 48/52] disable trivial subdomain hiding
+Subject: [PATCH 48/53] disable trivial subdomain hiding
 
 ---
  components/url_formatter/url_formatter.cc | 3 +--
@@ -22,5 +22,5 @@ index 58cadb980bb8..afae1ebcda5f 100644
                             HostComponentTransform(trim_trivial_subdomains),
                             &url_string, &new_parsed->host, adjustments);
 -- 
-2.25.1
+2.21.1
 

--- a/0049-work-around-Vanadium-resources-being-ignored.patch
+++ b/0049-work-around-Vanadium-resources-being-ignored.patch
@@ -1,7 +1,7 @@
-From 07c58ae3aba251186a905bc8fc365a7736feeebc Mon Sep 17 00:00:00 2001
+From 861d8f417ad702f687bd6981dde6ffa12b325742 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Mon, 17 Feb 2020 05:20:56 -0500
-Subject: [PATCH 49/52] work around Vanadium resources being ignored
+Subject: [PATCH 49/53] work around Vanadium resources being ignored
 
 ---
  .../android/java/res/mipmap-hdpi/app_icon.png | Bin 6202 -> 2578 bytes
@@ -15,7 +15,7 @@ diff --git a/chrome/android/java/res/mipmap-hdpi/app_icon.png b/chrome/android/j
 index b6af9f59b7287436d7d3113794ac99621fa70673..9533ce927dbb3f4d3849d9a2c062ff31850ae454 100644
 GIT binary patch
 literal 2578
-zc-jFH3hniYP)<h;3K|Lk000e1NJLTq002k;002k`1ONa4|Kxkj00002VoOIv0RM-N
+zcmV+t3hniYP)<h;3K|Lk000e1NJLTq002k;002k`1ONa4|Kxkj00002VoOIv0RM-N
 z%)bBt3Cl@DK~!ko&6;g&9K{*Oe>1yxw$JbO8P_4Po#2Ed#34XHNoYhVQYlDKP@zf@
 zQc+t$^PyEskqT=10YutL<)xL{(l30d1VJe&MXDf_hLlDD6d<%Nae@tbabi31OJdIN
 zcelIK4?BCeciy|(%Zu9QboTA+?#yrg^UO0dI}873CN6Rw>VE|!0D;tB_gDcA3Wb9@
@@ -67,7 +67,7 @@ zXXB@sW|~>%NnwTFPc9S4yIy9tcp`dZ$9=x*cD58r()wd%HYdv}pnUV*K$DqAt8PAy
 o?sU%izlC<8Z|MbZHC}-I7X>G&nZLZnpa1{>07*qoM6N<$f{)wb@Bjb+
 
 literal 6202
-zc-jFv7{%v_P)<h;3K|Lk000e1NJLTq002k;002k`1^@s6RqeA!000;PNkl<ZcmeHv
+zcmV-A7{%v_P)<h;3K|Lk000e1NJLTq002k;002k`1^@s6RqeA!000;PNkl<ZcmeHv
 z36xz`neO-Rea^YVt-7hIR8@vlr7H8BkRb$+03tS|L6)>=)Yr>?&nLG1y7g((!oyZu
 z#rKe=b+z(n2Lzkf$Z8zy76_3+NeCbcfrLOpAR$#5s#0^+ozJlM|L)zMRqIw!w<vNG
 z#I^iuecAWkbM_g&^X>ot_kYd_F*7RLA5GwoHmO;7i;ajxsR0nS1}JMw#${~@y3`g;
@@ -192,7 +192,7 @@ diff --git a/chrome/android/java/res/mipmap-mdpi/app_icon.png b/chrome/android/j
 index 32cac71c8686593f0e00e2c1c029fdbaef09a4a0..5c340f7a0936223c14d858784e18e38443264df5 100644
 GIT binary patch
 delta 1525
-zc-jH=1q%AJ9sCQB8Gi%-008|9F$@3z00Lr5M??VshmXv^000HGNkl<ZSi`lLU2GIp
+zcmV<R1q%AJ9sCQB8Gi%-008|9F$@3z00Lr5M??VshmXv^000HGNkl<ZSi`lLU2GIp
 z6vuz_x!W(dAGDPgkkXcqen|K(B@mz@F;Ot#NsW<&M3W*$67|6sV|d^NG)56M@dXG`
 zd@!QMKw?M`EG=LQRs*F_nzXdkZo4gPcelGU<HOAC=ghWXJbyQtWbT~v|KEGgx%Zws
 z@IQ+%OD(gR`UYTF?LQL;h)7k7)MlwkST0uK17kwJ8|&0Nw2OUx#L%<T2wA^LH8tw%
@@ -224,7 +224,7 @@ z{<{13&F;_;egcGvx^7Cd_*Y@pfjQ)oiw6ma5h27BA)-XH{YID#fvsg;1MI5aOsE-t
 bgP8I!dk-SXspj&t00000NkvXXu0mjf!`a_H
 
 literal 3763
-zc-jH84ovZhP)<h;3K|Lk000e1NJLTq001xm001xu1^@s6R|5Hm000hpNkl<ZcmdT~
+zcmV;k4ovZhP)<h;3K|Lk000e1NJLTq001xm001xu1^@s6R|5Hm000hpNkl<ZcmdT~
 zd6<>eeSUxETkf5E@9fJA;0!XuFawODKyX2<;?f4esA=mWF{V$g)y5~qV${0iX%o|>
 z)y9(eG>eZlY7^^Y(|`*G6+^%U1Pl^{03yr`Gcfzy<$lXqdcQND_nC19xS;;gcjo1M
 z%foly_x#TJ{myshl2Qu)pJ4(35n(h=))b9AARyE27;30bPzG&)V>}N9K<gy^4-wXF
@@ -302,7 +302,7 @@ diff --git a/chrome/android/java/res/mipmap-xhdpi/app_icon.png b/chrome/android/
 index 56eeb6f6fd5a62a6fb3bdf064d96997c69a4f745..2110d524c9c403b80301dd34709d4f6fcc430f28 100644
 GIT binary patch
 literal 3727
-zc-jGv4sh{_P)<h;3K|Lk000e1NJLTq003YB003YJ1ONa4NRhv@00002VoOIv0RM-N
+zcmV;A4sh{_P)<h;3K|Lk000e1NJLTq003YB003YJ1ONa4NRhv@00002VoOIv0RM-N
 z%)bBt4oFEvK~#9!?VM?BT-SBSe{Y!?awu{rky<E9q83w|B}<lV$yH+4ixMM+<2Y^|
 zApX!GY10O^fueDP26ciKU4p_6)EGe>%L$UY1q@{Y?80_qYqjHgk+Nu`EZGz#$|NO{
 z5*KkB&b)c=_QShx8@`!&Z%Ety&@+(c&0FsM|Ia<=-gD2pm+=4c@rv@Hl~`P|DEj_C
@@ -376,7 +376,7 @@ z9k%K%AG1#Yxqn*%9UWbMYjPp9L%?(fLrhE;_#FIcjJeuX<!lB}<Wj@nvNy-CEq8V~
 tXMdbzt~W?J>%)T!-Glpw=5&Y9{{mHf#%w_K>9PO-002ovPDHLkV1nv5AYT9g
 
 literal 9181
-zc-jHoBO=_1P)<h;3K|Lk000e1NJLTq003YB003YJ1^@s6;+S_h001MTNkl<ZcmeHw
+zcmV<3BO=_1P)<h;3K|Lk000e1NJLTq003YB003YJ1^@s6;+S_h001MTNkl<ZcmeHw
 z37j2OneYFcs=N2Tbf>eVJA2Y(NgyPE5kxR3pbjdGqd16;<M3vDF3zxwilX3x<BaHY
 zaddRl`6<IZ9c7ULWg!AWOd=2rNytt*=}vm@yVO$We6RYuRqdrn-*l6{A^LmY%|BK5
 z-db+`|KIt(vz)3HM1=ouubi1aAcVjvY@*!zh*A0Xr;de=Z=Ql=N0tn>GV4@kox=4~
@@ -558,7 +558,7 @@ diff --git a/chrome/android/java/res/mipmap-xxhdpi/app_icon.png b/chrome/android
 index 6deb0e4928164f343101bff8345e1c3c544f7210..f4894e5b5b5047708bad46853f06c3bd68e54aa0 100644
 GIT binary patch
 literal 6160
-zc-jFF81LtaP)<h;3K|Lk000e1NJLTq0058x0058(1ONa4O;0K_00002VoOIv0RM-N
+zcmV+r81LtaP)<h;3K|Lk000e1NJLTq0058x0058(1ONa4O;0K_00002VoOIv0RM-N
 z%)bBt7s*LPK~#9!?VWj$9MyTif89OTUfN4qUAvM%Vzo#}kw8e`00IoMAyC-Zv11cE
 z#ARa2c9khRNmU%jE?jneRKQ1U2OQsb0CQs(64)FD34sBFBqRhvNGt6n?Xv9LGu@p(
 z`g%RnJ<~JOqr>HIYIgg4{oZfB?|b)a_>25S{vu5j=_Gi*exgUPS<jU0zmn^?14Vaj
@@ -679,7 +679,7 @@ ze;qSGZcNx~(z;hnFCCERG|Xu(gX37CIo5#0=as%T&i%$B5IZ^CZx(=KhUWMH@_Mq@
 iy8!i)|Hl}MBmWOUsYCM~E)RwP0000<MNUMnLSTZfrRkLb
 
 literal 15361
-zc-jF0JpRLpP)<h;3K|Lk000e1NJLTq0058x0058(1^@s6=SJeV002A4Nkl<ZcmeIb
+zcmV+cJpRLpP)<h;3K|Lk000e1NJLTq0058x0058(1^@s6=SJeV002A4Nkl<ZcmeIb
 z37j2Ong9KJPSsuR?R`ln>Fj$#5<&tbETABWD5K(ni?}%Ms52-o;^H8Vj;N!fGN_}X
 zxP!~<GU5U_h#)&85SAnmvLxN<^xk*5b!(|}-g}>})6~B{eLLNqPWl3QI?t!7Zf@67
 z_3hvDoaLM%r4%M>$LyGy06;`|jvHa(rtlm#Ej;FP91@y>{i)|NT+e2JXaegK0ZNUr
@@ -980,7 +980,7 @@ diff --git a/chrome/android/java/res/mipmap-xxxhdpi/app_icon.png b/chrome/androi
 index 32241024ecd783e1d1cf60479648e0bebe2b7763..1e02f37a1a940619f19cb73eb3605e14e8b0cfef 100644
 GIT binary patch
 literal 9104
-zc-jGwBX8V^P)<h;3K|Lk000e1NJLTq006)M006)U1ONa4_|>G000002VoOIv0RM-N
+zcmV;BBX8V^P)<h;3K|Lk000e1NJLTq006)M006)U1ONa4_|>G000002VoOIv0RM-N
 z%)bBtBS}d_K~#9!?VWd&9MzrgKNY%rva)7I5-1QPB!UbAga|emY{2&6*v9dAkKb7z
 zN1ns_t?_y9t@rKPn>hB`hPAy8Zygq6!ai)+0}j{(BQi(`fk8+JWsPP=(nu3JR(O9@
 zPTf`ARXqdCZ_b3O>AH36`@O$#e>W7oA#cbV@`k)2|5Zhp?h0g7SADuG8&~A%u0UN8
@@ -1158,7 +1158,7 @@ z&TnT3ZAJm_ecYKSLdb8y_m^AzAbV#p&N$%xk2#Y?sB;t)z0T1Ll>ZM}!uj~k+35iQ
 O0000<MNUMnLSTY_yT{`I
 
 literal 21370
-zc-jCaK-s^EP)<h;3K|Lk000e1NJLTq006)M006)U1^@s6Qrv6@002`#Nkl<ZcmeIb
+zcmV)7K*zs{P)<h;3K|Lk000e1NJLTq006)M006)U1^@s6Qrv6@002`#Nkl<ZcmeIb
 z2b^S8l|TNy_r1!UbI){7hY2%1IgmkuilTx+LD#T9g;iG<6)|AY6~ii+{|cz9s3_`h
 z7Z=5Vih_XPDtUlmn84&P)440Zdf}db)$Lc!``q8_sj2DinXa)<b9k@9RMo5ceor{}
 z+<O@jVNT}cA5}R1fn`qSM29PkF-%$JgyHxIVM;P5#mGm;oJ=Rs*))=a=7=$)GDm<i
@@ -1473,8 +1473,8 @@ z23GW*5`0;Ukg=YBZRRr-lRS?Vgt?!A!$DBvo}EvW@&-)+qj&?Uu`#@0#e8aRsAWS5
 zLrr`uI{D2e6L{*;zu&y`xot)3Z~HXA(Vc(UNJ5n60td?4DOwGIifaAwCttsJtbhOC
 zNZ7Mrh>`i|<U-2dbcq|!%Wy|`HNcrXaz#ClN!2tC1_2033g1>aMr?vA<i24#okn9!
 zqtjP(A)YmrMZhY&?r+;Tw13avZv5&O?p0!cB?MA%I~4*j&ZK_)hkqe2!#rV-)UlyM
-z>FtmI<vT_?VKT-~5Xg&)vH*YLDeC{Ya2(gNyKDlRIC`%}-eM%ZbtVy~b60gk4*^sY
-ztLy}rZ3~<%QovL?5x4&Kmp^}}|ImT77kjGp|6ShtGsaNRsSu!ykzuL!Uw?b+lY{%7
+z>FtmI<vT_?VKT-~5Xg&)vH*YLDeC{Ya2(gNyKDlRIC`%}-eM%ZbtVy~b60gk4+NNP
+z3!E%cz*IUBxBm8*KYynILKD60|ImT77kjGp|6ShtGsaNRsSu!ykzuL!Uw?b+lY{%7
 z`-Pn|z?gOnyTP$CRFN`3UkO4a0qwg*5rMq5Qu$oYG{nc^SUj%=OMBW_+OWYGPMX9w
 zXJoPKxh=Q<_pLWSDM4S}$nO+90OJ$-iCZ2#q8AuByf6L4y?5M_85=xIL}l=+d{CEf
 z<ts_tn4W}R-~;B?ONkYK!~#HafR&{etm%PG41(ySiTg<qMu++j|L%^T-*RBzp2@Ah
@@ -1572,5 +1572,5 @@ z{Tu<Nnkz_QrH@kre%VA&j>i@7a|D<pgg?NK4*0B0Z&c2C8GxUY{~vduWcP4*f|dXP
 N002ovPDHLkV1m9{eU1PC
 
 -- 
-2.25.1
+2.21.1
 

--- a/0050-Download-on-Android-Q-Remove-a-DCHECK-in-CreateReser.patch
+++ b/0050-Download-on-Android-Q-Remove-a-DCHECK-in-CreateReser.patch
@@ -1,7 +1,7 @@
-From 42e83e49281b8f1b8abb4d43ce586b67820daa07 Mon Sep 17 00:00:00 2001
+From 341652fa0c20855609c04d5b1603a471af0046d8 Mon Sep 17 00:00:00 2001
 From: Xing Liu <xingliu@chromium.org>
 Date: Tue, 18 Feb 2020 21:10:54 +0000
-Subject: [PATCH 50/52] Download on Android Q: Remove a DCHECK in
+Subject: [PATCH 50/53] Download on Android Q: Remove a DCHECK in
  CreateReservation.
 
 When resuming a download, the suggested path can be content URI. This
@@ -31,5 +31,5 @@ index f4bc7a4ee132..ea2032d721eb 100644
    // deleted when all the reservations are revoked.
    if (g_reservation_map == NULL)
 -- 
-2.25.1
+2.21.1
 

--- a/0051-Upstream-internal-DownloadCollectionBridge-code.patch
+++ b/0051-Upstream-internal-DownloadCollectionBridge-code.patch
@@ -1,7 +1,7 @@
-From 9ae066cd034fc1744fe80673381173d83b19a8cb Mon Sep 17 00:00:00 2001
+From 95b596832f09cd04a9f27ff2f5bd883cb8055e1c Mon Sep 17 00:00:00 2001
 From: Min Qin <qinmin@chromium.org>
 Date: Wed, 26 Feb 2020 15:19:59 -0800
-Subject: [PATCH 51/52] Upstream internal DownloadCollectionBridge code
+Subject: [PATCH 51/53] Upstream internal DownloadCollectionBridge code
 
 This will allow download in public chromium build to work on Q with MediaStore.
 
@@ -1312,5 +1312,5 @@ index 000000000000..c4664aab7b1e
 +    }
 +}
 -- 
-2.25.1
+2.21.1
 

--- a/0052-disable-unused-safe-browsing-option-by-default.patch
+++ b/0052-disable-unused-safe-browsing-option-by-default.patch
@@ -1,7 +1,7 @@
-From 38402e4057df55ad3e9ef57166bf50210703ca6d Mon Sep 17 00:00:00 2001
+From ba290738f67e06262a550cca3c74c5b95f42cd61 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Thu, 12 Mar 2020 13:01:02 -0400
-Subject: [PATCH 52/52] disable unused safe browsing option by default
+Subject: [PATCH 52/53] disable unused safe browsing option by default
 
 Safe Browsing is currently a no-op due to the lack of Play Services, and
 support for using the local database backend hasn't been implemented.
@@ -25,5 +25,5 @@ index b7a7797a037d..f8fdd6a57763 100644
    registry->RegisterBooleanPref(prefs::kSafeBrowsingProceedAnywayDisabled,
                                  false);
 -- 
-2.25.1
+2.21.1
 

--- a/0053-disable-V8-JIT.patch
+++ b/0053-disable-V8-JIT.patch
@@ -1,0 +1,26 @@
+From 89b58572bdd8a7ca459563d283b7d6cc0273fa3e Mon Sep 17 00:00:00 2001
+From: Zoraver Kang <zkang@wpi.edu>
+Date: Fri, 13 Mar 2020 23:55:12 -0400
+Subject: [PATCH 53/53] disable V8 JIT
+
+---
+ content/browser/android/content_startup_flags.cc | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/content/browser/android/content_startup_flags.cc b/content/browser/android/content_startup_flags.cc
+index 680ae76ce5c0..4f3f9e70b2a9 100644
+--- a/content/browser/android/content_startup_flags.cc
++++ b/content/browser/android/content_startup_flags.cc
+@@ -57,6 +57,9 @@ void SetContentCommandLineFlags(bool single_process) {
+   // Disable anti-aliasing.
+   parsed_command_line->AppendSwitch(
+       cc::switches::kDisableCompositedAntialiasing);
++
++  // Disable V8 JIT
++  parsed_command_line->AppendSwitchASCII(switches::kJavaScriptFlags, "--jitless");
+ }
+ 
+ }  // namespace content
+-- 
+2.21.1
+


### PR DESCRIPTION
I have successfully built and run Vanadium with this patch. Performance-wise, I observed a ~25% decrease on Speedometer 2.0, but did not notice a meaningful difference when viewing several relatively js-heavy web pages.