### PR TITLE
Enable WebRTC support with privacy in mind

### DIFF
--- a/patches/0047-most-private-WebRTC-IP-handling-policy-by-default.patch
+++ b/patches/0047-most-private-WebRTC-IP-handling-policy-by-default.patch
@@ -16,7 +16,7 @@ index fdff0c9b7f6b..da07406c5f28 100644
    registry->RegisterBooleanPref(prefs::kWebRTCNonProxiedUdpEnabled, true);
    registry->RegisterStringPref(prefs::kWebRTCIPHandlingPolicy,
 -                               blink::kWebRTCIPHandlingDefault);
-+                               blink::kWebRTCIPHandlingDisableNonProxiedUdp);
++                               blink::kWebRTCIPHandlingDefaultPublicInterfaceOnly);
    registry->RegisterStringPref(prefs::kWebRTCUDPPortRange, std::string());
    registry->RegisterBooleanPref(prefs::kWebRtcEventLogCollectionAllowed, false);
    registry->RegisterListPref(prefs::kWebRtcLocalIpsAllowedUrls);


### PR DESCRIPTION
Today Vanadium uses the most locked-down policy for WebRTC, which unfortunately means that even valid WebRTC use-cases, such as peer-to-peer screen sharing, are not working.

To verify, go to [this website](https://webrtc.github.io/samples/src/content/peerconnection/trickle-ice/) and click "Gather candidates" - no IP address will be discovered, not via LTE, nor via WiFi, with or without VPN. This makes it impossible to establish P2P connection to exchange media.

I propose to change the policy to "public interfaces only". 

With this setting, WebRTC is able to see our public IP address, and establish P2P connection, on all networks. At the same time, no private IP addresses are being leaked.

I can also confirm that when using VPN to hide home public IP, with this policy WebRTC is sharing only VPN IP, so there is no privacy leak.

Any website that user is accessing in the browser is anyway able to see their public IP address, so WebRTC is not leaking any extra information that they are otherwise unable to retrieve.

It is bad if users start to using less secure browsers just for websites where they need WebRTC functionality to work.

Finally, this change will also help reducing browser fingerprinting, as WebRTC is working for the majority of Android users, where at least one IP address is visible.