### PR TITLE
Recolor logos used in chrome://version

### DIFF
--- a/patches/0001-use-64-bit-WebView-processes.patch
+++ b/patches/0001-use-64-bit-WebView-processes.patch
@@ -1,7 +1,7 @@
-From 39191ed157be65222a40306cf5d2bb5ff0e4095b Mon Sep 17 00:00:00 2001
+From 20a32750a63d698e166a5ddc3d43a86e6c886162 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Thu, 26 Jan 2017 01:30:12 -0500
-Subject: [PATCH 01/57] use 64-bit WebView processes
+Subject: [PATCH 01/58] use 64-bit WebView processes
 
 ---
  android_webview/nonembedded/java/AndroidManifest.xml | 1 -

--- a/patches/0002-switch-to-fstack-protector-strong.patch
+++ b/patches/0002-switch-to-fstack-protector-strong.patch
@@ -1,7 +1,7 @@
-From 659700bc0415a6a655d84f2ac18ac5d5bf679876 Mon Sep 17 00:00:00 2001
+From f329fbbe62a641458418a6c88c7c38dbff4e882a Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Wed, 26 Dec 2018 10:20:24 -0500
-Subject: [PATCH 02/57] switch to -fstack-protector-strong
+Subject: [PATCH 02/58] switch to -fstack-protector-strong
 
 ---
  build/config/compiler/BUILD.gn | 6 +-----

--- a/patches/0003-enable-fwrapv-in-Clang-for-non-UBSan-builds.patch
+++ b/patches/0003-enable-fwrapv-in-Clang-for-non-UBSan-builds.patch
@@ -1,7 +1,7 @@
-From cfb2b8702ba37014a432d9112404457e8420db08 Mon Sep 17 00:00:00 2001
+From f4ee346dfed8041c8f247c2cfd60f2a0a8edb584 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Thu, 22 Dec 2016 07:15:34 -0500
-Subject: [PATCH 03/57] enable -fwrapv in Clang for non-UBSan builds
+Subject: [PATCH 03/58] enable -fwrapv in Clang for non-UBSan builds
 
 ---
  build/config/compiler/BUILD.gn | 4 ++++

--- a/patches/0004-enable-ftrivial-auto-var-init-zero.patch
+++ b/patches/0004-enable-ftrivial-auto-var-init-zero.patch
@@ -1,7 +1,7 @@
-From d3ada82ad2ca35f87ca7ecac4088fd2ee7f17453 Mon Sep 17 00:00:00 2001
+From ba87866cc5d4190d1874d72b6fb9996372917494 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Wed, 8 Apr 2020 20:48:17 -0400
-Subject: [PATCH 04/57] enable -ftrivial-auto-var-init=zero
+Subject: [PATCH 04/58] enable -ftrivial-auto-var-init=zero
 
 ---
  build/config/compiler/BUILD.gn | 4 ++++

--- a/patches/0005-Vanadium-branding.patch
+++ b/patches/0005-Vanadium-branding.patch
@@ -1,7 +1,7 @@
-From 68886ac1aff9bf30dd67fa9e9006573da5bfb38b Mon Sep 17 00:00:00 2001
+From ff07bafe5eca54d258548ea746d1fe14a12f9387 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Sun, 6 Aug 2017 12:45:14 -0400
-Subject: [PATCH 05/57] Vanadium branding
+Subject: [PATCH 05/58] Vanadium branding
 
 Current incantation of the recolor command:
 
@@ -145,7 +145,7 @@ new file mode 100644
 index 0000000000000000000000000000000000000000..d9d6661c938b2907e30da3ae87cdb2894db5592d
 GIT binary patch
 literal 11327
-zc-jF!EWp!=P)<h;3K|Lk000e1NJLTq006@P006@X1ONa4m3D0*00002VoOIv0RM-N
+zcmV-FEWp!=P)<h;3K|Lk000e1NJLTq006@P006@X1ONa4m3D0*00002VoOIv0RM-N
 z%)bBtEBHx7K~#9!?VWj)99MnsKlfJkKKmk#mXTyhSd#Y*%Ra`5ZCUog#tV)yF&KC+
 z<|GDU90K9Jge8O+2<PDNut@^%ybwqX4mOD~#x|Rm=jGuAZ?Y}P+NBwdW}lwvwYsb7
 zzCWs$s-B*i?&)QO$#0HE)79N|Z~eaax7^?T-QN}0Q9VgAq==9~B1y1@DNLZ1EKwAS
@@ -366,14 +366,14 @@ zJ0a3!Go$*HoHB+u);$m(um^Pmpo6HZ%F^*i{~yS0JYSiOkN*Gw002ovPDHLkV1iRV
 Bx8MK(
 
 literal 0
-Hc-jL100001
+HcmV?d00001
 
 diff --git a/chrome/android/java/res_vanadium/drawable-hdpi/product_logo_name.png b/chrome/android/java/res_vanadium/drawable-hdpi/product_logo_name.png
 new file mode 100644
 index 0000000000000000000000000000000000000000..8678cbbb730de9c3ff9d3dba7d928d60f28bd550
 GIT binary patch
 literal 1998
-zc-jHZ2Qm1GP)<h;3K|Lk000e1NJLTq005f+001Be1ONa4uVuoq00002VoOIv0RM-N
+zcmV;<2Qm1GP)<h;3K|Lk000e1NJLTq005f+001Be1ONa4uVuoq00002VoOIv0RM-N
 z%)bBt2Zu>SK~!ko<=J0sWOWq>@Xx*Tue$}h(?xgL^$(e{1YKD$ttiGof~^Vx9)MOu
 zG$zJ$V+<<#(2`(G2$D7sv-n`r`s9OR+7Oj!jP4K>9x$+jvMdlpCd<G5<L-9a?Y7g-
 zOlN%PbUM?eP`V|f@STVG{k!LP&i9^kf9KpA+yX)cp|aCLam8fei-l{8d&(cGTp%zN
@@ -414,14 +414,14 @@ zza1|{8eS^B9}!%))KF3pS28cMJ#j<i+Hm*uwq56aHaKx+;rQJ1`Nz)uvHbcbt!9+#
 gs)YxeZ9!A;U++Vmx7pctfdBvi07*qoM6N<$g5_ZC5&!@I
 
 literal 0
-Hc-jL100001
+HcmV?d00001
 
 diff --git a/chrome/android/java/res_vanadium/drawable-mdpi/fre_product_logo.png b/chrome/android/java/res_vanadium/drawable-mdpi/fre_product_logo.png
 new file mode 100644
 index 0000000000000000000000000000000000000000..40b88b5225ddff2fb47116a99a38999218e744ec
 GIT binary patch
 literal 6794
-zc-jGq8g=D~P)<h;3K|Lk000e1NJLTq004pj004pr1ONa4APU%a00002VoOIv0RM-N
+zcmV;58g=D~P)<h;3K|Lk000e1NJLTq004pj004pr1ONa4APU%a00002VoOIv0RM-N
 z%)bBt8be7$K~#9!)tz~iB*lH_KM{G<)z|bjJ@>)D%!mO-Fw7-DAPmTokc7~a^mM>3
 zZzcS8pLT_9R@Sb(&)T)*U3n#2eztCw(_%quSrW30g+~aD#AO%`F)++9!yMhycU9M2
 zm6esTe`IDI-BsOnwFSR?U7eMc85!}--xa_3MWpxuOOYgpLdU@%#5jW(oWUeO8V!Yp
@@ -554,14 +554,14 @@ zhj>D$5MmkU-7e!>Q2kdIXfIhW74NXI16-hOVT5&Tll`hE8(I@M7MRpEgsm*{#hgm!
 s;^t9aPfn=Q!52i_!lZI+YPsnD1F3svQs!l<l>h($07*qoM6N<$g1%n2wg3PC
 
 literal 0
-Hc-jL100001
+HcmV?d00001
 
 diff --git a/chrome/android/java/res_vanadium/drawable-mdpi/product_logo_name.png b/chrome/android/java/res_vanadium/drawable-mdpi/product_logo_name.png
 new file mode 100644
 index 0000000000000000000000000000000000000000..5f92063170520afa34dd48fa6610ea122439e916
 GIT binary patch
 literal 1200
-zc-jH51W)^kP)<h;3K|Lk000e1NJLTq003tI000#T1ONa4@uE1m00002VoOIv0RM-N
+zcmV;h1W)^kP)<h;3K|Lk000e1NJLTq003tI000#T1ONa4@uE1m00002VoOIv0RM-N
 z%)bBt1Zhb`K~z}7&DURyTy+%(@Xx(>_FsX@O}84i3U(VMgzx}UVwc9o;1FXpBtoWy
 z2j6rWUf_X*Ex|`ac1+~Kw;kh?hR6=+gBnd1V-!O{cS$sAG|)-^n3k4yW}(~d?#%4H
 zJk0Ig(t_M=8p?UO_x{fBob&yjbAEqr@Ss2<(bv_zXSLeh+uv!6mFS39qGs}1Psy+Z
@@ -587,14 +587,14 @@ z^+sAqN|1`A|9R&d!QRnoG_`We?y>N~$>SGZU49|`b6{BT;s2taFnJGY>5Ee&#m%|^
 O0000<MNUMnLSTZ4d0|-q
 
 literal 0
-Hc-jL100001
+HcmV?d00001
 
 diff --git a/chrome/android/java/res_vanadium/drawable-xhdpi/fre_product_logo.png b/chrome/android/java/res_vanadium/drawable-xhdpi/fre_product_logo.png
 new file mode 100644
 index 0000000000000000000000000000000000000000..07ecccb90a3786c3c3d7ac33a3f8cb2d2ee555b2
 GIT binary patch
 literal 16100
-zc-jHvJ{!S_P)<h;3K|Lk000e1NJLTq009I5009ID1ONa4WC4PK00002VoOIv0RM-N
+zcmV<AJ{!S_P)<h;3K|Lk000e1NJLTq009I5009ID1ONa4WC4PK00002VoOIv0RM-N
 z%)bBtKAlNKK~#9!?Y()N9A|y!|9+mT>T52|jP6^OWZ9N1VOvH9-zHeb#!fgw4%lQv
 z$ijkcSV%%nLjpgJCFC%egaq>2WV4%1AUFXM8<TL^1|O0SNyfU5(Tp@#&(+g+RXzJh
 zbx&7!Rrhqy^fjzM^HOW3y6UOt_&(q3`99xAyqU#AATUW`(?ymf-K5CSOD`ws#wNu|
@@ -906,14 +906,14 @@ zHcQ#BHdrh4<*AJ_B6{r&$*>;S8h$!F714vru|u<1B12pyR4S0QllFOiQcu_e_IP%D
 q!#O!IXc-t}kqB(e_H@WD3jY_Ejr#a36nZuQ0000<MNUMnLSTZIDYe}I
 
 literal 0
-Hc-jL100001
+HcmV?d00001
 
 diff --git a/chrome/android/java/res_vanadium/drawable-xhdpi/product_logo_name.png b/chrome/android/java/res_vanadium/drawable-xhdpi/product_logo_name.png
 new file mode 100644
 index 0000000000000000000000000000000000000000..ee268c83d97f8d6b73eac0dbe25a204dcc91d4da
 GIT binary patch
 literal 2609
-zc-jFm3eNS3P)<h;3K|Lk000e1NJLTq007Pa001fo1ONa4QNyg;00002VoOIv0RM-N
+zcmV-13eNS3P)<h;3K|Lk000e1NJLTq007Pa001fo1ONa4QNyg;00002VoOIv0RM-N
 z%)bBt3F=8iK~#9!?VEp$9Az2DKl9G)>|MKe?OY3KEzmHhZ7oJh_b?bl5q6Cl$`8$6
 zVyeMtyrsqjL?Wkupu|7C13_#I&?Eea{E9vN5hVoEGmQ!{$}OUR0>T#Bv=rLj-0j}p
 z?#}Mc_{YxP?flr@59Y4e+;@|^n`hsd?>o=)KF|BS&-<SA1?mt~siI;sg@r%{tPPb<
@@ -966,14 +966,14 @@ zR{4SA1I10^GC3}7F0I#ApB+75niI9R&DV<0m-ZK5R*5d?U#*rgcSy_XegEQref)de
 TPbPHy00000NkvXXu0mjf*Ld(I
 
 literal 0
-Hc-jL100001
+HcmV?d00001
 
 diff --git a/chrome/android/java/res_vanadium/drawable-xxhdpi/fre_product_logo.png b/chrome/android/java/res_vanadium/drawable-xxhdpi/fre_product_logo.png
 new file mode 100644
 index 0000000000000000000000000000000000000000..4f300d7f849b005ba63163d63a643f3aeb737aea
 GIT binary patch
 literal 26693
-zc-jCpK+3;~P)<h;3K|Lk000e1NJLTq00D*o00D*w1ONa4)rszI00002VoOIv0RM-N
+zcmV)WK(4=uP)<h;3K|Lk000e1NJLTq00D*o00D*w1ONa4)rszI00002VoOIv0RM-N
 z%)bBtXZ}e<K~#9!?Y(!LBu9Ps|E}tuxOs2)a#YSbC6rMH1Ok&yFg9R#z!)AIunpLL
 z%wufxke!VaVEiK*3?>O1Bmol20R<$TPP(+WySF*bPV7*>KYC`TXQroTW_M<HW_CaQ
 zy4&5E>h9|5`qVenx4tD_$?8A=kjBJDrvsA(Bz>49u+a!}I!}@z!wwdh;UrRoh%-qC
@@ -1289,7 +1289,7 @@ zdcKKqUq4ciB!{qTmJ6-Wr*uL*_0Tg2KpGerq@K0fPBJ*qNO3#8zT<uz$-B{8IEHn3
 z5G2ug55gx)5<nM6+b~wufriD%p(7mSsG}z7$fu09GoisrTOZ*OCh77ir8C53+`>W=
 zkzqAfmrLe(DVH+jn;lOl#X&6e8Z#xe261c>!<(Mk&NjB?#DU0|Pqs$oYlT2#m^;{1
 zK?R!U{p?|;N#x^dybFzK_VRna>lZ-L&9j^!*y2l}ydlV7{<7cbp@$x1m@r|YaDTh3
-zcPoBe8^Jv+(B;#`0T3wf*90>}crP?X+R4?Rf+UIHeT13ued0h?E@(BTlWdKlRiKF9
+zcPoBe8^Jv+(B;#`1T#c<FEmBk$<?5OB#GdCgqiVu;y_j|Xf>vj0rV#e*ldlVRiKF9
 zzd)QAF{Fisg^lsB*(9T4{U12UP(|6GGsHFgDzj_+8dobLmCYQl<C+R8l1(=UnIKeS
 z{=C+pg0lxv`oY}h?#>J}7UE&M3C6_6;YUo+U*RQ9^M1}{x^BBzHZL@$Igj@-U7=i*
 zMSh7u)-+JI3Kc*jsgl3QkS0w!_ly!XY&^QwRcjOkL5}l%)#Lk`1Pd5^jQ$FN%#Fip
@@ -1489,14 +1489,14 @@ zmdO6dLevV2PCKFk1e8tyg&_<~Vak+T6mgOyRl46yrqzfT&dhB~rQ@;TuHku8A=pF*
 gCy1=|1GgRie-#m>m)v0)5&!@I07*qoM6N<$f-sBn4*&oF
 
 literal 0
-Hc-jL100001
+HcmV?d00001
 
 diff --git a/chrome/android/java/res_vanadium/drawable-xxhdpi/product_logo_name.png b/chrome/android/java/res_vanadium/drawable-xxhdpi/product_logo_name.png
 new file mode 100644
 index 0000000000000000000000000000000000000000..fc327262fd9479d15200e5ebca3f5335a1ce12c4
 GIT binary patch
 literal 4270
-zc-jH35K-@mP)<h;3K|Lk000e1NJLTq00A`s002J-1ONa4EBcpR00002VoOIv0RM-N
+zcmV;f5K-@mP)<h;3K|Lk000e1NJLTq00A`s002J-1ONa4EBcpR00002VoOIv0RM-N
 z%)bBt5NAn5K~#9!?VVe28`pWqe`j}b;Y}oD-6h)*Bwyq{=mJ@mRC}5zU^<Q`Gqz+Z
 zeTeH!(@;q|(_}iGkvxslNj>RMO&_Z1q%mnH(^#G+rXu^L^(CS+aZ^=^B}kQ%Sh6F*
 zvUQ^rkst|@xGb>S2P_r~VlR*kg0O`@W(W{x&+fOoe|+aV-{q{>jujFrDn4X#q|wQs
@@ -1581,14 +1581,14 @@ z*2`;HlJ4qiTN*q=E}fs&#<Ev(?_^F){hCug1Ockg5ozLPfoK}+P1Fbf4>8lX6)B~&
 QLI3~&07*qoM6N<$f)Jt_fB*mh
 
 literal 0
-Hc-jL100001
+HcmV?d00001
 
 diff --git a/chrome/android/java/res_vanadium/drawable-xxxhdpi/fre_product_logo.png b/chrome/android/java/res_vanadium/drawable-xxxhdpi/fre_product_logo.png
 new file mode 100644
 index 0000000000000000000000000000000000000000..52abcdfc19c13770971730c8bd4d8267a633ac22
 GIT binary patch
 literal 39011
-zc-jC^K(D`vP)<h;3K|Lk000e1NJLTq00IaA00IaI1ONa4q4nPA00002VoOIv0RM-N
+zcmV)xK$E|TP)<h;3K|Lk000e1NJLTq00IaA00IaI1ONa4q4nPA00002VoOIv0RM-N
 z%)bBtfB;EEK~#9!?45U<Bu9Dozg686H{RY}4!S!@r;~KbIR}u)29a!IW57g%jcpvk
 z*v7^YkWF#`1I9MI7>j5yK}Z5cKmiFPp?tcy;WqD1?ojU^J+qT~W_o64cEa{=KGN+>
 zcXd})S3UjYN4%U)f<TbQL}8<$6GAeJKr%ppX#$u?G&IiV3C4(GBH78~gpi!VA)*ZN
@@ -1904,8 +1904,8 @@ zAtnhgKOCs$P3V5aDezV6u~v$0uvy^wynth#$$`xf0p8CnqrUc_F4zn*#b5GChFJ2r
 z5hb(i=REEqMHn5c!e*%UTlq2X-i@Ux&b;~)*1AtUB%suzu^jo8u(a1K;J{=qAA117
 z!d2dV!`cB!f;4BKm+9y$SJ-pk0t(y1o7z1i&Jz9n36_gjL?sA@`8W?U($2}F`^bTV
 z^*q4G8L4AsDl%NlAW4$cryp=XCOmKGVtYX)jYXxF-uwru!(BsBK0`UJ2P|A3BeDFE
-zIs2oD-DjQFsTzblrrE-d0)GVe?1;5;Ce}w1@(@6b=d!PkgkKf_P(ZK0JNPkQAX1Y2
-z)rS{2RiwYbee9^i+Az-!&Lu+z1Kopup!8T}iM?7oQTE-texSSu)rnT+D|xwRPGr^q
+zIs2oD-DjQFsTzblrrE-d0)GVe?1;5;Ce}w1@(@6b=d!PkgkKgr_%UA~Qj+}DhZi_i
+zq`$y@?5M-qFwYLoB|`=P(m*Z01Kopup!8T}iM?7oQTE-texSSu)rnT+D|xwRPGr^q
 z`z$M*w=~KW&L>Us;`GKAKG~)~Vz9s&L|t5z>Vtp^9`EkwI?z~Rh~FcD>5+l8Sx1}?
 zVbJG`3k~+WAA=8)tRsnx%@UU}LNaTnZj>J=wL>V^mhRuZ^8;>%L~kO3C~N8M%tG>J
 zYzkl0znn2?c~vXqS%%i>{DG6baFD%D{YlEziPbrW{PZ~RW^pJyKhBHT$FxTkmqIeg
@@ -2221,10 +2221,10 @@ zNnf2<2ZGFV7&#Sq5%Z!T1<mSWRjmw#kO+8If0gm=neZqf49^qbZ}*j=R=9KSn<z@G
 zn)^McHOPA^sDi&u5(K#pjhLToy$*y};u&O8e^us?f!Vg1)8lQqts>(H3O~?ZpZV_@
 zMhPtE{r9o@a93U_SF><=;`KaiOfp=|8F8xs02mNSL_t)@9;S%-$<jO{M3Mu<xaf5!
 z-X6znqawCtY1penWNDyH=!?M(v5(C%+R<JKy$m;Z<=nSYfkBm!j$*;VNtQOkb4ZaS
-z?ehm75hTqs81((-@J*wvbGYX=VO3)p0mBzO=nCPyI~0n*$AjxL@0;;S!YZM1cI8q%
-zfsHB>2nzEmmb);6MFxY**vc63wl3>#LJ*5*h%xx*)<0!XB-+}Wjv(UVFZ9nRne#2y
-ztANVy_tM|hvca+Nh${Ji;W3jqTe*w{;w`C6+=~ccbAWk5pHqL?2_kbx5Cn_J>xRD;
-zV-Bq|I<zKHsS-owY>LIdTVx1uEkPFiQm!7M0|%I9*H=bg-x=}09kTzV6?l#OVUjtY
+z?ehm75hTqs81((-@J*wvbGYX=VO3)p3gNsv6pFydgX=TzoAF7)Dxq?A<x)L?jVcld
+z3iB$KyD)=A27}Ak${6vsF6(YW5Q}GsG5F`!KV?uP+S;3rAmZXL^v@@m^DWk^fXeUp
+z(%;px!Ljg&D*1omF_So3xr_zkEvZc0iwIzIfO$fnQ-9eBB6CL&1dGV)hQAhL4y`jf
+zv?fuh5<}%|ip9TMWC(CAK^FW{t{$NS2bcjR7ux7%*H=bg-x=}09kTzV6?l#OVUjtY
 z(OfkYyCYTdGH^RytVYcJ>X;kPWuBx9Z{edH8j?dy(|7mo*VtAk@CO}35EOP&T&Ld|
 zXBOEho$5K1O8)Mag~H>i2H%iBYLXzrbAXtiJJAy~bPh6&cBi`DN_R>QF}>Y%Dd&PA
 zu;cox)E)7?lHs;TIIIO!^OJYe5#)a_hhuKMlwC}b@Xd`LprLb!DMC-CUZoOxR(Tsh
@@ -2341,14 +2341,14 @@ z_ovCc>JVL~6Nel*qf8EkA(UZKq##1!Qp6RmDdR~WZ@xb2TgT;pb#Gjxe1+ay)NW^0
 f`ch_Jq&DIIbfZ@m$+<~>00000NkvXXu0mjf!$8AO
 
 literal 0
-Hc-jL100001
+HcmV?d00001
 
 diff --git a/chrome/android/java/res_vanadium/drawable-xxxhdpi/product_logo_name.png b/chrome/android/java/res_vanadium/drawable-xxxhdpi/product_logo_name.png
 new file mode 100644
 index 0000000000000000000000000000000000000000..5f16990a7eb67c441bfc62d50a4e92f95c0f4f22
 GIT binary patch
 literal 5925
-zc-jFa7ux8FP)<h;3K|Lk000e1NJLTq00Eo;002}71ONa49E3^V00002VoOIv0RM-N
+zcmV+=7ux8FP)<h;3K|Lk000e1NJLTq00Eo;002}71ONa49E3^V00002VoOIv0RM-N
 z%)bBt7T!rjK~#9!?VW3I99NZqzuVpO(9<5-ma!dTYwU!O1cx9c1V|NBN`~dR6d=Qr
 z;9Wu?k?a=B0u`Gjfm)z~9jXYhOTeO*uml3JYO~8D0oK~=BfOGWu#f~N!5-W3Te4>)
 zjYgVh_x_lkQTI&G^c`g+&6xhCT<%dn=AQ0*`kZ_3x#x;^P>w=|ETAD!nMOe;4fx2R
@@ -2465,14 +2465,14 @@ zntO)Bsb@2f>)9Xy)CEPqd3ZD)!gH8BJZeXNYNm&WN0I*rsl^JT&aD`J00000NkvXX
 Hu0mjf>GD|)
 
 literal 0
-Hc-jL100001
+HcmV?d00001
 
 diff --git a/chrome/android/java/res_vanadium/mipmap-hdpi/app_icon.png b/chrome/android/java/res_vanadium/mipmap-hdpi/app_icon.png
 new file mode 100644
 index 0000000000000000000000000000000000000000..9533ce927dbb3f4d3849d9a2c062ff31850ae454
 GIT binary patch
 literal 2578
-zc-jFH3hniYP)<h;3K|Lk000e1NJLTq002k;002k`1ONa4|Kxkj00002VoOIv0RM-N
+zcmV+t3hniYP)<h;3K|Lk000e1NJLTq002k;002k`1ONa4|Kxkj00002VoOIv0RM-N
 z%)bBt3Cl@DK~!ko&6;g&9K{*Oe>1yxw$JbO8P_4Po#2Ed#34XHNoYhVQYlDKP@zf@
 zQc+t$^PyEskqT=10YutL<)xL{(l30d1VJe&MXDf_hLlDD6d<%Nae@tbabi31OJdIN
 zcelIK4?BCeciy|(%Zu9QboTA+?#yrg^UO0dI}873CN6Rw>VE|!0D;tB_gDcA3Wb9@
@@ -2524,14 +2524,14 @@ zXXB@sW|~>%NnwTFPc9S4yIy9tcp`dZ$9=x*cD58r()wd%HYdv}pnUV*K$DqAt8PAy
 o?sU%izlC<8Z|MbZHC}-I7X>G&nZLZnpa1{>07*qoM6N<$f{)wb@Bjb+
 
 literal 0
-Hc-jL100001
+HcmV?d00001
 
 diff --git a/chrome/android/java/res_vanadium/mipmap-mdpi/app_icon.png b/chrome/android/java/res_vanadium/mipmap-mdpi/app_icon.png
 new file mode 100644
 index 0000000000000000000000000000000000000000..5c340f7a0936223c14d858784e18e38443264df5
 GIT binary patch
 literal 1532
-zc-jH{1q1qtP)<h;3K|Lk000e1NJLTq001xm001xu1ONa4{R=S+00002VoOIv0RM-N
+zcmV<Y1q1qtP)<h;3K|Lk000e1NJLTq001xm001xu1ONa4{R=S+00002VoOIv0RM-N
 z%)bBt1+_^;K~z}7wU}LO6jc<*fAhK9FSj4Gl@^fFmXCf&_%0<7pdv9*FyTp!k%UB(
 zB1RJR!53qA-~}{B5jF7z2vK}6qQ*dCNDwS7U<+0QrBIr*wA609Eo^tUyEEg%%<SjP
 zwqQIrnPl#q^Z(y_&bjxVJMce?FiS17nfeA`SnWR(2#82ki_~VRNmwpc;R9nrzZ>h+
@@ -2563,14 +2563,14 @@ zm1+;i!}o^%y8HLd?$8i^0)&aWZc4NGS7FwHIpmUy2MLG~A;c6RqC~U(MwktOtz}*V
 i?5f^Os2P5PnDQ@s4<gB_=JK-u0000<MNUMnLSTa0>e?Ux
 
 literal 0
-Hc-jL100001
+HcmV?d00001
 
 diff --git a/chrome/android/java/res_vanadium/mipmap-xhdpi/app_icon.png b/chrome/android/java/res_vanadium/mipmap-xhdpi/app_icon.png
 new file mode 100644
 index 0000000000000000000000000000000000000000..2110d524c9c403b80301dd34709d4f6fcc430f28
 GIT binary patch
 literal 3727
-zc-jGv4sh{_P)<h;3K|Lk000e1NJLTq003YB003YJ1ONa4NRhv@00002VoOIv0RM-N
+zcmV;A4sh{_P)<h;3K|Lk000e1NJLTq003YB003YJ1ONa4NRhv@00002VoOIv0RM-N
 z%)bBt4oFEvK~#9!?VM?BT-SBSe{Y!?awu{rky<E9q83w|B}<lV$yH+4ixMM+<2Y^|
 zApX!GY10O^fueDP26ciKU4p_6)EGe>%L$UY1q@{Y?80_qYqjHgk+Nu`EZGz#$|NO{
 z5*KkB&b)c=_QShx8@`!&Z%Ety&@+(c&0FsM|Ia<=-gD2pm+=4c@rv@Hl~`P|DEj_C
@@ -2644,14 +2644,14 @@ z9k%K%AG1#Yxqn*%9UWbMYjPp9L%?(fLrhE;_#FIcjJeuX<!lB}<Wj@nvNy-CEq8V~
 tXMdbzt~W?J>%)T!-Glpw=5&Y9{{mHf#%w_K>9PO-002ovPDHLkV1nv5AYT9g
 
 literal 0
-Hc-jL100001
+HcmV?d00001
 
 diff --git a/chrome/android/java/res_vanadium/mipmap-xxhdpi/app_icon.png b/chrome/android/java/res_vanadium/mipmap-xxhdpi/app_icon.png
 new file mode 100644
 index 0000000000000000000000000000000000000000..f4894e5b5b5047708bad46853f06c3bd68e54aa0
 GIT binary patch
 literal 6160
-zc-jFF81LtaP)<h;3K|Lk000e1NJLTq0058x0058(1ONa4O;0K_00002VoOIv0RM-N
+zcmV+r81LtaP)<h;3K|Lk000e1NJLTq0058x0058(1ONa4O;0K_00002VoOIv0RM-N
 z%)bBt7s*LPK~#9!?VWj$9MyTif89OTUfN4qUAvM%Vzo#}kw8e`00IoMAyC-Zv11cE
 z#ARa2c9khRNmU%jE?jneRKQ1U2OQsb0CQs(64)FD34sBFBqRhvNGt6n?Xv9LGu@p(
 z`g%RnJ<~JOqr>HIYIgg4{oZfB?|b)a_>25S{vu5j=_Gi*exgUPS<jU0zmn^?14Vaj
@@ -2772,14 +2772,14 @@ ze;qSGZcNx~(z;hnFCCERG|Xu(gX37CIo5#0=as%T&i%$B5IZ^CZx(=KhUWMH@_Mq@
 iy8!i)|Hl}MBmWOUsYCM~E)RwP0000<MNUMnLSTZfrRkLb
 
 literal 0
-Hc-jL100001
+HcmV?d00001
 
 diff --git a/chrome/android/java/res_vanadium/mipmap-xxxhdpi/app_icon.png b/chrome/android/java/res_vanadium/mipmap-xxxhdpi/app_icon.png
 new file mode 100644
 index 0000000000000000000000000000000000000000..1e02f37a1a940619f19cb73eb3605e14e8b0cfef
 GIT binary patch
 literal 9104
-zc-jGwBX8V^P)<h;3K|Lk000e1NJLTq006)M006)U1ONa4_|>G000002VoOIv0RM-N
+zcmV;BBX8V^P)<h;3K|Lk000e1NJLTq006)M006)U1ONa4_|>G000002VoOIv0RM-N
 z%)bBtBS}d_K~#9!?VWd&9MzrgKNY%rva)7I5-1QPB!UbAga|emY{2&6*v9dAkKb7z
 zN1ns_t?_y9t@rKPn>hB`hPAy8Zygq6!ai)+0}j{(BQi(`fk8+JWsPP=(nu3JR(O9@
 zPTf`ARXqdCZ_b3O>AH36`@O$#e>W7oA#cbV@`k)2|5Zhp?h0g7SADuG8&~A%u0UN8
@@ -2957,7 +2957,7 @@ z&TnT3ZAJm_ecYKSLdb8y_m^AzAbV#p&N$%xk2#Y?sB;t)z0T1Ll>ZM}!uj~k+35iQ
 O0000<MNUMnLSTY_yT{`I
 
 literal 0
-Hc-jL100001
+HcmV?d00001
 
 diff --git a/chrome/android/java/res_vanadium/values/channel_constants.xml b/chrome/android/java/res_vanadium/values/channel_constants.xml
 new file mode 100644

--- a/patches/0006-Vanadium-branding-for-WebView.patch
+++ b/patches/0006-Vanadium-branding-for-WebView.patch
@@ -1,7 +1,7 @@
-From 5d6d760a2b117526942f437f8bc479b1ee71802f Mon Sep 17 00:00:00 2001
+From a4cc863b08db371853793d96e7dc1ed032d707b3 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Sun, 16 Feb 2020 13:40:14 -0500
-Subject: [PATCH 06/57] Vanadium branding for WebView
+Subject: [PATCH 06/58] Vanadium branding for WebView
 
 ---
  android_webview/nonembedded/java/AndroidManifest.xml | 2 +-

--- a/patches/0008-remove-Google-prefix-from-storage-settings-label.patch
+++ b/patches/0008-remove-Google-prefix-from-storage-settings-label.patch
@@ -1,7 +1,7 @@
-From 0be20b6b32c71142b4ae304191adda5cdda96e5b Mon Sep 17 00:00:00 2001
+From 50aa0f9b699f901a5d458bcc980387ec76707af3 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Wed, 8 Apr 2020 09:51:35 -0400
-Subject: [PATCH 08/57] remove Google prefix from storage settings label
+Subject: [PATCH 08/58] remove Google prefix from storage settings label
 
 ---
  chrome/browser/ui/android/strings/android_chrome_strings.grd | 2 +-

--- a/patches/0009-remove-Help-feedback-menu-entry.patch
+++ b/patches/0009-remove-Help-feedback-menu-entry.patch
@@ -1,7 +1,7 @@
-From 57ad0f6dd398892a34052177fb0c2020bb845e65 Mon Sep 17 00:00:00 2001
+From 7ac2c026db458d1f19d51f162003ae45bfb09335 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Sat, 6 Jul 2019 05:56:45 -0400
-Subject: [PATCH 09/57] remove Help & feedback menu entry
+Subject: [PATCH 09/58] remove Help & feedback menu entry
 
 ---
  .../java/src/org/chromium/chrome/browser/vr/VrShell.java | 2 +-

--- a/patches/0010-hide-passwords.google.com-link-when-not-supported.patch
+++ b/patches/0010-hide-passwords.google.com-link-when-not-supported.patch
@@ -1,7 +1,7 @@
-From c8d7096dbaeba7bae63e0d07306c2e967dabe5b1 Mon Sep 17 00:00:00 2001
+From 7532815f328000ddef072aa7a144b08a81c12c1b Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Sun, 13 Aug 2017 19:33:04 -0400
-Subject: [PATCH 10/57] hide passwords.google.com link when not supported
+Subject: [PATCH 10/58] hide passwords.google.com link when not supported
 
 ---
  .../browser/password_manager/settings/PasswordSettings.java   | 4 ++++

--- a/patches/0011-disable-first-run-welcome-page.patch
+++ b/patches/0011-disable-first-run-welcome-page.patch
@@ -1,7 +1,7 @@
-From 608ac61c1abd8ebfbf6db3274b8581527eb15417 Mon Sep 17 00:00:00 2001
+From 5a3f8b5ffe0b9db87997706cb1652c1a2f4e80c4 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Thu, 24 Nov 2016 08:19:03 -0500
-Subject: [PATCH 11/57] disable first run welcome page
+Subject: [PATCH 11/58] disable first run welcome page
 
 ---
  .../chromium/chrome/browser/firstrun/FirstRunActivity.java    | 4 ++--

--- a/patches/0012-disable-seed-based-field-trials.patch
+++ b/patches/0012-disable-seed-based-field-trials.patch
@@ -1,7 +1,7 @@
-From 1a4dad36e21c855724b37bb132fc18c2841ce8ea Mon Sep 17 00:00:00 2001
+From 7702a2a3e03ed2c1b39bfa0c18bc4c7a15ad7240 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Tue, 25 Dec 2018 16:19:51 -0500
-Subject: [PATCH 12/57] disable seed-based field trials
+Subject: [PATCH 12/58] disable seed-based field trials
 
 ---
  components/variations/service/variations_field_trial_creator.cc | 2 ++

--- a/patches/0013-disable-navigation-error-correction-by-default.patch
+++ b/patches/0013-disable-navigation-error-correction-by-default.patch
@@ -1,7 +1,7 @@
-From ba37acad2509b13aaa3de2fa43b7292ce8ea996a Mon Sep 17 00:00:00 2001
+From 5b4660245a3d7b080f088b256567e5aac2522bf1 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Wed, 23 Nov 2016 08:29:58 -0500
-Subject: [PATCH 13/57] disable navigation error correction by default
+Subject: [PATCH 13/58] disable navigation error correction by default
 
 ---
  chrome/browser/ui/navigation_correction_tab_observer.cc | 2 +-

--- a/patches/0014-disable-contextual-search-by-default.patch
+++ b/patches/0014-disable-contextual-search-by-default.patch
@@ -1,7 +1,7 @@
-From 1c7028394a1562a5318b911c61fbc7cd0be94f63 Mon Sep 17 00:00:00 2001
+From d0094023bc7f991c52c0717eb91568d30a66a03c Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Wed, 23 Nov 2016 09:26:51 -0500
-Subject: [PATCH 14/57] disable contextual search by default
+Subject: [PATCH 14/58] disable contextual search by default
 
 ---
  .../browser/contextualsearch/ContextualSearchFieldTrial.java    | 2 +-

--- a/patches/0015-disable-network-prediction-by-default.patch
+++ b/patches/0015-disable-network-prediction-by-default.patch
@@ -1,7 +1,7 @@
-From e728e77b06e961c93810e793c55218f1b3b6f96b Mon Sep 17 00:00:00 2001
+From 3f5fe1046395938d5e8ab5a0789b1a2d699f1eee Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Wed, 23 Nov 2016 08:31:44 -0500
-Subject: [PATCH 15/57] disable network prediction by default
+Subject: [PATCH 15/58] disable network prediction by default
 
 ---
  chrome/browser/net/prediction_options.h | 2 +-

--- a/patches/0016-disable-metrics-by-default.patch
+++ b/patches/0016-disable-metrics-by-default.patch
@@ -1,7 +1,7 @@
-From 2f26d745f76803ee0434e26699c947d6d6ccebcb Mon Sep 17 00:00:00 2001
+From bb8295d921ced47b5e3d3d41dc2e84f0f72d1e26 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Thu, 24 Nov 2016 11:41:00 -0500
-Subject: [PATCH 16/57] disable metrics by default
+Subject: [PATCH 16/58] disable metrics by default
 
 ---
  .../chromium/chrome/browser/firstrun/FirstRunActivityBase.java  | 2 +-

--- a/patches/0017-disable-hyperlink-auditing-by-default.patch
+++ b/patches/0017-disable-hyperlink-auditing-by-default.patch
@@ -1,7 +1,7 @@
-From 6cd2a94b0641338f56968b526c90cdcc19031ab9 Mon Sep 17 00:00:00 2001
+From 558d785aadb9126be2f63ce26bdd96d9a751526d Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Sat, 26 Nov 2016 14:57:22 -0500
-Subject: [PATCH 17/57] disable hyperlink auditing by default
+Subject: [PATCH 17/58] disable hyperlink auditing by default
 
 ---
  chrome/browser/chrome_content_browser_client.cc | 2 +-

--- a/patches/0018-disable-showing-popular-sites-by-default.patch
+++ b/patches/0018-disable-showing-popular-sites-by-default.patch
@@ -1,7 +1,7 @@
-From 8a9bd9e2be2ad56ceda5bb753682b5aab8823adf Mon Sep 17 00:00:00 2001
+From 2a80ef381e9ba516bbf7d1d7801143eb001d13d4 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Tue, 6 Mar 2018 00:27:41 -0500
-Subject: [PATCH 18/57] disable showing popular sites by default
+Subject: [PATCH 18/58] disable showing popular sites by default
 
 ---
  components/ntp_tiles/features.cc | 4 ++--

--- a/patches/0019-disable-article-suggestions-feature-by-default.patch
+++ b/patches/0019-disable-article-suggestions-feature-by-default.patch
@@ -1,7 +1,7 @@
-From fdd9d4ad54dd4af21f174081284aa3ed0b1e59ee Mon Sep 17 00:00:00 2001
+From c1b5c9b8509806b0e004356b3393dc08898153d5 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Thu, 8 Mar 2018 22:43:12 -0500
-Subject: [PATCH 19/57] disable article suggestions feature by default
+Subject: [PATCH 19/58] disable article suggestions feature by default
 
 ---
  components/feed/core/shared_prefs/pref_names.cc | 4 ++--

--- a/patches/0020-disable-prefetching-suggested-pages-by-default.patch
+++ b/patches/0020-disable-prefetching-suggested-pages-by-default.patch
@@ -1,7 +1,7 @@
-From c7ee7a725a39edb3d73a6ebfc9dd424524bdd985 Mon Sep 17 00:00:00 2001
+From 1acfd576ef74265b74e8d187ae832eac3e07b12e Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Fri, 12 Jul 2019 04:10:21 -0400
-Subject: [PATCH 20/57] disable prefetching suggested pages by default
+Subject: [PATCH 20/58] disable prefetching suggested pages by default
 
 ---
  components/offline_pages/core/offline_page_feature.cc | 2 +-

--- a/patches/0021-disable-content-feed-suggestions-by-default.patch
+++ b/patches/0021-disable-content-feed-suggestions-by-default.patch
@@ -1,7 +1,7 @@
-From 2a434626c2f516340bfdb844de2a210ca1bbe626 Mon Sep 17 00:00:00 2001
+From 242f54f75268d5641219332e96e310407ea2ad6d Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Sun, 22 Mar 2020 01:23:48 -0400
-Subject: [PATCH 21/57] disable content feed suggestions by default
+Subject: [PATCH 21/58] disable content feed suggestions by default
 
 ---
  components/feed/feed_feature_list.cc | 2 +-

--- a/patches/0022-disable-sensors-access-by-default.patch
+++ b/patches/0022-disable-sensors-access-by-default.patch
@@ -1,7 +1,7 @@
-From 3640c9727d4527665d331b8e4d5817d8c66b19f3 Mon Sep 17 00:00:00 2001
+From 2b4ec7b90b88170469f83d6c8e324533199c509a Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Sun, 16 Jun 2019 15:57:29 -0400
-Subject: [PATCH 22/57] disable sensors access by default
+Subject: [PATCH 22/58] disable sensors access by default
 
 ---
  .../content_settings/core/browser/content_settings_registry.cc  | 2 +-

--- a/patches/0023-disable-third-party-cookies-by-default.patch
+++ b/patches/0023-disable-third-party-cookies-by-default.patch
@@ -1,7 +1,7 @@
-From 448c99d5527b4c7296eb8488f8f62e2efbfae669 Mon Sep 17 00:00:00 2001
+From 2d04ff05f3c2afdb7089f8ec8f9f9f29e71b2efe Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Sun, 16 Jun 2019 16:01:31 -0400
-Subject: [PATCH 23/57] disable third party cookies by default
+Subject: [PATCH 23/58] disable third party cookies by default
 
 ---
  components/content_settings/core/browser/cookie_settings.cc | 2 +-

--- a/patches/0024-disable-background-sync-by-default.patch
+++ b/patches/0024-disable-background-sync-by-default.patch
@@ -1,7 +1,7 @@
-From 339710aefbd5de56a9bc2522ff120f0bfff3592d Mon Sep 17 00:00:00 2001
+From 6b359e417de7a137fd4aa2340669e2651f6888b0 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Sun, 16 Jun 2019 21:57:26 -0400
-Subject: [PATCH 24/57] disable background sync by default
+Subject: [PATCH 24/58] disable background sync by default
 
 ---
  .../content_settings/core/browser/content_settings_registry.cc  | 2 +-

--- a/patches/0025-disable-payment-support-by-default.patch
+++ b/patches/0025-disable-payment-support-by-default.patch
@@ -1,7 +1,7 @@
-From 0fea1f585e2840415e3802869559c6a307fbac17 Mon Sep 17 00:00:00 2001
+From 3fd8a635b6e183d9be019a1dc087ac700507febe Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Tue, 18 Jun 2019 22:28:53 -0400
-Subject: [PATCH 25/57] disable payment support by default
+Subject: [PATCH 25/58] disable payment support by default
 
 ---
  components/payments/core/payment_prefs.cc | 2 +-

--- a/patches/0026-disable-media-router-media-remoting-by-default.patch
+++ b/patches/0026-disable-media-router-media-remoting-by-default.patch
@@ -1,7 +1,7 @@
-From 26e8a67018b645b7ea3d1721d0aaf20f4de25f97 Mon Sep 17 00:00:00 2001
+From 9735ba52e3d609f565363f3ac5b8936446334de1 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Thu, 4 Jul 2019 18:11:27 -0400
-Subject: [PATCH 26/57] disable media router media remoting by default
+Subject: [PATCH 26/58] disable media router media remoting by default
 
 ---
  chrome/browser/profiles/profile.cc | 2 +-

--- a/patches/0027-disable-media-router-by-default.patch
+++ b/patches/0027-disable-media-router-by-default.patch
@@ -1,7 +1,7 @@
-From 7bc91cbdb3eb2741c06b4b67ae1f083712060f6c Mon Sep 17 00:00:00 2001
+From 5e6ddae4150bbeebb12a62d4c3bcc47e3ac19746 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Thu, 4 Jul 2019 19:08:52 -0400
-Subject: [PATCH 27/57] disable media router by default
+Subject: [PATCH 27/58] disable media router by default
 
 ---
  .../media/router/media_router_feature.cc      | 19 +++++++++----------

--- a/patches/0028-disable-offering-translations-by-default.patch
+++ b/patches/0028-disable-offering-translations-by-default.patch
@@ -1,7 +1,7 @@
-From 89b9eefd98f81efc11b3b4282821d4aecdcf545a Mon Sep 17 00:00:00 2001
+From 457affd7393d601d45bcd9c50ed5cc0915f0f60c Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Fri, 12 Jul 2019 03:58:01 -0400
-Subject: [PATCH 28/57] disable offering translations by default
+Subject: [PATCH 28/58] disable offering translations by default
 
 ---
  chrome/browser/ui/browser_ui_prefs.cc | 2 +-

--- a/patches/0029-disable-browser-sign-in-feature-by-default.patch
+++ b/patches/0029-disable-browser-sign-in-feature-by-default.patch
@@ -1,7 +1,7 @@
-From 3dc4a4491221bdd9dec0c20049769e2d4ddff76c Mon Sep 17 00:00:00 2001
+From 25c7a28af4cecb6d18aa7a92b145d05f3f5623e5 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Fri, 12 Jul 2019 04:23:18 -0400
-Subject: [PATCH 29/57] disable browser sign in feature by default
+Subject: [PATCH 29/58] disable browser sign in feature by default
 
 ---
  chrome/browser/signin/account_consistency_mode_manager.cc       | 2 +-

--- a/patches/0030-disable-browser-autologin-by-default.patch
+++ b/patches/0030-disable-browser-autologin-by-default.patch
@@ -1,7 +1,7 @@
-From 27cf179d9c02646cbfdde5d5d2a0e72d1de163fd Mon Sep 17 00:00:00 2001
+From 8f42014de9e86540b3b1fd1cf257ab5ab1fef8c8 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Sun, 22 Mar 2020 03:07:08 -0400
-Subject: [PATCH 30/57] disable browser autologin by default
+Subject: [PATCH 30/58] disable browser autologin by default
 
 ---
  .../signin/internal/identity_manager/primary_account_manager.cc | 2 +-

--- a/patches/0031-disable-safe-browsing-reporting-opt-in-by-default.patch
+++ b/patches/0031-disable-safe-browsing-reporting-opt-in-by-default.patch
@@ -1,7 +1,7 @@
-From 0c043c67f998b63cc859071d14c34e440684e0d3 Mon Sep 17 00:00:00 2001
+From de4bb0b9ef5016f4d07fc5d1f45af045ecbee36a Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Fri, 12 Jul 2019 05:22:11 -0400
-Subject: [PATCH 31/57] disable safe browsing reporting opt-in by default
+Subject: [PATCH 31/58] disable safe browsing reporting opt-in by default
 
 ---
  components/safe_browsing/core/common/safe_browsing_prefs.cc | 2 +-

--- a/patches/0032-disable-unused-safe-browsing-option-by-default.patch
+++ b/patches/0032-disable-unused-safe-browsing-option-by-default.patch
@@ -1,7 +1,7 @@
-From e4d798d2baa3933735ecab045019eb2511699ee8 Mon Sep 17 00:00:00 2001
+From 6b4d211a27b132eb9015f026b7ab6f4853c1053f Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Thu, 12 Mar 2020 13:01:02 -0400
-Subject: [PATCH 32/57] disable unused safe browsing option by default
+Subject: [PATCH 32/58] disable unused safe browsing option by default
 
 Safe Browsing is currently a no-op due to the lack of Play Services, and
 support for using the local database backend hasn't been implemented.

--- a/patches/0033-disable-media-DRM-preprovisioning-by-default.patch
+++ b/patches/0033-disable-media-DRM-preprovisioning-by-default.patch
@@ -1,7 +1,7 @@
-From 4c2ea3d95573e445c11a4f2d95479a3549478498 Mon Sep 17 00:00:00 2001
+From 4a4edabba93ba99744800332a428794a40c1112c Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Thu, 21 May 2020 12:27:29 -0400
-Subject: [PATCH 33/57] disable media DRM preprovisioning by default
+Subject: [PATCH 33/58] disable media DRM preprovisioning by default
 
 This switches to fetching on-demand, which can only happen if DRM media
 support is enabled.

--- a/patches/0034-enable-dubious-Do-Not-Track-feature-by-default.patch
+++ b/patches/0034-enable-dubious-Do-Not-Track-feature-by-default.patch
@@ -1,7 +1,7 @@
-From 6e132052aad6e6e62bf5bed87fcddd5df983336e Mon Sep 17 00:00:00 2001
+From e3df68004d5df6855c4e9d493c17cdc32a5103b8 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Tue, 1 Aug 2017 11:16:11 -0400
-Subject: [PATCH 34/57] enable dubious Do Not Track feature by default
+Subject: [PATCH 34/58] enable dubious Do Not Track feature by default
 
 ---
  chrome/browser/ui/browser_ui_prefs.cc | 2 +-

--- a/patches/0035-mark-non-secure-origins-as-non-secure-by-default.patch
+++ b/patches/0035-mark-non-secure-origins-as-non-secure-by-default.patch
@@ -1,7 +1,7 @@
-From 9408e450cc21d4b6611e40eb36187a0afd89f7ed Mon Sep 17 00:00:00 2001
+From 0b23063de6713f84dfed190fe948b8b90a968dbc Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Fri, 20 Oct 2017 21:20:50 -0400
-Subject: [PATCH 35/57] mark non-secure origins as non-secure by default
+Subject: [PATCH 35/58] mark non-secure origins as non-secure by default
 
 ---
  components/security_state/core/security_state.cc | 8 +++-----

--- a/patches/0036-enable-strict-site-isolation-by-default-on-Android.patch
+++ b/patches/0036-enable-strict-site-isolation-by-default-on-Android.patch
@@ -1,7 +1,7 @@
-From e9e9de31f31548346ca3f82255e076c27de411ce Mon Sep 17 00:00:00 2001
+From 7d8006831d26e039331ed441236c57f586e3fccf Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Thu, 2 May 2019 07:15:32 -0400
-Subject: [PATCH 36/57] enable strict site isolation by default on Android
+Subject: [PATCH 36/58] enable strict site isolation by default on Android
 
 ---
  chrome/browser/about_flags.cc    | 19 -------------------

--- a/patches/0037-most-private-WebRTC-IP-handling-policy-by-default.patch
+++ b/patches/0037-most-private-WebRTC-IP-handling-policy-by-default.patch
@@ -1,7 +1,7 @@
-From 161f12d78204cdab9ec3ac29fa164c17f235d458 Mon Sep 17 00:00:00 2001
+From 2750c24b5c77989fd3a96864c097cc321397cc10 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Thu, 21 May 2020 12:58:04 -0400
-Subject: [PATCH 37/57] most private WebRTC IP handling policy by default
+Subject: [PATCH 37/58] most private WebRTC IP handling policy by default
 
 ---
  chrome/browser/ui/browser_ui_prefs.cc | 2 +-

--- a/patches/0038-disable-search-engine-permissions-by-default.patch
+++ b/patches/0038-disable-search-engine-permissions-by-default.patch
@@ -1,7 +1,7 @@
-From 24b924f71c37f5409af52fd47310428dc11e7aab Mon Sep 17 00:00:00 2001
+From 8c38f36dd7c45c7b70113cc8ded8b088567f7faa Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Tue, 1 Aug 2017 20:29:56 -0400
-Subject: [PATCH 38/57] disable search engine permissions by default
+Subject: [PATCH 38/58] disable search engine permissions by default
 
 Disable the geolocation and notification permissions for the default
 search engine by default.

--- a/patches/0039-stub-out-the-battery-status-API.patch
+++ b/patches/0039-stub-out-the-battery-status-API.patch
@@ -1,7 +1,7 @@
-From 74fbe49252a1774a484d4af0f30590668351ff6b Mon Sep 17 00:00:00 2001
+From 9f3964934823e971c1ee04e40e313970112075c5 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Mon, 17 Jun 2019 11:29:21 -0400
-Subject: [PATCH 39/57] stub out the battery status API
+Subject: [PATCH 39/58] stub out the battery status API
 
 Pretend that the device is always plugged in and fully charged.
 ---

--- a/patches/0040-always-use-local-new-tab-page.patch
+++ b/patches/0040-always-use-local-new-tab-page.patch
@@ -1,7 +1,7 @@
-From 6697df624d979c796cb0484cd788aa3f2bd83dc6 Mon Sep 17 00:00:00 2001
+From a938ac5e283933a283bf21d3c6924c5ee4900244 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Mon, 17 Jun 2019 13:14:22 -0400
-Subject: [PATCH 40/57] always use local new tab page
+Subject: [PATCH 40/58] always use local new tab page
 
 ---
  chrome/browser/search/search.cc | 2 +-

--- a/patches/0041-disable-search-provider-logo.patch
+++ b/patches/0041-disable-search-provider-logo.patch
@@ -1,7 +1,7 @@
-From 9dddd52c553b73443ee60a467ba29e328fadb2e3 Mon Sep 17 00:00:00 2001
+From 7777584ca31b13f90881f610d626844ae68b6beb Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Mon, 17 Jun 2019 12:03:52 -0400
-Subject: [PATCH 41/57] disable search provider logo
+Subject: [PATCH 41/58] disable search provider logo
 
 ---
  .../template_url_service_factory_android.cc   | 31 +------------------

--- a/patches/0042-stop-ignoring-download-location-prompt-setting.patch
+++ b/patches/0042-stop-ignoring-download-location-prompt-setting.patch
@@ -1,7 +1,7 @@
-From 79f6fe9a73d35aa723c55f38cfe66cde2852bfbb Mon Sep 17 00:00:00 2001
+From 22b333aa8f8e17dca757efcc927724ebc958a2c5 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Fri, 28 Jun 2019 16:56:37 -0400
-Subject: [PATCH 42/57] stop ignoring download location prompt setting
+Subject: [PATCH 42/58] stop ignoring download location prompt setting
 
 ---
  .../download/DownloadLocationDialogBridge.java    | 15 ---------------

--- a/patches/0043-show-download-prompt-again-by-default.patch
+++ b/patches/0043-show-download-prompt-again-by-default.patch
@@ -1,7 +1,7 @@
-From ee773a378bea9b9ed3e1a57b665db6e9383b59fa Mon Sep 17 00:00:00 2001
+From b9372a535cfc7d5507b4a91941537850c53b515a Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Fri, 28 Jun 2019 17:48:49 -0400
-Subject: [PATCH 43/57] show download prompt again by default
+Subject: [PATCH 43/58] show download prompt again by default
 
 ---
  .../chrome/browser/download/DownloadLocationCustomView.java   | 4 ----

--- a/patches/0044-rename-Sync-and-Google-services-Services.patch
+++ b/patches/0044-rename-Sync-and-Google-services-Services.patch
@@ -1,7 +1,7 @@
-From 667742557e6202b0f1dc2ae66e0aab65ea059da3 Mon Sep 17 00:00:00 2001
+From 5f560f411bc09ed9ffd26a1081d0af86c5b96b7c Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Fri, 2 Aug 2019 23:28:06 -0400
-Subject: [PATCH 44/57] rename Sync and Google services -> Services
+Subject: [PATCH 44/58] rename Sync and Google services -> Services
 
 ---
  .../browser/ui/android/strings/android_chrome_strings.grd   | 6 +++---

--- a/patches/0045-remove-data-reduction-preference.patch
+++ b/patches/0045-remove-data-reduction-preference.patch
@@ -1,7 +1,7 @@
-From e1aacc3482679e98983e84f1ce78db1eba097bf2 Mon Sep 17 00:00:00 2001
+From 8563110ac289cd4107b96f748343d4dc268f13b4 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Fri, 2 Aug 2019 22:06:31 -0400
-Subject: [PATCH 45/57] remove data reduction preference
+Subject: [PATCH 45/58] remove data reduction preference
 
 ---
  chrome/android/java/res/xml/main_preferences.xml       | 10 +++++-----

--- a/patches/0046-remove-translate-offer-preference.patch
+++ b/patches/0046-remove-translate-offer-preference.patch
@@ -1,7 +1,7 @@
-From 468956418b80d39dbb834142e8970067a1b17790 Mon Sep 17 00:00:00 2001
+From 40fcfa24813457e66633c5dfefc5b7b4c1fdc72b Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Fri, 2 Aug 2019 21:11:17 -0400
-Subject: [PATCH 46/57] remove translate offer preference
+Subject: [PATCH 46/58] remove translate offer preference
 
 ---
  .../java/res/xml/languages_preferences.xml    |  8 ++--

--- a/patches/0047-remove-sync-preferences.patch
+++ b/patches/0047-remove-sync-preferences.patch
@@ -1,7 +1,7 @@
-From 37246ed3fd00ddfb69fe4304a83dc2aaad51174e Mon Sep 17 00:00:00 2001
+From 67c0446a9c48ce24bcda9df232fcaf0bb3761543 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Fri, 2 Aug 2019 21:12:28 -0400
-Subject: [PATCH 47/57] remove sync preferences
+Subject: [PATCH 47/58] remove sync preferences
 
 ---
  .../res/xml/sync_and_services_preferences.xml |  56 +++----

--- a/patches/0048-remove-navigation-error-preference.patch
+++ b/patches/0048-remove-navigation-error-preference.patch
@@ -1,7 +1,7 @@
-From 42125c6292694accbe7343516755dbfc203aaf27 Mon Sep 17 00:00:00 2001
+From c0f2c078d94d762c039001000ebd3314a5973f58 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Fri, 2 Aug 2019 23:46:41 -0400
-Subject: [PATCH 48/57] remove navigation error preference
+Subject: [PATCH 48/58] remove navigation error preference
 
 ---
  .../sync/settings/SyncAndServicesSettings.java    | 15 +++++++++------

--- a/patches/0049-remove-password-leak-detection-preference.patch
+++ b/patches/0049-remove-password-leak-detection-preference.patch
@@ -1,7 +1,7 @@
-From 6511f473f93e191745e57100ebe9a37b582e0712 Mon Sep 17 00:00:00 2001
+From 1418d987e04a901c5725939845f6f9a0b19a9029 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Wed, 8 Apr 2020 09:04:51 -0400
-Subject: [PATCH 49/57] remove password leak detection preference
+Subject: [PATCH 49/58] remove password leak detection preference
 
 ---
  .../browser/sync/settings/SyncAndServicesSettings.java | 10 ++++++++--

--- a/patches/0050-remove-safe-browsing-reporting-preference.patch
+++ b/patches/0050-remove-safe-browsing-reporting-preference.patch
@@ -1,7 +1,7 @@
-From 03bef273608bde5a9df4e4ead167f4f5aeac16b8 Mon Sep 17 00:00:00 2001
+From 32b822a15690909c52c33f04e7d04a8aaa486ac6 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Fri, 2 Aug 2019 23:48:41 -0400
-Subject: [PATCH 50/57] remove safe browsing reporting preference
+Subject: [PATCH 50/58] remove safe browsing reporting preference
 
 ---
  .../sync/settings/SyncAndServicesSettings.java       | 12 +++++++-----

--- a/patches/0051-remove-usage-and-crash-reports-preference.patch
+++ b/patches/0051-remove-usage-and-crash-reports-preference.patch
@@ -1,7 +1,7 @@
-From bc474d2697766e25b7d47a12ff36324d3f4821e6 Mon Sep 17 00:00:00 2001
+From 4ed0aca3339cf5618d34ee365e5f37a2dff4345f Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Fri, 2 Aug 2019 23:49:13 -0400
-Subject: [PATCH 51/57] remove usage and crash reports preference
+Subject: [PATCH 51/58] remove usage and crash reports preference
 
 ---
  .../browser/sync/settings/SyncAndServicesSettings.java | 10 ++++++----

--- a/patches/0052-remove-url-keyed-anonymized-data-preference.patch
+++ b/patches/0052-remove-url-keyed-anonymized-data-preference.patch
@@ -1,7 +1,7 @@
-From 79f73a21220bfbdfd756332ef023bfc4fdc40821 Mon Sep 17 00:00:00 2001
+From ea33efdf729b040c3a318b73068a430dd73d8205 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Fri, 2 Aug 2019 23:50:03 -0400
-Subject: [PATCH 52/57] remove url keyed anonymized data preference
+Subject: [PATCH 52/58] remove url keyed anonymized data preference
 
 ---
  .../sync/settings/SyncAndServicesSettings.java       | 12 +++++++-----

--- a/patches/0053-remove-redundant-services-preference-category.patch
+++ b/patches/0053-remove-redundant-services-preference-category.patch
@@ -1,7 +1,7 @@
-From de1e45b38643ed6766bd92647f8563bba4037d20 Mon Sep 17 00:00:00 2001
+From a3a70de4eff6ea02484e630b197136e454cdc199 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Sat, 3 Aug 2019 00:34:43 -0400
-Subject: [PATCH 53/57] remove redundant services preference category
+Subject: [PATCH 53/58] remove redundant services preference category
 
 ---
  .../res/xml/sync_and_services_preferences.xml |  8 ++++----

--- a/patches/0054-redirect-settings-help-icon.patch
+++ b/patches/0054-redirect-settings-help-icon.patch
@@ -1,7 +1,7 @@
-From bba5542de136f9c0c50ab2188caba1b7991c6b7b Mon Sep 17 00:00:00 2001
+From 202f7f10c4cc04a4f3c626921b6397e7b97b65b0 Mon Sep 17 00:00:00 2001
 From: Zoraver Kang <zkang@wpi.edu>
 Date: Fri, 16 Aug 2019 02:03:45 -0400
-Subject: [PATCH 54/57] redirect settings help icon
+Subject: [PATCH 54/58] redirect settings help icon
 
 ---
  .../src/org/chromium/chrome/browser/help/HelpAndFeedback.java   | 2 +-

--- a/patches/0055-set-default-search-engine-to-DuckDuckGo.patch
+++ b/patches/0055-set-default-search-engine-to-DuckDuckGo.patch
@@ -1,7 +1,7 @@
-From 01355b6f3bb499f589732d93114dfa4c2c361172 Mon Sep 17 00:00:00 2001
+From 9f33e900be00b812a4ce0e721a2dda5d49ae9082 Mon Sep 17 00:00:00 2001
 From: Zoraver Kang <zkang@wpi.edu>
 Date: Sat, 17 Aug 2019 15:53:50 -0400
-Subject: [PATCH 55/57] set default search engine to DuckDuckGo
+Subject: [PATCH 55/58] set default search engine to DuckDuckGo
 
 ---
  components/search_engines/template_url_prepopulate_data.cc | 2 +-

--- a/patches/0056-disable-trivial-subdomain-hiding.patch
+++ b/patches/0056-disable-trivial-subdomain-hiding.patch
@@ -1,7 +1,7 @@
-From df7fb3da0168b1b98b584177af91f6a0919d1cf7 Mon Sep 17 00:00:00 2001
+From 186596f4f71ec24614d81fae9eda4d18de6e9c21 Mon Sep 17 00:00:00 2001
 From: JTL <jtl@teamclassified.ca>
 Date: Sat, 21 Dec 2019 04:04:24 +0000
-Subject: [PATCH 56/57] disable trivial subdomain hiding
+Subject: [PATCH 56/58] disable trivial subdomain hiding
 
 ---
  components/url_formatter/url_formatter.cc | 3 +--

--- a/patches/0057-disable-broken-warning-for-auto-var-init.patch
+++ b/patches/0057-disable-broken-warning-for-auto-var-init.patch
@@ -1,7 +1,7 @@
-From 2543aa7c413459a46c734c4ab3595ea99524cba2 Mon Sep 17 00:00:00 2001
+From de9bfe1f1a3d606f82656c94402b34be78acbcff Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Thu, 21 May 2020 14:07:54 -0400
-Subject: [PATCH 57/57] disable broken warning for auto var init
+Subject: [PATCH 57/58] disable broken warning for auto var init
 
 ---
  build/config/compiler/BUILD.gn | 2 +-

--- a/patches/0058-Recolor-logos-used-in-chrome-version.patch
+++ b/patches/0058-Recolor-logos-used-in-chrome-version.patch
@@ -1,0 +1,167 @@
+From 78f29de4be3222f8470e80821b7c4a3ce5d3c4ac Mon Sep 17 00:00:00 2001
+From: A Mak <refragable@mailbox.org>
+Date: Sat, 25 Jul 2020 05:41:58 -0700
+Subject: [PATCH 58/58] Recolor logos used in chrome://version
+
+---
+ .../chromium/product_logo.png                 | Bin 2435 -> 1327 bytes
+ .../chromium/product_logo_white.png           | Bin 2094 -> 1293 bytes
+ 2 files changed, 0 insertions(+), 0 deletions(-)
+
+diff --git a/components/resources/default_100_percent/chromium/product_logo.png b/components/resources/default_100_percent/chromium/product_logo.png
+index f0c34708c97aaf3a0633af3625b3f2d3c0575161..6076953975307973c5aa02ccdb4db6fb645ae4c8 100644
+GIT binary patch
+delta 1319
+zcmV+?1=#w76R!%88Gi%-00769K#2eV1olZpK~#9!?b-u$BuN|w@Hrdnr&G*9*k{GI
+z&v$DpUT@sd*|u%lw(U6^-~GGNsaMsR*Ka$6Tl9XLq)}6;`lZ_KKoDYwee?Y<d9o+k
+z<#DFCoUZ+%ckx{Y8y=fAEj8`D^skcOhKt1s50c+ZUXw6woPVq~YifjYdkT^W(k-wi
+zvbcXsR-<>eSuL}so|N`WGLm#wipWYyfah(O%VxF2n%bdpCb4)ZK3FNPA6!R_WmS9!
+z6h}xiL1|Qyt$!|PtnL;K(M_D@tno<vA;Gh;vJxtkyEhuvwA{qM65-;ozIFl$BdiqX
+z`_a2?q^y++lz*;`gf(-g%3o;|!bxGUJ`Y(sDkToC;f<7)Wg}s&y1W4g5LN=Cbu-!{
+z(T>Y;&(D|t+5TJZcNyNyZ?h;l-{yXk_f65)rC$^~eXveYGALnVSi{)z3C7Owb$oAV
+zUX~))KS3^QIlKnm5BA#w#9IG*18NX60!wkD4PW2^41Zu9&cI7}53Q&|1CGOV%)va&
+z$09Ti8(5QRp9Vee>Rks#T;9bAGH9++nV_#blP`USm%U2h(@IaL@?L%2-O2>YnL@o{
+zNqyhS>dr9icN>N2F#67GfY<}CGTm?1@&g-CPdO5iI&25tC%i0{Ok|@MU(weh$`UNY
+zax|hD?SCIjtjSuJ38j&86|p+BFkmlzb<xr@C4dZVn#z0Gx=OZey3W~1d4_c^Oep;f
+z18b!6UTunf_Do*y^l`9KjY17)@|KR^hWW`_F+iv+PDBxGF}}uhj;bXC{RG{P7PL`T
+zVine4E!IpDSnuXzP7El|NFx-&w3n}=(3F?+Xn#3V0HV?YNtiyOlBJ`+byn~irjNE%
+z=uM-)thd)eOFfDZiD+Da%VbnaHeREpYq1XN(S>gGq7MVH!dTV1>HCmXDa^mCbyR=~
+zGdVRPW?mx0Q2*V0+;iq}uwG?sDesTQe7B#hl}{0>o^*nJ2TNpB%8@t^4-=+}0q~^j
+z)qn6tnx6?s9p&AZMrWh6<SIUTjiv9F|6Jo_ZIo*e4qO=lV6Aw$7PUHSC7k#cCm>Ts
+zrS#%i3~J%5>H!jKqkpWzIwON`){H>2!Vyr`vZrcL%X2tB#lkVDN8lVhE}~Mp6%$sQ
+zwe-#!h`9zAF;WpV125wy5tY&v7u=lyD}OzGlVvSdW!A=jzr@iZDy0J-{(YLn+6Q%_
+ze8}>Xb-M3EmLIJ8zM1Elkg^sXRt-5f;4PdqN=jLcFLADf+K*o8yp<i}&-9Dc`~=H7
+ztMS}ox`L3hIvnMH$gK6a5?|w1tVa|2@H9T6sUZwVtUY}umjhnwtdvSt{%-Mdz<)2+
+zFxIAb^)^xKLd;rtt#Q0oVKLD@jhFEt22q9{BkJF3nCZo<byi-7c=75FE2WZJ0v0bJ
+zhJ~0lXSdQnt1vc|lw#yyri@DIKEvTKyVc@H<XbKNCz;jv|J-lQTV81-WvM_R@-S#X
+z?fh8Xle5|}dpb~XZv`r)RIucs*?)lA^J}-VfzPsRR)T%Df?<j&Lpg>d)b3w9v+PHN
+zmY%%kUtcDWmQ#wbUO-jR@j-W*{p8j1dji?jML(2dG-WsrgW%)zua48yJ?!@c#`#uD
+z&eFn9O8(VYi_!ZpJM~A$M;*QD-hRH-V!wlR&~}F%bkNMh29Bzme|UR>Iv~-02g^ci
+d7@Kty%74D#xyw1O1>yhz002ovPDHLkV1l3FjOG9U
+
+literal 2435
+zcmV-}34Hd6P)<h;3K|Lk000e1NJLTq00651001Be1^@s6ZJ&q&0000PbVXQnQ*UN;
+zcVTj606}DLVr3vnZDD6+Qe|Oed2z{QJOBU*B}qg<RCwC#oNH_p*A>UloyXd{Ua!4t
+z1HmT5F*pPfQsIRl1*Hnj(gqY1s4#6*RjLGC+7Gm(YU8C!Tea%LuG$nON|2+dADT82
+zkG?BajaNylwum-t(u9^2idQ@=8Va_9jUT)7xIHtzWA3bH_5oh6aps7-vpaL=&Y3&E
+z`QLNTj3Ja#@XWK@!6fSoA*AS?KK7N<jfzeibR7c7x+oCH>Oe=XkLmwQ^{g5#wjJ+A
+z@vIah7BGci-I6%74y$|~Ydw}x=mJ&8{U-lSfhUW^AomQeJ2aNjpa09VD=&MndNymY
+zZcdzDE{WthMTJLI4fWFi)Pj_;Mj3egdRZb9qDWpC99F-EYCGn^>RDM~-O_pLvxEo-
+zvKk3Yswka;b&6H$46C)MmdRO7gB`CQxc6-jR?o@;>(-}EemAQL`*pzeL@;Vh!8!?A
+zaj+Wed=eQ(P2T>eAFX_?5Uh#)PnY7q)c~2t*C>o7jwOjDRqlgzeec_Iwj%_`3DlEs
+zeHG)<{W=c&K#ieazomm@6g`AZ{BpzIch`9OP_h}IcCqq-wrQ|#OPt)Ssq~u~j@_n`
+z>Q<1dbBb8J<XNU@G$e`ei|C$z)q4DuWNEfcd9ZS}v-`5YsipbnR8u8`NUH0TWFoLS
+zr8WYo6Oq$mQu|P!RcK4CU;K{8UrBa^g*k~2dPhjM;HcjJW8#zj;cyVH4vvB#Vw@`I
+zW?x}&i@@q;{JNx3fQ|PDpsm>lksukpHj?%A^^a>OP7P0ttB9~b=wy_OpMrq#Fi?U^
+zK@zDb2s`gTaQdZZ_pNxR$apQvDNMRR{Z>{iB^oNSAFTa`TomkP+chkf$AA9(N^N&0
+zV`5hya1Jqb?ikM|=Zvz-vb5b;E^Ju>f|da@6woI_03&`Cki$=J48Zeyn<2U?0_Uy=
+z;m_v-HJ7qs`Jo4zs-KRx)jzm86kbp#M;0|!N17G~B1@ZVBP~no8;o*SbEt7?b7)c9
+z-QnE@{4zSP7t0`98l{hw);#t5xcY-E&I>!hW5|66+s5w~cc^>9q20qSepqeCS^K&E
+z_p)Oer6*_mpi5k8wb`4qzL%|!x%6Qt+urH2zLkBq`G9bCF-W6WY<-HqjqUM@E9<U<
+z*EUc>s*KYhq6~`>*b8Sb0#y4AT}7-Z?A{!LN7gmKGk>7)=6Py+An@`rjCb1w*b!R{
+zzdt?<{X^8;j|gNk(?CpxHGfM2F>Z=46aY2M?(`$v`ly3CrCEJL5xUv3l>uX2sD#UL
+zI$2$7zjV&TriUAfEye9%#eih3i`vIo`$<-;8GVd_9%jdVk?qg>n`Z0FZHJkU(|kZ6
+z!|WXSK8>-`gWHp+vgwM!iWKeOCr<TuEP|`=U4gN&3=khc`?4Tx-OvEv`VEDDU*ex!
+zO@3D~LOA*cfQVYXrM(u89vj1Tf(fS?5Ex6ORUjt3OL|@%X}}EwPT3Q7F^x{#Q{)hC
+zfV3%R2s^?c?sS1Q&Mwk2hv7HOsob6%c)A(H7R;MmZiED@YuSrTrDE)On{q;qG&^R;
+zEWsLOHyiImiaR&6PZ3J1Z@QV%#+Z-Y6$=9pp?jyEPB8$Rm$v}bP(c+19^X(8$NmG;
+zK;>s##?PZTXpXDIjAwmSGRQvJTv|o0@|nf&_bqhDu|~Ozxu=Bl=ym`u$*Eq<C05(%
+z5+}yl_M{6q2~KUC!hs=&i<xHaS>UD|CQ^`RSTD!KE!PLzP04{;DIZ;6CD4#Nldq}?
+zLgO7_&@pbkZ&?6NoTJk~&CLoZDuuVs11zo=K;l4^WGs>dqG+itgz`*Ak~h)u`O-d4
+zmdvxgwSXT(+%~5RS18StD$&<+SRo&ibHGPuSdm9Rb;w37yz5S=t&yO{FTud5U3s0}
+z4=`-tI)d)Q*i;g6_!n$X$LNjYiMP;^<+j!${77*MU8)Vi95)A5ojZ9}UDwBXwX}+W
+zideU3p{bblemihZpc<dy8i1^3SLs~SG))K3Ji8fKaqd1eHDSsr^$6>!b7RonLT;!j
+zr>;DxB8upmr6?WO$uv-H%u*OG5d2rt(na_YyIoXr-oc7-=|An7$`^p+=VbcOJven<
+zU<Z!})%e)f4iK!;wTtiDM|s;^%!mOb@x458Qmn%Lk}BW_pGdD%qI@VPWXZLTc?&C2
+z_gg1bwaUAfedO&6I1PRbU{$mAmKB}Cnc&CPH2|MjPvCE7R57Co&hHRRK7#H4%!jK6
+z9pa=EQ?)Rc<E(@o;b!~sJn6M$1t%S;JW$5x!00sNHkD`n$=<p@?m9S<MaA>ERet3-
+zz>c*5Uw<6nWIus-E>ako0BEcw@ZfS>)=>EMUvU;zQ|CVXo4@IyJU$ueq+YJW`G*1q
+zJds&aEhBYynB6oToPu^RUrJ4{mE(r$WPQ@drJbV8$JBfS*7k0IqA0%;B=O^Jl@-kZ
+z7L^mbX8ke>8&?vj!WOQLQ~1YO1ztZn0S~MS84tVM;#AOdstJPlLIK6t#MCR6)8Xk^
+zhG8w|M=WPsqQa@1G`m^4SSZlN-DnBsW8Zv&)%NoB6F(fNt*({_L|KxH+1XN0Et>@;
+zlYtdY1n$1G?nXT85VWeA*0XD4;B$Pu%UjON*QLJ5QqEM?&A!Mo8y4kKXtxwY&*hh|
+zr~ReCr=Gd`RCSHNJKrA=<__`d1jYhd20ps39&{E4JAtaGTE8TTt1(`E-wjsJJS#lG
+zV)nByHGV%kk$KISvAa#S0PGJ1bX|kBZT`HVYPvp-H$aC4s%M_vGOUKZ{Kd#42<)4{
+zrKP4Nv#eYz)gk25AQJWibshTkab2g|c5U<@_qyD(8HLpZc3&i#8K3x-uIu1Lto2n>
+zRA|2^2pV-rQJIrA^*k;f-u;olt6q0|Ru)(d`{|Pn+b2fHKB;DvVLqqIKM-iH)1b;P
+z+trksYO1P=a!`_`522#|-Ro-4W_*I>W>5U!%9kZs-Y1AclOT%3{96@N)rVKhlo<bk
+zkQuw`plSL=tbPa~eGcQ(3;DAN-UQ3DGQeutwr`|mN%pN*mF#^1F}tFzNq!?33jDVw
+z=)V#O`Y$;>net%uY(`=A%(L4%X7$Xoxn%zrU;wnwBh^2=+Oq%v002ovPDHLkV1lwM
+Bu4(`P
+
+diff --git a/components/resources/default_100_percent/chromium/product_logo_white.png b/components/resources/default_100_percent/chromium/product_logo_white.png
+index 454b33fe2a7c80048010d342457ee98d093af0ff..2a7299988d6ff0a317a336c2477f90ec57babbb9 100644
+GIT binary patch
+delta 1284
+zcmV+f1^fE05RD3u8Gi%-00769K#2eV1k_1HK~#9!?Aim6B}V{&;a856b19nO{IHI-
+zzPmMJ+nTd)?bx=BiETSMTN4|9y1HI<b?;8S+MRd4+5b4NudnOdew+!h9tx7bcz>l1
+zj17&%!fBCkWY3}7dygTg_pBM|88>FGN+C)_7A8jO*Qql{4S(^;8nCACo%K{2Da43s
+ztfOVo-&0$MZr5klfHnP;j9*hpQLIs&RWyp&w~<JnSOeDdI>AYbEGF_`6-9oG9NueI
+zfY1i5A2z9*5NmXzKqN{mF)Je({o|<ECd+CA&L+c}Q84=N(L@xi*Mq<)B&#Sqf9Q^z
+zC~GCqu!*qdY=2w%o7jbfMH1HYDNCZtMiA-p!Me3QwpQJBH2VvzQIa+)X^&tEck$dW
+zcl|Zx_k!=U-JG?#qWrZ5YYNvCtu9?r9QI)CN4Ci7!D`9l{ko4=x22kYH^!Qo^Y>F@
+zeWqqG{`Ymndek3BQ^PPMtSHK4R`3$-%;su7VIGsH;(usP;8f1y9M0te>@Jg)R2+zZ
+z&Baoz`tb((DITb#U;MUf)Y13U*n6=wOgNQFTmZnKpXeHGUNusCY<0jOvH@HBvxTkC
+zpsm#9)TCL<4>+2mL`Ses9JY@60xwsVLmthnqL~Xs7jX%fVl#m$i$f-=3%rLdx|g|X
+zx6Z|7E`JT!Tw?%a%Rj$|D{rfm$4-rN+M@RW7fT!co&>XLzy%!nZ?94Fp6Y}3J<w*j
+zMy*uhVkOC1(S8&%!t5(xi&@R73ROflZ321<6PYZU#&l*fi<twosT{TE^Z?#7b|~7P
+zUDR!&ez+(e(KQ-SHfSUk04}K-k>i6EHN&ZxD}QwWJ6YDJjzq*!6tNFOxtTjnR8byZ
+zh@-QZ%^VtNq?s1lhiiKkT)dyMDz(4Q1+q0L%j>0)!EC9~`uvXC_lnsE>%CqpRm@J3
+ztd;LbR#~Qi{f>)FRM8RK$g4EdN;|4dW5M_K;+247u$l|MrpFGs7dX{(v}1m|e6re@
+zGk^3mAEA@ot)JFX8)vN~%vw$&$3zu1^FAGj6l?4L=7N)CH4uzhy;-x@IcsR0vX;G5
+zL#^sCmU4a%)Wf-+H+57|V^+YLfVK3Q8uaexR!OR(X7eeJ>ZqcI5$pLuzyVI(Y*~w2
+zO;-EAl^m<1it1SS&y@yi3$6Xlr>rDdPk;4(%JR*s9-CF~ZBW*tL#r`+m~S`*Nh+Jc
+zN^USv+h{glx6TEw@z0w01(r`%^R>mPut8Zvq4GaX)}y$G)jYu*#?!*PEMg9wv>U8V
+zEeYNZxP508RRZ9cZwHcKwQzyC@ioDF8<=(61J#&SaiO4nmrr?_4$5fij`~llm4EQf
+zs~=W1hxz8!FRQ4Mx$5nxjkSSU^LH%$tBRggii*kSbQ4w7cy%b0@S_(0nIE+zU#gsM
+z<9yy)cxh#KQdtG#D5L`uwSIByE{Zi#!AX~~&sR`sR3R&50w!wHZ;e^KJUbAu3fT86
+zB&J>&<#ZaTjlb3B_URO1aOQQ)Lw#i$X}PF~IT~s!bqg9Z`h4a!xK1Fiy6DGp;!(y4
+zbfEU>-*s2E?i^ev;Pa}M{ENpeDfv&ZQcUxI@})m@i|U$NcT4iBmf#w!|7XMMU}KZv
+u&>tI>=UA)LD@4i~tWh|0oH`n;qYwbti8x%1#JbG@0000<MNUMnLSTZ>{fJZm
+
+delta 2092
+zcmV+{2-EkC3a${48Gi-<003>Dhynlr2lYurK~#7F?c9A(6!#s+asTNbZ70*xcBcPz
+zrZ=7Gw9`o^Lm$$J;ekV=#>PKlGl>Zm&?BCBf)6=uI+ND11Ph3u;+-N7g~pbc7-Njp
+zQ$VF9gI6$|a0kYOiVAYvaop|hNs{r?@5*lHH^=S51vw)9?SIUBV3xgQU0(C^w|fr@
+z06Y}&c>nt*mSxGd-tVMs@%%8Q!1GvgzUODD1)fKf3*6sN%<cYqEc*e#<2`t+%eMFZ
+zeEE*P>Zf<~4QFiaMe1e`2q{vOlJng#Zt;L1_b%SnyEDn+{w~MLi!0Wp+k1bo;?=&>
+zPg(n5-0DF(fqzURs47-D73-6m+*l-Mam(9;Gq&}X(rEiNj+Hm-SeIFQ)-B)e5eXe=
+zG-a@=V70NzB~dimUQ5mQ{FGzm%^KDfueb`AZ0SbEmL7uYVX;!v$GUK%Ti#}j=Co<E
+zfK^=<%;OR$E0xHxM!~wIp!0W&3%Zbz??T4rt1uGSnSWq?BCkjO*%*EQ7{?lOR!l68
+zi1i%n%I&VD#*H1HrCT~-%<rOHFm9GdSa(d*fTRelzoKZHPiPMN2*(;zt1z(?G3z+i
+z-|W8gRkO`6rJLK4zOe)8mMbuBlEGd@`sN-QVW)k8#X?oEQX6`ZlJBYDSa~zXnrjap
+z-B1(8vwyD=s`ZzVme+|i0-LtUh4g}Mq!skshniW~hnn|pqP24vJ=eTKTgR<W8{YjW
+zoL|&2n!BsRpIg}JTTht_KlGW4T)qvvT_btL-6NJVkGG(_Z^*K@_t9x$O`wcQhG}3m
+zFxw|gwg1S+Y0L{}uwP35_!Bht8_)EQf&I6CnSZe6RZDketmeZ(q?uZgyxxh_`(Qsr
+zs>KB(fvq`t1EG+Ju1_R1T#{fvC*rLSB>ZPc!iYbFx)UGa_Xn=x4~N{?RdWqR_5CP5
+zI)IYD-$H5QZIm4w!oCy36?#||G!9H&u2Y6ctUB8lQ3+A-K>6=AA>wiNDBC(Qd1=(Z
+zr+@C-r0m}x@i+&Spk&uLUafsb&RNytHcm0uwQ8(4P*$yD&^V`l$~5O#a}JIzl%Z~@
+zo@jMpKNe+QLbBP3l)NiQv2@{YX9wUNmGH-7BAzJ~@oS|OB_dYt5mDPBLJ&o~d47;k
+z-p1ZzgD8J{2o=ZgpyC}bA@ySa$r0F2`F{p<uqHBpWG7`+YLv0E+cJRt%GV-gTe}Vb
+zBeUK~`I*P9Vzx6y;It|^nLnICW8Y2&m{r-oUtP!iUVD_|HN^v~dW;&!V2^T6S-6I|
+z#cB(cnF*<y40eg-G8V1<C!Qp*`DGr6q6F*F$xxqGD;80IQG{<)fc?}k4iL=BQ-40n
+z58LTc*!~f~p)+GRd^QOC+0eH&4oW>K_88`@PMr}H8teTUkCRJKacPVs_DDeNzBP~-
+zB1Wi0t*ibxVMUZ<Fimkz9qK;k6zf`>aC-fbFw|tQ*%e+SWwm0_x;8Yo55aLoihxQn
+zP?uBB>=AL(E28O2fKU=lM-Wx#LVu`k5>VYNqNXK`+6#B_mrLV6(im0c#UJAZ)+&vk
+zUyt$!HR_BI+HkZnv->bkar_Q;wAaEMC#;RJo>K<1V@|QIvkUDiRJN5ny0I|lU-0^Z
+zc>Nu1s4CWFe-?1kDZ<?!B$yKFE`|x_eVl5joA~-mofF*nfbIr3w6W@*aDV$WMvz8z
+z<c(q94owJDoUvM`IEDnh`STo40|eL0gj0^iYO)3Kl%*Y#Bw_1c8KfFe<>a~R$G1bM
+zZyi@+peof~9DhRp1jiq%&g1kk#E#YY5MW*KrNx?68Ent3lCe(ixj*$|EGS~v+fzeb
+zN}aeY!ZQ$>1eL{lq*;2LV}IpXzYx|nm7y~-*62xS>+<6L4k;38Bve{2;Km&hZEisW
+zs)Dsi`td_P4N&)OiZfP@HFJNkR7R;)*}H*zAwj~XIxVQwZUI&21^5G@&l}sqgf%);
+z`2vfk0pHTUz?xI6rr0j9;*V8h&dlbVzgYK;rI-#&(5tma!k|xt^?!{Br1JL!weqZh
+zkRal8`>6J)dU0I7BcR@A)w_bX#}VtyZ(YS7tKJ<86NPz;RbFxqhQ{@<nyV!=b%_u~
+z5g+u5ICM@x>3ag|E{M2xOT=hEK*O0~G-yCou~xT8C13DK0e_sZvM(S}x7B}AApTel
+z%z3)bo+tI(&1<Zg6@UJ>))7j*)*h1Z`f(ZU1W<W?>gpHp=7mw1_Yb1BS)2mu-Op(X
+zV3@(vt?|Oj9*6$Zt?|dIwn{lC?BZ7-8s;_D=SzK$WE}{8DubL(IrfRx><eIZ$sO!`
+zV;J>1P$~H?fKC2gGkPIQ{L_CS%iNc!9^e1f>seRt8F?kgE`LsmR4tpzEcYXG&mbBu
+zg>|7;HAw?Bs(zEfI<t8EodPeF`_JdtL>Z%I*=jZkFP3>xaWbF_wYnuN9cd0f&fkOe
+z;Nn<SuzUUgR>5XR%QjKgK>_9iL-#ML>NKDdQi(>@#rzF}vlf4M>x*T+<AjmH$skqA
+ztO%gWAw-2*OMg|J7yAk8FZjD#XFdM80ne8VKS%dq$FdHJ6F`~P(7GLUKGe5H9Zf%@
+zCkQGD>^J!52E-$dl|k#>`ciq|=5O~0@2POt><gl{C47&$*)NZzH>hGl`aS-MEOQ$F
+ztgDr;ef*VYcil{)uP?u_(^K|Z)%6#O8wXP>-w*smekBT(f7aEk$FcHw94n9afch_}
+WF>+$Wd{SEg0000<MNUMnLSTZd>m+ah
+
+-- 
+2.27.0
+


### PR DESCRIPTION
https://github.com/GrapheneOS/Vanadium/issues/30

Hi,

I've desaturated the Chromium logos used in the version page using the same command as the Vanadium branding patch. The png files have been optimized with `tools/resources/optimize-png-files.sh`.

Let me know if I need to remove the "chromium" in the image or if I need to use the unoptimized png to make this patch acceptable.

Tested working on Pixel 4.

![Vanadium](https://user-images.githubusercontent.com/25138778/88468336-b1b3fa80-ce96-11ea-9cb4-4a6417918aba.png)

![Vanadium-darkmode](https://user-images.githubusercontent.com/25138778/88468456-ef198780-ce98-11ea-8ed4-747a65873748.png)

