### PR TITLE
Import Restore-Search-Ready-Omnibox-flag.patch from Bromite

### DIFF
--- a/patches/0001-disable-checkout_nacl.patch
+++ b/patches/0001-disable-checkout_nacl.patch
@@ -1,7 +1,7 @@
-From 37f548af699d80d69bfa0dfe6af6e114f8db9d0b Mon Sep 17 00:00:00 2001
+From cf2ee84f40da56afb2de242cb856f540692fa3a1 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Sat, 21 Nov 2020 01:30:06 -0500
-Subject: [PATCH 01/76] disable checkout_nacl
+Subject: [PATCH 01/77] disable checkout_nacl
 
 ---
  DEPS | 2 +-
@@ -21,5 +21,5 @@ index c9e3829fcc236..778904f718844 100644
    # By default, do not check out src-internal. This can be overridden e.g. with
    # custom_vars.
 -- 
-2.33.0
+2.31.1
 

--- a/patches/0002-use-64-bit-WebView-processes.patch
+++ b/patches/0002-use-64-bit-WebView-processes.patch
@@ -1,7 +1,7 @@
-From 2057205ca28fb8fa0f58cb4a94e25be00dd4f73d Mon Sep 17 00:00:00 2001
+From 702058d73d29e2e4f29828493cb8567260d53884 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Thu, 26 Jan 2017 01:30:12 -0500
-Subject: [PATCH 02/76] use 64-bit WebView processes
+Subject: [PATCH 02/77] use 64-bit WebView processes
 
 ---
  android_webview/nonembedded/java/AndroidManifest.xml | 1 -
@@ -20,5 +20,5 @@ index 640cc51d9eac1..289fd730f116d 100644
          {# This part is shared between stand-alone WebView and Monochrome #}
          {% macro common(manifest_package, webview_lib) %}
 -- 
-2.33.0
+2.31.1
 

--- a/patches/0003-switch-to-fstack-protector-strong.patch
+++ b/patches/0003-switch-to-fstack-protector-strong.patch
@@ -1,7 +1,7 @@
-From 5a3b9160bc513ac522e454e10f666226264dd9c4 Mon Sep 17 00:00:00 2001
+From 5d4c6607a66c1f449abd9f79145158b2391fc379 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Wed, 26 Dec 2018 10:20:24 -0500
-Subject: [PATCH 03/76] switch to -fstack-protector-strong
+Subject: [PATCH 03/77] switch to -fstack-protector-strong
 
 ---
  build/config/compiler/BUILD.gn | 6 +-----
@@ -30,5 +30,5 @@ index d7073ad38f0bf..c6b72a7894d9b 100644
      }
  
 -- 
-2.33.0
+2.31.1
 

--- a/patches/0004-enable-fwrapv-in-Clang-for-non-UBSan-builds.patch
+++ b/patches/0004-enable-fwrapv-in-Clang-for-non-UBSan-builds.patch
@@ -1,7 +1,7 @@
-From c98f2542c510ddf6660f9f2998037f120ce4747e Mon Sep 17 00:00:00 2001
+From 22a3742969a513fe90395efd77d29911f1e09f59 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Thu, 22 Dec 2016 07:15:34 -0500
-Subject: [PATCH 04/76] enable -fwrapv in Clang for non-UBSan builds
+Subject: [PATCH 04/77] enable -fwrapv in Clang for non-UBSan builds
 
 ---
  build/config/compiler/BUILD.gn | 4 ++++
@@ -23,5 +23,5 @@ index c6b72a7894d9b..7d48076798362 100644
      if (fatal_linker_warnings && !is_apple && current_os != "aix") {
        ldflags += [ "-Wl,--fatal-warnings" ]
 -- 
-2.33.0
+2.31.1
 

--- a/patches/0005-enable-ftrivial-auto-var-init-zero.patch
+++ b/patches/0005-enable-ftrivial-auto-var-init-zero.patch
@@ -1,7 +1,7 @@
-From d526e3c3d9665c5f30a2ad6301375d336cb710a2 Mon Sep 17 00:00:00 2001
+From 12a2aeb77774d781e10fd41ce886b780b254cda6 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Wed, 8 Apr 2020 20:48:17 -0400
-Subject: [PATCH 05/76] enable -ftrivial-auto-var-init=zero
+Subject: [PATCH 05/77] enable -ftrivial-auto-var-init=zero
 
 ---
  build/config/compiler/BUILD.gn | 4 ++++
@@ -23,5 +23,5 @@ index 7d48076798362..25f3ffbeff64d 100644
      if (fatal_linker_warnings && !is_apple && current_os != "aix") {
        ldflags += [ "-Wl,--fatal-warnings" ]
 -- 
-2.33.0
+2.31.1
 

--- a/patches/0006-disable-broken-warning-for-auto-var-init.patch
+++ b/patches/0006-disable-broken-warning-for-auto-var-init.patch
@@ -1,7 +1,7 @@
-From f557330bc1268e0eb4540d4b2f3afbc9af92424b Mon Sep 17 00:00:00 2001
+From fc6b59de25c233f8bdb25446f732c0298c01f9ae Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Thu, 21 May 2020 14:07:54 -0400
-Subject: [PATCH 06/76] disable broken warning for auto var init
+Subject: [PATCH 06/77] disable broken warning for auto var init
 
 ---
  build/config/compiler/BUILD.gn | 2 +-
@@ -21,5 +21,5 @@ index 25f3ffbeff64d..7c4192ae293d6 100644
  
      # Linker warnings.
 -- 
-2.33.0
+2.31.1
 

--- a/patches/0007-Vanadium-branding.patch
+++ b/patches/0007-Vanadium-branding.patch
@@ -1,7 +1,7 @@
-From b18555e2cd7357bb25c98c19f690a911e8530e5d Mon Sep 17 00:00:00 2001
+From 0cf857907860ef7fe8db7efd97e14feaaf67e8ea Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Sun, 6 Aug 2017 12:45:14 -0400
-Subject: [PATCH 07/76] Vanadium branding
+Subject: [PATCH 07/77] Vanadium branding
 
 Current incantation of the recolor command:
 
@@ -174,7 +174,7 @@ new file mode 100644
 index 0000000000000000000000000000000000000000..d9d6661c938b2907e30da3ae87cdb2894db5592d
 GIT binary patch
 literal 11327
-zc-jF!EWp!=P)<h;3K|Lk000e1NJLTq006@P006@X1ONa4m3D0*00002VoOIv0RM-N
+zcmV-FEWp!=P)<h;3K|Lk000e1NJLTq006@P006@X1ONa4m3D0*00002VoOIv0RM-N
 z%)bBtEBHx7K~#9!?VWj)99MnsKlfJkKKmk#mXTyhSd#Y*%Ra`5ZCUog#tV)yF&KC+
 z<|GDU90K9Jge8O+2<PDNut@^%ybwqX4mOD~#x|Rm=jGuAZ?Y}P+NBwdW}lwvwYsb7
 zzCWs$s-B*i?&)QO$#0HE)79N|Z~eaax7^?T-QN}0Q9VgAq==9~B1y1@DNLZ1EKwAS
@@ -395,14 +395,14 @@ zJ0a3!Go$*HoHB+u);$m(um^Pmpo6HZ%F^*i{~yS0JYSiOkN*Gw002ovPDHLkV1iRV
 Bx8MK(
 
 literal 0
-Hc-jL100001
+HcmV?d00001
 
 diff --git a/chrome/android/java/res_vanadium/drawable-hdpi/product_logo_name.png b/chrome/android/java/res_vanadium/drawable-hdpi/product_logo_name.png
 new file mode 100644
 index 0000000000000000000000000000000000000000..8678cbbb730de9c3ff9d3dba7d928d60f28bd550
 GIT binary patch
 literal 1998
-zc-jHZ2Qm1GP)<h;3K|Lk000e1NJLTq005f+001Be1ONa4uVuoq00002VoOIv0RM-N
+zcmV;<2Qm1GP)<h;3K|Lk000e1NJLTq005f+001Be1ONa4uVuoq00002VoOIv0RM-N
 z%)bBt2Zu>SK~!ko<=J0sWOWq>@Xx*Tue$}h(?xgL^$(e{1YKD$ttiGof~^Vx9)MOu
 zG$zJ$V+<<#(2`(G2$D7sv-n`r`s9OR+7Oj!jP4K>9x$+jvMdlpCd<G5<L-9a?Y7g-
 zOlN%PbUM?eP`V|f@STVG{k!LP&i9^kf9KpA+yX)cp|aCLam8fei-l{8d&(cGTp%zN
@@ -443,14 +443,14 @@ zza1|{8eS^B9}!%))KF3pS28cMJ#j<i+Hm*uwq56aHaKx+;rQJ1`Nz)uvHbcbt!9+#
 gs)YxeZ9!A;U++Vmx7pctfdBvi07*qoM6N<$g5_ZC5&!@I
 
 literal 0
-Hc-jL100001
+HcmV?d00001
 
 diff --git a/chrome/android/java/res_vanadium/drawable-mdpi/fre_product_logo.png b/chrome/android/java/res_vanadium/drawable-mdpi/fre_product_logo.png
 new file mode 100644
 index 0000000000000000000000000000000000000000..40b88b5225ddff2fb47116a99a38999218e744ec
 GIT binary patch
 literal 6794
-zc-jGq8g=D~P)<h;3K|Lk000e1NJLTq004pj004pr1ONa4APU%a00002VoOIv0RM-N
+zcmV;58g=D~P)<h;3K|Lk000e1NJLTq004pj004pr1ONa4APU%a00002VoOIv0RM-N
 z%)bBt8be7$K~#9!)tz~iB*lH_KM{G<)z|bjJ@>)D%!mO-Fw7-DAPmTokc7~a^mM>3
 zZzcS8pLT_9R@Sb(&)T)*U3n#2eztCw(_%quSrW30g+~aD#AO%`F)++9!yMhycU9M2
 zm6esTe`IDI-BsOnwFSR?U7eMc85!}--xa_3MWpxuOOYgpLdU@%#5jW(oWUeO8V!Yp
@@ -583,14 +583,14 @@ zhj>D$5MmkU-7e!>Q2kdIXfIhW74NXI16-hOVT5&Tll`hE8(I@M7MRpEgsm*{#hgm!
 s;^t9aPfn=Q!52i_!lZI+YPsnD1F3svQs!l<l>h($07*qoM6N<$g1%n2wg3PC
 
 literal 0
-Hc-jL100001
+HcmV?d00001
 
 diff --git a/chrome/android/java/res_vanadium/drawable-mdpi/product_logo_name.png b/chrome/android/java/res_vanadium/drawable-mdpi/product_logo_name.png
 new file mode 100644
 index 0000000000000000000000000000000000000000..5f92063170520afa34dd48fa6610ea122439e916
 GIT binary patch
 literal 1200
-zc-jH51W)^kP)<h;3K|Lk000e1NJLTq003tI000#T1ONa4@uE1m00002VoOIv0RM-N
+zcmV;h1W)^kP)<h;3K|Lk000e1NJLTq003tI000#T1ONa4@uE1m00002VoOIv0RM-N
 z%)bBt1Zhb`K~z}7&DURyTy+%(@Xx(>_FsX@O}84i3U(VMgzx}UVwc9o;1FXpBtoWy
 z2j6rWUf_X*Ex|`ac1+~Kw;kh?hR6=+gBnd1V-!O{cS$sAG|)-^n3k4yW}(~d?#%4H
 zJk0Ig(t_M=8p?UO_x{fBob&yjbAEqr@Ss2<(bv_zXSLeh+uv!6mFS39qGs}1Psy+Z
@@ -616,14 +616,14 @@ z^+sAqN|1`A|9R&d!QRnoG_`We?y>N~$>SGZU49|`b6{BT;s2taFnJGY>5Ee&#m%|^
 O0000<MNUMnLSTZ4d0|-q
 
 literal 0
-Hc-jL100001
+HcmV?d00001
 
 diff --git a/chrome/android/java/res_vanadium/drawable-xhdpi/fre_product_logo.png b/chrome/android/java/res_vanadium/drawable-xhdpi/fre_product_logo.png
 new file mode 100644
 index 0000000000000000000000000000000000000000..07ecccb90a3786c3c3d7ac33a3f8cb2d2ee555b2
 GIT binary patch
 literal 16100
-zc-jHvJ{!S_P)<h;3K|Lk000e1NJLTq009I5009ID1ONa4WC4PK00002VoOIv0RM-N
+zcmV<AJ{!S_P)<h;3K|Lk000e1NJLTq009I5009ID1ONa4WC4PK00002VoOIv0RM-N
 z%)bBtKAlNKK~#9!?Y()N9A|y!|9+mT>T52|jP6^OWZ9N1VOvH9-zHeb#!fgw4%lQv
 z$ijkcSV%%nLjpgJCFC%egaq>2WV4%1AUFXM8<TL^1|O0SNyfU5(Tp@#&(+g+RXzJh
 zbx&7!Rrhqy^fjzM^HOW3y6UOt_&(q3`99xAyqU#AATUW`(?ymf-K5CSOD`ws#wNu|
@@ -935,14 +935,14 @@ zHcQ#BHdrh4<*AJ_B6{r&$*>;S8h$!F714vru|u<1B12pyR4S0QllFOiQcu_e_IP%D
 q!#O!IXc-t}kqB(e_H@WD3jY_Ejr#a36nZuQ0000<MNUMnLSTZIDYe}I
 
 literal 0
-Hc-jL100001
+HcmV?d00001
 
 diff --git a/chrome/android/java/res_vanadium/drawable-xhdpi/product_logo_name.png b/chrome/android/java/res_vanadium/drawable-xhdpi/product_logo_name.png
 new file mode 100644
 index 0000000000000000000000000000000000000000..ee268c83d97f8d6b73eac0dbe25a204dcc91d4da
 GIT binary patch
 literal 2609
-zc-jFm3eNS3P)<h;3K|Lk000e1NJLTq007Pa001fo1ONa4QNyg;00002VoOIv0RM-N
+zcmV-13eNS3P)<h;3K|Lk000e1NJLTq007Pa001fo1ONa4QNyg;00002VoOIv0RM-N
 z%)bBt3F=8iK~#9!?VEp$9Az2DKl9G)>|MKe?OY3KEzmHhZ7oJh_b?bl5q6Cl$`8$6
 zVyeMtyrsqjL?Wkupu|7C13_#I&?Eea{E9vN5hVoEGmQ!{$}OUR0>T#Bv=rLj-0j}p
 z?#}Mc_{YxP?flr@59Y4e+;@|^n`hsd?>o=)KF|BS&-<SA1?mt~siI;sg@r%{tPPb<
@@ -995,14 +995,14 @@ zR{4SA1I10^GC3}7F0I#ApB+75niI9R&DV<0m-ZK5R*5d?U#*rgcSy_XegEQref)de
 TPbPHy00000NkvXXu0mjf*Ld(I
 
 literal 0
-Hc-jL100001
+HcmV?d00001
 
 diff --git a/chrome/android/java/res_vanadium/drawable-xxhdpi/fre_product_logo.png b/chrome/android/java/res_vanadium/drawable-xxhdpi/fre_product_logo.png
 new file mode 100644
 index 0000000000000000000000000000000000000000..4f300d7f849b005ba63163d63a643f3aeb737aea
 GIT binary patch
 literal 26693
-zc-jCpK+3;~P)<h;3K|Lk000e1NJLTq00D*o00D*w1ONa4)rszI00002VoOIv0RM-N
+zcmV)WK(4=uP)<h;3K|Lk000e1NJLTq00D*o00D*w1ONa4)rszI00002VoOIv0RM-N
 z%)bBtXZ}e<K~#9!?Y(!LBu9Ps|E}tuxOs2)a#YSbC6rMH1Ok&yFg9R#z!)AIunpLL
 z%wufxke!VaVEiK*3?>O1Bmol20R<$TPP(+WySF*bPV7*>KYC`TXQroTW_M<HW_CaQ
 zy4&5E>h9|5`qVenx4tD_$?8A=kjBJDrvsA(Bz>49u+a!}I!}@z!wwdh;UrRoh%-qC
@@ -1318,7 +1318,7 @@ zdcKKqUq4ciB!{qTmJ6-Wr*uL*_0Tg2KpGerq@K0fPBJ*qNO3#8zT<uz$-B{8IEHn3
 z5G2ug55gx)5<nM6+b~wufriD%p(7mSsG}z7$fu09GoisrTOZ*OCh77ir8C53+`>W=
 zkzqAfmrLe(DVH+jn;lOl#X&6e8Z#xe261c>!<(Mk&NjB?#DU0|Pqs$oYlT2#m^;{1
 zK?R!U{p?|;N#x^dybFzK_VRna>lZ-L&9j^!*y2l}ydlV7{<7cbp@$x1m@r|YaDTh3
-zcPoBe8^Jv+(B;#`0T3wf*90>}crP?X+R4?Rf+UIHeT13ued0h?E@(BTlWdKlRiKF9
+zcPoBe8^Jv+(B;#`1T#c<FEmBk$<?5OB#GdCgqiVu;y_j|Xf>vj0rV#e*ldlVRiKF9
 zzd)QAF{Fisg^lsB*(9T4{U12UP(|6GGsHFgDzj_+8dobLmCYQl<C+R8l1(=UnIKeS
 z{=C+pg0lxv`oY}h?#>J}7UE&M3C6_6;YUo+U*RQ9^M1}{x^BBzHZL@$Igj@-U7=i*
 zMSh7u)-+JI3Kc*jsgl3QkS0w!_ly!XY&^QwRcjOkL5}l%)#Lk`1Pd5^jQ$FN%#Fip
@@ -1518,14 +1518,14 @@ zmdO6dLevV2PCKFk1e8tyg&_<~Vak+T6mgOyRl46yrqzfT&dhB~rQ@;TuHku8A=pF*
 gCy1=|1GgRie-#m>m)v0)5&!@I07*qoM6N<$f-sBn4*&oF
 
 literal 0
-Hc-jL100001
+HcmV?d00001
 
 diff --git a/chrome/android/java/res_vanadium/drawable-xxhdpi/product_logo_name.png b/chrome/android/java/res_vanadium/drawable-xxhdpi/product_logo_name.png
 new file mode 100644
 index 0000000000000000000000000000000000000000..fc327262fd9479d15200e5ebca3f5335a1ce12c4
 GIT binary patch
 literal 4270
-zc-jH35K-@mP)<h;3K|Lk000e1NJLTq00A`s002J-1ONa4EBcpR00002VoOIv0RM-N
+zcmV;f5K-@mP)<h;3K|Lk000e1NJLTq00A`s002J-1ONa4EBcpR00002VoOIv0RM-N
 z%)bBt5NAn5K~#9!?VVe28`pWqe`j}b;Y}oD-6h)*Bwyq{=mJ@mRC}5zU^<Q`Gqz+Z
 zeTeH!(@;q|(_}iGkvxslNj>RMO&_Z1q%mnH(^#G+rXu^L^(CS+aZ^=^B}kQ%Sh6F*
 zvUQ^rkst|@xGb>S2P_r~VlR*kg0O`@W(W{x&+fOoe|+aV-{q{>jujFrDn4X#q|wQs
@@ -1610,14 +1610,14 @@ z*2`;HlJ4qiTN*q=E}fs&#<Ev(?_^F){hCug1Ockg5ozLPfoK}+P1Fbf4>8lX6)B~&
 QLI3~&07*qoM6N<$f)Jt_fB*mh
 
 literal 0
-Hc-jL100001
+HcmV?d00001
 
 diff --git a/chrome/android/java/res_vanadium/drawable-xxxhdpi/fre_product_logo.png b/chrome/android/java/res_vanadium/drawable-xxxhdpi/fre_product_logo.png
 new file mode 100644
 index 0000000000000000000000000000000000000000..52abcdfc19c13770971730c8bd4d8267a633ac22
 GIT binary patch
 literal 39011
-zc-jC^K(D`vP)<h;3K|Lk000e1NJLTq00IaA00IaI1ONa4q4nPA00002VoOIv0RM-N
+zcmV)xK$E|TP)<h;3K|Lk000e1NJLTq00IaA00IaI1ONa4q4nPA00002VoOIv0RM-N
 z%)bBtfB;EEK~#9!?45U<Bu9Dozg686H{RY}4!S!@r;~KbIR}u)29a!IW57g%jcpvk
 z*v7^YkWF#`1I9MI7>j5yK}Z5cKmiFPp?tcy;WqD1?ojU^J+qT~W_o64cEa{=KGN+>
 zcXd})S3UjYN4%U)f<TbQL}8<$6GAeJKr%ppX#$u?G&IiV3C4(GBH78~gpi!VA)*ZN
@@ -1933,8 +1933,8 @@ zAtnhgKOCs$P3V5aDezV6u~v$0uvy^wynth#$$`xf0p8CnqrUc_F4zn*#b5GChFJ2r
 z5hb(i=REEqMHn5c!e*%UTlq2X-i@Ux&b;~)*1AtUB%suzu^jo8u(a1K;J{=qAA117
 z!d2dV!`cB!f;4BKm+9y$SJ-pk0t(y1o7z1i&Jz9n36_gjL?sA@`8W?U($2}F`^bTV
 z^*q4G8L4AsDl%NlAW4$cryp=XCOmKGVtYX)jYXxF-uwru!(BsBK0`UJ2P|A3BeDFE
-zIs2oD-DjQFsTzblrrE-d0)GVe?1;5;Ce}w1@(@6b=d!PkgkKf_P(ZK0JNPkQAX1Y2
-z)rS{2RiwYbee9^i+Az-!&Lu+z1Kopup!8T}iM?7oQTE-texSSu)rnT+D|xwRPGr^q
+zIs2oD-DjQFsTzblrrE-d0)GVe?1;5;Ce}w1@(@6b=d!PkgkKgr_%UA~Qj+}DhZi_i
+zq`$y@?5M-qFwYLoB|`=P(m*Z01Kopup!8T}iM?7oQTE-texSSu)rnT+D|xwRPGr^q
 z`z$M*w=~KW&L>Us;`GKAKG~)~Vz9s&L|t5z>Vtp^9`EkwI?z~Rh~FcD>5+l8Sx1}?
 zVbJG`3k~+WAA=8)tRsnx%@UU}LNaTnZj>J=wL>V^mhRuZ^8;>%L~kO3C~N8M%tG>J
 zYzkl0znn2?c~vXqS%%i>{DG6baFD%D{YlEziPbrW{PZ~RW^pJyKhBHT$FxTkmqIeg
@@ -2250,10 +2250,10 @@ zNnf2<2ZGFV7&#Sq5%Z!T1<mSWRjmw#kO+8If0gm=neZqf49^qbZ}*j=R=9KSn<z@G
 zn)^McHOPA^sDi&u5(K#pjhLToy$*y};u&O8e^us?f!Vg1)8lQqts>(H3O~?ZpZV_@
 zMhPtE{r9o@a93U_SF><=;`KaiOfp=|8F8xs02mNSL_t)@9;S%-$<jO{M3Mu<xaf5!
 z-X6znqawCtY1penWNDyH=!?M(v5(C%+R<JKy$m;Z<=nSYfkBm!j$*;VNtQOkb4ZaS
-z?ehm75hTqs81((-@J*wvbGYX=VO3)p0mBzO=nCPyI~0n*$AjxL@0;;S!YZM1cI8q%
-zfsHB>2nzEmmb);6MFxY**vc63wl3>#LJ*5*h%xx*)<0!XB-+}Wjv(UVFZ9nRne#2y
-ztANVy_tM|hvca+Nh${Ji;W3jqTe*w{;w`C6+=~ccbAWk5pHqL?2_kbx5Cn_J>xRD;
-zV-Bq|I<zKHsS-owY>LIdTVx1uEkPFiQm!7M0|%I9*H=bg-x=}09kTzV6?l#OVUjtY
+z?ehm75hTqs81((-@J*wvbGYX=VO3)p3gNsv6pFydgX=TzoAF7)Dxq?A<x)L?jVcld
+z3iB$KyD)=A27}Ak${6vsF6(YW5Q}GsG5F`!KV?uP+S;3rAmZXL^v@@m^DWk^fXeUp
+z(%;px!Ljg&D*1omF_So3xr_zkEvZc0iwIzIfO$fnQ-9eBB6CL&1dGV)hQAhL4y`jf
+zv?fuh5<}%|ip9TMWC(CAK^FW{t{$NS2bcjR7ux7%*H=bg-x=}09kTzV6?l#OVUjtY
 z(OfkYyCYTdGH^RytVYcJ>X;kPWuBx9Z{edH8j?dy(|7mo*VtAk@CO}35EOP&T&Ld|
 zXBOEho$5K1O8)Mag~H>i2H%iBYLXzrbAXtiJJAy~bPh6&cBi`DN_R>QF}>Y%Dd&PA
 zu;cox)E)7?lHs;TIIIO!^OJYe5#)a_hhuKMlwC}b@Xd`LprLb!DMC-CUZoOxR(Tsh
@@ -2370,14 +2370,14 @@ z_ovCc>JVL~6Nel*qf8EkA(UZKq##1!Qp6RmDdR~WZ@xb2TgT;pb#Gjxe1+ay)NW^0
 f`ch_Jq&DIIbfZ@m$+<~>00000NkvXXu0mjf!$8AO
 
 literal 0
-Hc-jL100001
+HcmV?d00001
 
 diff --git a/chrome/android/java/res_vanadium/drawable-xxxhdpi/product_logo_name.png b/chrome/android/java/res_vanadium/drawable-xxxhdpi/product_logo_name.png
 new file mode 100644
 index 0000000000000000000000000000000000000000..5f16990a7eb67c441bfc62d50a4e92f95c0f4f22
 GIT binary patch
 literal 5925
-zc-jFa7ux8FP)<h;3K|Lk000e1NJLTq00Eo;002}71ONa49E3^V00002VoOIv0RM-N
+zcmV+=7ux8FP)<h;3K|Lk000e1NJLTq00Eo;002}71ONa49E3^V00002VoOIv0RM-N
 z%)bBt7T!rjK~#9!?VW3I99NZqzuVpO(9<5-ma!dTYwU!O1cx9c1V|NBN`~dR6d=Qr
 z;9Wu?k?a=B0u`Gjfm)z~9jXYhOTeO*uml3JYO~8D0oK~=BfOGWu#f~N!5-W3Te4>)
 zjYgVh_x_lkQTI&G^c`g+&6xhCT<%dn=AQ0*`kZ_3x#x;^P>w=|ETAD!nMOe;4fx2R
@@ -2494,7 +2494,7 @@ zntO)Bsb@2f>)9Xy)CEPqd3ZD)!gH8BJZeXNYNm&WN0I*rsl^JT&aD`J00000NkvXX
 Hu0mjf>GD|)
 
 literal 0
-Hc-jL100001
+HcmV?d00001
 
 diff --git a/chrome/android/java/res_vanadium_base/DIR_METADATA b/chrome/android/java/res_vanadium_base/DIR_METADATA
 new file mode 100644
@@ -2524,7 +2524,7 @@ new file mode 100644
 index 0000000000000000000000000000000000000000..9533ce927dbb3f4d3849d9a2c062ff31850ae454
 GIT binary patch
 literal 2578
-zc-jFH3hniYP)<h;3K|Lk000e1NJLTq002k;002k`1ONa4|Kxkj00002VoOIv0RM-N
+zcmV+t3hniYP)<h;3K|Lk000e1NJLTq002k;002k`1ONa4|Kxkj00002VoOIv0RM-N
 z%)bBt3Cl@DK~!ko&6;g&9K{*Oe>1yxw$JbO8P_4Po#2Ed#34XHNoYhVQYlDKP@zf@
 zQc+t$^PyEskqT=10YutL<)xL{(l30d1VJe&MXDf_hLlDD6d<%Nae@tbabi31OJdIN
 zcelIK4?BCeciy|(%Zu9QboTA+?#yrg^UO0dI}873CN6Rw>VE|!0D;tB_gDcA3Wb9@
@@ -2576,14 +2576,14 @@ zXXB@sW|~>%NnwTFPc9S4yIy9tcp`dZ$9=x*cD58r()wd%HYdv}pnUV*K$DqAt8PAy
 o?sU%izlC<8Z|MbZHC}-I7X>G&nZLZnpa1{>07*qoM6N<$f{)wb@Bjb+
 
 literal 0
-Hc-jL100001
+HcmV?d00001
 
 diff --git a/chrome/android/java/res_vanadium_base/mipmap-mdpi/app_icon.png b/chrome/android/java/res_vanadium_base/mipmap-mdpi/app_icon.png
 new file mode 100644
 index 0000000000000000000000000000000000000000..5c340f7a0936223c14d858784e18e38443264df5
 GIT binary patch
 literal 1532
-zc-jH{1q1qtP)<h;3K|Lk000e1NJLTq001xm001xu1ONa4{R=S+00002VoOIv0RM-N
+zcmV<Y1q1qtP)<h;3K|Lk000e1NJLTq001xm001xu1ONa4{R=S+00002VoOIv0RM-N
 z%)bBt1+_^;K~z}7wU}LO6jc<*fAhK9FSj4Gl@^fFmXCf&_%0<7pdv9*FyTp!k%UB(
 zB1RJR!53qA-~}{B5jF7z2vK}6qQ*dCNDwS7U<+0QrBIr*wA609Eo^tUyEEg%%<SjP
 zwqQIrnPl#q^Z(y_&bjxVJMce?FiS17nfeA`SnWR(2#82ki_~VRNmwpc;R9nrzZ>h+
@@ -2615,14 +2615,14 @@ zm1+;i!}o^%y8HLd?$8i^0)&aWZc4NGS7FwHIpmUy2MLG~A;c6RqC~U(MwktOtz}*V
 i?5f^Os2P5PnDQ@s4<gB_=JK-u0000<MNUMnLSTa0>e?Ux
 
 literal 0
-Hc-jL100001
+HcmV?d00001
 
 diff --git a/chrome/android/java/res_vanadium_base/mipmap-xhdpi/app_icon.png b/chrome/android/java/res_vanadium_base/mipmap-xhdpi/app_icon.png
 new file mode 100644
 index 0000000000000000000000000000000000000000..2110d524c9c403b80301dd34709d4f6fcc430f28
 GIT binary patch
 literal 3727
-zc-jGv4sh{_P)<h;3K|Lk000e1NJLTq003YB003YJ1ONa4NRhv@00002VoOIv0RM-N
+zcmV;A4sh{_P)<h;3K|Lk000e1NJLTq003YB003YJ1ONa4NRhv@00002VoOIv0RM-N
 z%)bBt4oFEvK~#9!?VM?BT-SBSe{Y!?awu{rky<E9q83w|B}<lV$yH+4ixMM+<2Y^|
 zApX!GY10O^fueDP26ciKU4p_6)EGe>%L$UY1q@{Y?80_qYqjHgk+Nu`EZGz#$|NO{
 z5*KkB&b)c=_QShx8@`!&Z%Ety&@+(c&0FsM|Ia<=-gD2pm+=4c@rv@Hl~`P|DEj_C
@@ -2696,14 +2696,14 @@ z9k%K%AG1#Yxqn*%9UWbMYjPp9L%?(fLrhE;_#FIcjJeuX<!lB}<Wj@nvNy-CEq8V~
 tXMdbzt~W?J>%)T!-Glpw=5&Y9{{mHf#%w_K>9PO-002ovPDHLkV1nv5AYT9g
 
 literal 0
-Hc-jL100001
+HcmV?d00001
 
 diff --git a/chrome/android/java/res_vanadium_base/mipmap-xxhdpi/app_icon.png b/chrome/android/java/res_vanadium_base/mipmap-xxhdpi/app_icon.png
 new file mode 100644
 index 0000000000000000000000000000000000000000..f4894e5b5b5047708bad46853f06c3bd68e54aa0
 GIT binary patch
 literal 6160
-zc-jFF81LtaP)<h;3K|Lk000e1NJLTq0058x0058(1ONa4O;0K_00002VoOIv0RM-N
+zcmV+r81LtaP)<h;3K|Lk000e1NJLTq0058x0058(1ONa4O;0K_00002VoOIv0RM-N
 z%)bBt7s*LPK~#9!?VWj$9MyTif89OTUfN4qUAvM%Vzo#}kw8e`00IoMAyC-Zv11cE
 z#ARa2c9khRNmU%jE?jneRKQ1U2OQsb0CQs(64)FD34sBFBqRhvNGt6n?Xv9LGu@p(
 z`g%RnJ<~JOqr>HIYIgg4{oZfB?|b)a_>25S{vu5j=_Gi*exgUPS<jU0zmn^?14Vaj
@@ -2824,14 +2824,14 @@ ze;qSGZcNx~(z;hnFCCERG|Xu(gX37CIo5#0=as%T&i%$B5IZ^CZx(=KhUWMH@_Mq@
 iy8!i)|Hl}MBmWOUsYCM~E)RwP0000<MNUMnLSTZfrRkLb
 
 literal 0
-Hc-jL100001
+HcmV?d00001
 
 diff --git a/chrome/android/java/res_vanadium_base/mipmap-xxxhdpi/app_icon.png b/chrome/android/java/res_vanadium_base/mipmap-xxxhdpi/app_icon.png
 new file mode 100644
 index 0000000000000000000000000000000000000000..1e02f37a1a940619f19cb73eb3605e14e8b0cfef
 GIT binary patch
 literal 9104
-zc-jGwBX8V^P)<h;3K|Lk000e1NJLTq006)M006)U1ONa4_|>G000002VoOIv0RM-N
+zcmV;BBX8V^P)<h;3K|Lk000e1NJLTq006)M006)U1ONa4_|>G000002VoOIv0RM-N
 z%)bBtBS}d_K~#9!?VWd&9MzrgKNY%rva)7I5-1QPB!UbAga|emY{2&6*v9dAkKb7z
 zN1ns_t?_y9t@rKPn>hB`hPAy8Zygq6!ai)+0}j{(BQi(`fk8+JWsPP=(nu3JR(O9@
 zPTf`ARXqdCZ_b3O>AH36`@O$#e>W7oA#cbV@`k)2|5Zhp?h0g7SADuG8&~A%u0UN8
@@ -3009,7 +3009,7 @@ z&TnT3ZAJm_ecYKSLdb8y_m^AzAbV#p&N$%xk2#Y?sB;t)z0T1Ll>ZM}!uj~k+35iQ
 O0000<MNUMnLSTY_yT{`I
 
 literal 0
-Hc-jL100001
+HcmV?d00001
 
 diff --git a/chrome/android/java/res_vanadium_base/values/channel_constants.xml b/chrome/android/java/res_vanadium_base/values/channel_constants.xml
 new file mode 100644
@@ -3029,5 +3029,5 @@ index 0000000000000..3fb97b4d5dc97
 +    <string name="search_widget_title" translatable="false">Vanadium search</string>
 +</resources>
 -- 
-2.33.0
+2.31.1
 

--- a/patches/0008-Vanadium-branding-for-WebView.patch
+++ b/patches/0008-Vanadium-branding-for-WebView.patch
@@ -1,7 +1,7 @@
-From ab5235d637236237508d20f967ca9eb85c164526 Mon Sep 17 00:00:00 2001
+From aea570c7964e9e9d0923065779d3c3f5ca893a2d Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Sun, 16 Feb 2020 13:40:14 -0500
-Subject: [PATCH 08/76] Vanadium branding for WebView
+Subject: [PATCH 08/77] Vanadium branding for WebView
 
 ---
  android_webview/nonembedded/java/AndroidManifest.xml | 2 +-
@@ -21,5 +21,5 @@ index 289fd730f116d..74a938c989acb 100644
                   android:name="{{ application_name|default('org.chromium.android_webview.nonembedded.WebViewApkApplication') }}"
                   android:multiArch="true"
 -- 
-2.33.0
+2.31.1
 

--- a/patches/0010-Remove-logo-from-chrome-version.patch
+++ b/patches/0010-Remove-logo-from-chrome-version.patch
@@ -1,7 +1,7 @@
-From def926da65599b20d26a6b942bad2bda3c629b33 Mon Sep 17 00:00:00 2001
+From 1be91288697a68c17ff1bc6c8ea50593f6449520 Mon Sep 17 00:00:00 2001
 From: A Mak <refragable@mailbox.org>
 Date: Sat, 25 Jul 2020 17:56:47 -0700
-Subject: [PATCH 10/76] Remove logo from chrome://version
+Subject: [PATCH 10/77] Remove logo from chrome://version
 
 ---
  components/version_ui/resources/about_version.html | 7 -------
@@ -26,5 +26,5 @@ index 1caa96b60599c..d1158ca6b8836 100644
          <div id="company">$i18n{company}</div>
          <div id="copyright">$i18n{copyright}</div>
 -- 
-2.33.0
+2.31.1
 

--- a/patches/0011-redirect-settings-help-icon.patch
+++ b/patches/0011-redirect-settings-help-icon.patch
@@ -1,7 +1,7 @@
-From cee9c0ccdafc9eceb28e8694390a84529ab64586 Mon Sep 17 00:00:00 2001
+From e53da00338b016261524a1ceed275518bd8650c3 Mon Sep 17 00:00:00 2001
 From: "a@b.c" <a@b.c>
 Date: Sat, 16 Jan 2021 15:38:04 +0000
-Subject: [PATCH 11/76] redirect settings help icon
+Subject: [PATCH 11/77] redirect settings help icon
 
 ---
  .../chrome/browser/feedback/HelpAndFeedbackLauncherImpl.java    | 2 +-
@@ -21,5 +21,5 @@ index ccf04eb1168ed..5734f98f8bdde 100644
  
      private static HelpAndFeedbackLauncher sInstance;
 -- 
-2.33.0
+2.31.1
 

--- a/patches/0012-remove-Google-prefix-from-storage-settings-label.patch
+++ b/patches/0012-remove-Google-prefix-from-storage-settings-label.patch
@@ -1,7 +1,7 @@
-From bfac3315fef5c1bd32ab06aa12461d9387768bfb Mon Sep 17 00:00:00 2001
+From eb88bcc02033cd9d07ba9203e03677ec88d6c0a5 Mon Sep 17 00:00:00 2001
 From: "a@b.c" <a@b.c>
 Date: Sun, 17 Jan 2021 12:54:37 +0000
-Subject: [PATCH 12/76] remove Google prefix from storage settings label
+Subject: [PATCH 12/77] remove Google prefix from storage settings label
 
 ---
  chrome/browser/ui/android/strings/android_chrome_strings.grd | 2 +-
@@ -21,5 +21,5 @@ index abb59673fae6d..7a4139b29cd9c 100644
        <message name="IDS_STORAGE_MANAGEMENT_UNIMPORTANT_SITE_DATA_DESCRIPTION" desc="Text to describe the data stored by unimportant or infrequent sites.">
          Stored data that Vanadium doesn't think is important (e.g. sites with no saved settings or that you don't visit often)
 -- 
-2.33.0
+2.31.1
 

--- a/patches/0013-remove-Help-feedback-menu-entry.patch
+++ b/patches/0013-remove-Help-feedback-menu-entry.patch
@@ -1,7 +1,7 @@
-From f3af6768ec967edccf4adb2aa5efe4cdc0a4cd6a Mon Sep 17 00:00:00 2001
+From 758547d647f9bb08b30799c69daaa73b3c28f47d Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Thu, 15 Apr 2021 02:14:37 -0400
-Subject: [PATCH 13/76] remove Help & feedback menu entry
+Subject: [PATCH 13/77] remove Help & feedback menu entry
 
 ---
  .../browser/app/appmenu/AppMenuPropertiesDelegateImpl.java      | 2 ++
@@ -21,5 +21,5 @@ index adf42467c76eb..95a9c3ca49b9f 100644
          menu.findItem(R.id.enter_vr_id).setVisible(shouldShowEnterVr());
  
 -- 
-2.33.0
+2.31.1
 

--- a/patches/0014-hide-passwords.google.com-link-when-not-supported.patch
+++ b/patches/0014-hide-passwords.google.com-link-when-not-supported.patch
@@ -1,7 +1,7 @@
-From 453de559d0ae1c62b193510a11957fbd743d658f Mon Sep 17 00:00:00 2001
+From b60f71872a6c09444556102880ab0b0954283146 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Sun, 13 Aug 2017 19:33:04 -0400
-Subject: [PATCH 14/76] hide passwords.google.com link when not supported
+Subject: [PATCH 14/77] hide passwords.google.com link when not supported
 
 ---
  .../browser/password_manager/settings/PasswordSettings.java   | 4 ++++
@@ -30,5 +30,5 @@ index 4d9a4bfa06ca1..e0a2426ded122 100644
              return; // Don't add the Manage Account link if it's present.
          }
 -- 
-2.33.0
+2.31.1
 

--- a/patches/0015-disable-first-run-welcome-page.patch
+++ b/patches/0015-disable-first-run-welcome-page.patch
@@ -1,7 +1,7 @@
-From d33cb43cb8c2fcf05ff01a05b42cdf2560cbc6ac Mon Sep 17 00:00:00 2001
+From f6069d2b96d4e729e778c53b6fa9bc8e95cfb776 Mon Sep 17 00:00:00 2001
 From: csagan5 <32685696+csagan5@users.noreply.github.com>
 Date: Sun, 26 Nov 2017 22:51:43 +0100
-Subject: [PATCH 15/76] disable first run welcome page
+Subject: [PATCH 15/77] disable first run welcome page
 
 ---
  .../org/chromium/chrome/browser/firstrun/FirstRunUtils.java | 3 ---
@@ -64,5 +64,5 @@ index 13bec9f270f5b..ac3a3c0f7caf2 100644
  
      /**
 -- 
-2.33.0
+2.31.1
 

--- a/patches/0016-disable-seed-based-field-trials.patch
+++ b/patches/0016-disable-seed-based-field-trials.patch
@@ -1,7 +1,7 @@
-From 4457e1a6d17c7b6e8a4c62151c386c70a9e5b2ea Mon Sep 17 00:00:00 2001
+From 3a4f767ffafaba4ab48b871481a224ced5b0f5b5 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Tue, 25 Dec 2018 16:19:51 -0500
-Subject: [PATCH 16/76] disable seed-based field trials
+Subject: [PATCH 16/77] disable seed-based field trials
 
 ---
  components/variations/service/variations_field_trial_creator.cc | 2 ++
@@ -23,5 +23,5 @@ index 34182a0ba9149..1ef1a37276d67 100644
  
    platform_field_trials->SetupFeatureControllingFieldTrials(
 -- 
-2.33.0
+2.31.1
 

--- a/patches/0017-disable-fetching-variations.patch
+++ b/patches/0017-disable-fetching-variations.patch
@@ -1,7 +1,7 @@
-From 6a734d73dd691f7b99abf46ea9890ba7cbda073a Mon Sep 17 00:00:00 2001
+From 0f85d02ffdb73cf4508cc7371634d686de018169 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Wed, 18 Nov 2020 19:08:58 -0500
-Subject: [PATCH 17/76] disable fetching variations
+Subject: [PATCH 17/77] disable fetching variations
 
 ---
  .../org/chromium/chrome/browser/init/AsyncInitTaskRunner.java   | 2 +-
@@ -21,5 +21,5 @@ index 017a89155e5ca..9c10b32f7ec54 100644
  
      @VisibleForTesting
 -- 
-2.33.0
+2.31.1
 

--- a/patches/0018-disable-WebView-variations-support.patch
+++ b/patches/0018-disable-WebView-variations-support.patch
@@ -1,7 +1,7 @@
-From 0a34cac269cd3996886ef0280f19b1632266655a Mon Sep 17 00:00:00 2001
+From 2bbc358cfa81241600f0c5824312d0f75390140e Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Thu, 10 Dec 2020 10:09:18 -0500
-Subject: [PATCH 18/76] disable WebView variations support
+Subject: [PATCH 18/77] disable WebView variations support
 
 ---
  .../com/android/webview/chromium/WebViewChromiumAwInit.java   | 4 ----
@@ -37,5 +37,5 @@ index 51cd297e8c56a..9a808226008f1 100644
  
              setSingleton(this);
 -- 
-2.33.0
+2.31.1
 

--- a/patches/0019-disable-navigation-error-correction-by-default.patch
+++ b/patches/0019-disable-navigation-error-correction-by-default.patch
@@ -1,7 +1,7 @@
-From e0f5a6939457620c0e2162b1927a0c71369bafbe Mon Sep 17 00:00:00 2001
+From 184f28f21903306c3c082ecd095c49cde15e183f Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Wed, 23 Nov 2016 08:29:58 -0500
-Subject: [PATCH 19/76] disable navigation error correction by default
+Subject: [PATCH 19/77] disable navigation error correction by default
 
 ---
  chrome/browser/net/profile_network_context_service.cc | 2 +-
@@ -21,5 +21,5 @@ index 77573496f3548..ed2643f2372e5 100644
    registry->RegisterBooleanPref(prefs::kQuicAllowed, true);
    registry->RegisterBooleanPref(prefs::kGloballyScopeHTTPAuthCacheEnabled,
 -- 
-2.33.0
+2.31.1
 

--- a/patches/0020-disable-contextual-search-by-default.patch
+++ b/patches/0020-disable-contextual-search-by-default.patch
@@ -1,7 +1,7 @@
-From 7c719d9c06c96be9ea8eb36d90c418a3cc200683 Mon Sep 17 00:00:00 2001
+From ef117a1621860483e7a12e89a9f9b249eea4e817 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Wed, 23 Nov 2016 09:26:51 -0500
-Subject: [PATCH 20/76] disable contextual search by default
+Subject: [PATCH 20/77] disable contextual search by default
 
 ---
  .../browser/contextualsearch/ContextualSearchFieldTrial.java    | 2 +-
@@ -35,5 +35,5 @@ index 403c59f81857a..d4db9d7d0bfd5 100644
  #endif  // defined(OS_ANDROID)
    registry->RegisterStringPref(prefs::kSessionExitType, std::string());
 -- 
-2.33.0
+2.31.1
 

--- a/patches/0021-disable-network-prediction-by-default.patch
+++ b/patches/0021-disable-network-prediction-by-default.patch
@@ -1,7 +1,7 @@
-From 69b457da179eb01c2b4bae70bd835a266cb81b87 Mon Sep 17 00:00:00 2001
+From 218c60c0f181753e571fc864a0dd74ac3f89ed25 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Wed, 23 Nov 2016 08:31:44 -0500
-Subject: [PATCH 21/76] disable network prediction by default
+Subject: [PATCH 21/77] disable network prediction by default
 
 ---
  chrome/browser/net/prediction_options.h | 2 +-
@@ -21,5 +21,5 @@ index 2ae6a1093090d..7fc83de1aa0fa 100644
  
  enum class NetworkPredictionStatus {
 -- 
-2.33.0
+2.31.1
 

--- a/patches/0022-disable-metrics-by-default.patch
+++ b/patches/0022-disable-metrics-by-default.patch
@@ -1,7 +1,7 @@
-From c5820d84a415a779d71968cf29f54578ce465a26 Mon Sep 17 00:00:00 2001
+From 8f84f85332c48212f1516d859ad987f42b20c196 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Thu, 24 Nov 2016 11:41:00 -0500
-Subject: [PATCH 22/76] disable metrics by default
+Subject: [PATCH 22/77] disable metrics by default
 
 ---
  .../chromium/chrome/browser/firstrun/FirstRunActivityBase.java  | 2 +-
@@ -21,5 +21,5 @@ index a159e4a7f61d6..d3472b194b0cb 100644
      private boolean mNativeInitialized;
  
 -- 
-2.33.0
+2.31.1
 

--- a/patches/0023-disable-hyperlink-auditing-by-default.patch
+++ b/patches/0023-disable-hyperlink-auditing-by-default.patch
@@ -1,7 +1,7 @@
-From db84c3407462e93433482bb023c8226c68586793 Mon Sep 17 00:00:00 2001
+From 4e43d921888a3de9909f9274404d632686526aba Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Sat, 26 Nov 2016 14:57:22 -0500
-Subject: [PATCH 23/76] disable hyperlink auditing by default
+Subject: [PATCH 23/77] disable hyperlink auditing by default
 
 ---
  chrome/browser/chrome_content_browser_client.cc | 2 +-
@@ -21,5 +21,5 @@ index 99aadfa065fae..9d9d1d3be36b9 100644
    // user policy in addition to the same named ones in Local State (which are
    // used for mapping the command-line flags).
 -- 
-2.33.0
+2.31.1
 

--- a/patches/0024-disable-showing-popular-sites-by-default.patch
+++ b/patches/0024-disable-showing-popular-sites-by-default.patch
@@ -1,7 +1,7 @@
-From 9de8ee2c7e4c6521e9fa61c0410708da809df226 Mon Sep 17 00:00:00 2001
+From 4692d8fde0e59f6627d82cd1f994f2dd0ec0731a Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Tue, 6 Mar 2018 00:27:41 -0500
-Subject: [PATCH 24/76] disable showing popular sites by default
+Subject: [PATCH 24/77] disable showing popular sites by default
 
 ---
  components/ntp_tiles/features.cc | 4 ++--
@@ -27,5 +27,5 @@ index 4ce3356827cec..4414615ff6ac6 100644
  
  }  // namespace ntp_tiles
 -- 
-2.33.0
+2.31.1
 

--- a/patches/0025-disable-article-suggestions-feature-by-default.patch
+++ b/patches/0025-disable-article-suggestions-feature-by-default.patch
@@ -1,7 +1,7 @@
-From a1092972badab15f1e5720d2388cddb88b6d2484 Mon Sep 17 00:00:00 2001
+From bf999ed09f74601b9435f070a45b79a2126170ee Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Thu, 8 Mar 2018 22:43:12 -0500
-Subject: [PATCH 25/76] disable article suggestions feature by default
+Subject: [PATCH 25/77] disable article suggestions feature by default
 
 ---
  components/feed/core/shared_prefs/pref_names.cc | 4 ++--
@@ -37,5 +37,5 @@ index c5ea510f1e580..688887dc4ba76 100644
  const base::Feature kRemoteSuggestionsEmulateM58FetchingSchedule{
      "RemoteSuggestionsEmulateM58FetchingSchedule",
 -- 
-2.33.0
+2.31.1
 

--- a/patches/0026-disable-prefetching-suggested-pages-by-default.patch
+++ b/patches/0026-disable-prefetching-suggested-pages-by-default.patch
@@ -1,7 +1,7 @@
-From 1d44dacd630e1d63d0b52b22d33e3f3eefc05f6f Mon Sep 17 00:00:00 2001
+From deea9efd559cf5bd59352e17f87f08fa50f4dc4e Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Fri, 12 Jul 2019 04:10:21 -0400
-Subject: [PATCH 26/76] disable prefetching suggested pages by default
+Subject: [PATCH 26/77] disable prefetching suggested pages by default
 
 ---
  components/offline_pages/core/offline_page_feature.cc | 2 +-
@@ -21,5 +21,5 @@ index d1a9a4fca3778..21b689819c4b5 100644
  const base::Feature kOfflinePagesCTV2Feature{"OfflinePagesCTV2",
                                               base::FEATURE_DISABLED_BY_DEFAULT};
 -- 
-2.33.0
+2.31.1
 

--- a/patches/0027-disable-content-feed-suggestions-by-default.patch
+++ b/patches/0027-disable-content-feed-suggestions-by-default.patch
@@ -1,7 +1,7 @@
-From 2b78f59c5577901f5a5c194fa0a16028f690c619 Mon Sep 17 00:00:00 2001
+From 674fc110027e716cb4283877ff393c0dad444bae Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Sun, 22 Mar 2020 01:23:48 -0400
-Subject: [PATCH 27/76] disable content feed suggestions by default
+Subject: [PATCH 27/77] disable content feed suggestions by default
 
 ---
  .../org/chromium/chrome/browser/flags/CachedFeatureFlags.java | 2 +-
@@ -41,5 +41,5 @@ index 4a03ed02bf6c1..3967a0bd5bbe7 100644
  const base::Feature kInterestFeedV2Autoplay{"InterestFeedV2Autoplay",
                                              base::FEATURE_DISABLED_BY_DEFAULT};
 -- 
-2.33.0
+2.31.1
 

--- a/patches/0028-disable-sensors-access-by-default.patch
+++ b/patches/0028-disable-sensors-access-by-default.patch
@@ -1,7 +1,7 @@
-From d226022bff7c7c9492ded5f860d3e61545a74972 Mon Sep 17 00:00:00 2001
+From 5ea57129388c985b154853daa5b53324e19ae246 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Sun, 16 Jun 2019 15:57:29 -0400
-Subject: [PATCH 28/76] disable sensors access by default
+Subject: [PATCH 28/77] disable sensors access by default
 
 ---
  .../content_settings/core/browser/content_settings_registry.cc  | 2 +-
@@ -21,5 +21,5 @@ index 585b86afeeacd..d7272c314dfec 100644
             ValidSettings(CONTENT_SETTING_ALLOW, CONTENT_SETTING_BLOCK),
             WebsiteSettingsInfo::SINGLE_ORIGIN_ONLY_SCOPE,
 -- 
-2.33.0
+2.31.1
 

--- a/patches/0029-block-playing-protected-media-by-default.patch
+++ b/patches/0029-block-playing-protected-media-by-default.patch
@@ -1,7 +1,7 @@
-From 0a239f6ab37dc47a5e81420e87f2d473c1202505 Mon Sep 17 00:00:00 2001
+From 229927767829cead1f29cd95c2193531b4dbd92b Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Tue, 1 Dec 2020 00:29:28 -0500
-Subject: [PATCH 29/76] block playing protected media by default
+Subject: [PATCH 29/77] block playing protected media by default
 
 ---
  .../core/browser/content_settings_registry.cc       | 13 +------------
@@ -32,5 +32,5 @@ index d7272c314dfec..f07431fdcdf8b 100644
    Register(ContentSettingsType::PROTECTED_MEDIA_IDENTIFIER,
             "protected-media-identifier", protected_media_identifier_setting,
 -- 
-2.33.0
+2.31.1
 

--- a/patches/0030-disable-third-party-cookies-by-default.patch
+++ b/patches/0030-disable-third-party-cookies-by-default.patch
@@ -1,7 +1,7 @@
-From 128a2b127c92a604be9d4547f70d7ec4e50e2bff Mon Sep 17 00:00:00 2001
+From c533f90345c8bd08fb423c318176a2d0054ab384 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Sun, 16 Jun 2019 16:01:31 -0400
-Subject: [PATCH 30/76] disable third party cookies by default
+Subject: [PATCH 30/77] disable third party cookies by default
 
 ---
  components/content_settings/core/browser/cookie_settings.cc | 2 +-
@@ -21,5 +21,5 @@ index b1c017a14bbf2..0777068fa73c5 100644
  }
  
 -- 
-2.33.0
+2.31.1
 

--- a/patches/0031-disable-background-sync-by-default.patch
+++ b/patches/0031-disable-background-sync-by-default.patch
@@ -1,7 +1,7 @@
-From ffd13ede50c9da2b42931ecf8ffb30c4bd8ffbc4 Mon Sep 17 00:00:00 2001
+From f3da865632e56eb7b03f31bba7d13afc735d9ac5 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Sun, 16 Jun 2019 21:57:26 -0400
-Subject: [PATCH 31/76] disable background sync by default
+Subject: [PATCH 31/77] disable background sync by default
 
 ---
  .../content_settings/core/browser/content_settings_registry.cc  | 2 +-
@@ -21,5 +21,5 @@ index f07431fdcdf8b..52bc966a44096 100644
             ValidSettings(CONTENT_SETTING_ALLOW, CONTENT_SETTING_BLOCK),
             WebsiteSettingsInfo::SINGLE_ORIGIN_ONLY_SCOPE,
 -- 
-2.33.0
+2.31.1
 

--- a/patches/0032-disable-payment-support-by-default.patch
+++ b/patches/0032-disable-payment-support-by-default.patch
@@ -1,7 +1,7 @@
-From ebf08e9b2886adcba08f88eca48a60439731dbf1 Mon Sep 17 00:00:00 2001
+From eecfb64ad0717038b5f09fea70a7077db9338263 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Tue, 18 Jun 2019 22:28:53 -0400
-Subject: [PATCH 32/76] disable payment support by default
+Subject: [PATCH 32/77] disable payment support by default
 
 ---
  components/payments/core/payment_prefs.cc | 2 +-
@@ -21,5 +21,5 @@ index 9590d9494ed10..787ff68af12aa 100644
  }
  
 -- 
-2.33.0
+2.31.1
 

--- a/patches/0033-disable-media-router-media-remoting-by-default.patch
+++ b/patches/0033-disable-media-router-media-remoting-by-default.patch
@@ -1,7 +1,7 @@
-From 9bd8d97ff5c2e61fd91a033d96607a64b296484e Mon Sep 17 00:00:00 2001
+From 99b804ff63292c2a772330e51c1eb09b363eb6ba Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Thu, 4 Jul 2019 18:11:27 -0400
-Subject: [PATCH 33/76] disable media router media remoting by default
+Subject: [PATCH 33/77] disable media router media remoting by default
 
 ---
  chrome/browser/profiles/profile.cc | 2 +-
@@ -21,5 +21,5 @@ index d4db9d7d0bfd5..111fb80f051e1 100644
        media_router::prefs::kMediaRouterTabMirroringSources);
  #endif
 -- 
-2.33.0
+2.31.1
 

--- a/patches/0034-disable-media-router-by-default.patch
+++ b/patches/0034-disable-media-router-by-default.patch
@@ -1,7 +1,7 @@
-From 6dd38a7e129f062022a9319f22753027da64dc88 Mon Sep 17 00:00:00 2001
+From fc525338b6dc7a1a4e3379dfd3600b6ffc66e7bf Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Thu, 4 Jul 2019 19:08:52 -0400
-Subject: [PATCH 34/76] disable media router by default
+Subject: [PATCH 34/77] disable media router by default
 
 ---
  chrome/browser/media/router/media_router_feature.cc | 2 +-
@@ -35,5 +35,5 @@ index 3a757e266d7f3..d8320e139416e 100644
    registry->RegisterBooleanPref(prefs::kShowCastIconInToolbar, false);
  #endif  // !defined(OS_ANDROID)
 -- 
-2.33.0
+2.31.1
 

--- a/patches/0035-disable-offering-translations-by-default.patch
+++ b/patches/0035-disable-offering-translations-by-default.patch
@@ -1,7 +1,7 @@
-From 33e30b15c9986bf92a476bef8334c1fbdf0d9e9f Mon Sep 17 00:00:00 2001
+From f723b01b7de6aa3088fd6df6df9259d6f892623c Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Fri, 12 Jul 2019 03:58:01 -0400
-Subject: [PATCH 35/76] disable offering translations by default
+Subject: [PATCH 35/77] disable offering translations by default
 
 ---
  chrome/browser/ui/browser_ui_prefs.cc | 2 +-
@@ -21,5 +21,5 @@ index 20bb8b5bd368b..914ad46bd50fb 100644
    registry->RegisterStringPref(prefs::kCloudPrintEmail, std::string());
    registry->RegisterBooleanPref(prefs::kCloudPrintProxyEnabled, true);
 -- 
-2.33.0
+2.31.1
 

--- a/patches/0036-disable-browser-sign-in-feature-by-default.patch
+++ b/patches/0036-disable-browser-sign-in-feature-by-default.patch
@@ -1,7 +1,7 @@
-From f74d2413f7e8a6115e7bdaef9ff5da044924f12e Mon Sep 17 00:00:00 2001
+From 8faa184041dca20d1453a2000a541196b55709f6 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Fri, 12 Jul 2019 04:23:18 -0400
-Subject: [PATCH 36/76] disable browser sign in feature by default
+Subject: [PATCH 36/77] disable browser sign in feature by default
 
 ---
  chrome/browser/signin/account_consistency_mode_manager.cc       | 2 +-
@@ -35,5 +35,5 @@ index 8e380c5b5a919..826d640099636 100644
    registry->RegisterBooleanPref(prefs::kSignedInWithCredentialProvider, false);
  }
 -- 
-2.33.0
+2.31.1
 

--- a/patches/0037-disable-browser-autologin-by-default.patch
+++ b/patches/0037-disable-browser-autologin-by-default.patch
@@ -1,7 +1,7 @@
-From 4c35e5e9a71b7789bdae4fed3ccef2fa385e85f9 Mon Sep 17 00:00:00 2001
+From 8d987581eeb04eb119af204c96427439252159a3 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Sun, 22 Mar 2020 03:07:08 -0400
-Subject: [PATCH 37/76] disable browser autologin by default
+Subject: [PATCH 37/77] disable browser autologin by default
 
 ---
  .../signin/internal/identity_manager/primary_account_manager.cc | 2 +-
@@ -21,5 +21,5 @@ index 826d640099636..2951c9b0edcbc 100644
    registry->RegisterBooleanPref(prefs::kSigninAllowed, false);
    registry->RegisterBooleanPref(prefs::kSigninAllowedByPolicy, true);
 -- 
-2.33.0
+2.31.1
 

--- a/patches/0038-disable-safe-browsing-reporting-opt-in-by-default.patch
+++ b/patches/0038-disable-safe-browsing-reporting-opt-in-by-default.patch
@@ -1,7 +1,7 @@
-From c7561dbc3800f8429594e5bd4cf24cb342bc7b51 Mon Sep 17 00:00:00 2001
+From 933ccb68b10cceecd548eb39303ef17fbf08d490 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Fri, 12 Jul 2019 05:22:11 -0400
-Subject: [PATCH 38/76] disable safe browsing reporting opt-in by default
+Subject: [PATCH 38/77] disable safe browsing reporting opt-in by default
 
 ---
  components/safe_browsing/core/common/safe_browsing_prefs.cc | 2 +-
@@ -21,5 +21,5 @@ index 479c0634baf69..34106a97f2eb9 100644
        prefs::kSafeBrowsingEnabled, true,
        user_prefs::PrefRegistrySyncable::SYNCABLE_PREF);
 -- 
-2.33.0
+2.31.1
 

--- a/patches/0039-disable-unused-safe-browsing-option-by-default.patch
+++ b/patches/0039-disable-unused-safe-browsing-option-by-default.patch
@@ -1,7 +1,7 @@
-From 4a0400f64998a213549a3b7cbe21fecad178da39 Mon Sep 17 00:00:00 2001
+From dce8e440f792fd34388560ece2fd817f8e5797e0 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Thu, 12 Mar 2020 13:01:02 -0400
-Subject: [PATCH 39/76] disable unused safe browsing option by default
+Subject: [PATCH 39/77] disable unused safe browsing option by default
 
 Safe Browsing is currently a no-op due to the lack of Play Services, and
 support for using the local database backend hasn't been implemented.
@@ -25,5 +25,5 @@ index 34106a97f2eb9..170924a29ec0c 100644
    registry->RegisterBooleanPref(prefs::kSafeBrowsingEnhanced, false);
    registry->RegisterBooleanPref(prefs::kSafeBrowsingProceedAnywayDisabled,
 -- 
-2.33.0
+2.31.1
 

--- a/patches/0040-disable-media-DRM-preprovisioning-by-default.patch
+++ b/patches/0040-disable-media-DRM-preprovisioning-by-default.patch
@@ -1,7 +1,7 @@
-From 7151776da26c5ccf3c81a302758a960468ea31f5 Mon Sep 17 00:00:00 2001
+From d0b56324f338f1d7c4b5117cc02633887f449ba1 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Thu, 21 May 2020 12:27:29 -0400
-Subject: [PATCH 40/76] disable media DRM preprovisioning by default
+Subject: [PATCH 40/77] disable media DRM preprovisioning by default
 
 This switches to fetching on-demand, which can only happen if DRM media
 support is enabled.
@@ -23,5 +23,5 @@ index 9b32170f89608..a5d51808a6cd3 100644
  // Determines if MediaDrmOriginIdManager should attempt to pre-provision origin
  // IDs at startup (whenever a profile is loaded). Also used by tests that
 -- 
-2.33.0
+2.31.1
 

--- a/patches/0041-enable-prefetch-privacy-changes-by-default.patch
+++ b/patches/0041-enable-prefetch-privacy-changes-by-default.patch
@@ -1,7 +1,7 @@
-From 33460f3d86a5b21eb46575cd5a0e3216a22a4a6e Mon Sep 17 00:00:00 2001
+From dd022a758b1458a96dc686a3f8061f152473a8c9 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Fri, 23 Oct 2020 23:59:13 -0400
-Subject: [PATCH 41/76] enable prefetch privacy changes by default
+Subject: [PATCH 41/77] enable prefetch privacy changes by default
 
 ---
  third_party/blink/common/features.cc | 2 +-
@@ -21,5 +21,5 @@ index be6f237f403c6..68b460ca28b0e 100644
  // Decodes jpeg 4:2:0 formatted images to YUV instead of RGBX and stores in this
  // format in the image decode cache. See crbug.com/919627 for details on the
 -- 
-2.33.0
+2.31.1
 

--- a/patches/0042-enable-user-agent-freeze-by-default.patch
+++ b/patches/0042-enable-user-agent-freeze-by-default.patch
@@ -1,7 +1,7 @@
-From 2c43cd5eec48bb650e847c29faef8e8b1c53a753 Mon Sep 17 00:00:00 2001
+From a6a13b1664397605e3ef9890a14bb52386553ea5 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Wed, 3 Mar 2021 13:42:41 -0500
-Subject: [PATCH 42/76] enable user agent freeze by default
+Subject: [PATCH 42/77] enable user agent freeze by default
 
 ---
  third_party/blink/common/features.cc | 2 +-
@@ -21,5 +21,5 @@ index 68b460ca28b0e..775eca6d5ce4e 100644
  // Enables the frequency capping for detecting overlay popups. Overlay-popups
  // are the interstitials that pop up and block the main content of the page.
 -- 
-2.33.0
+2.31.1
 

--- a/patches/0043-enable-split-cache-by-default.patch
+++ b/patches/0043-enable-split-cache-by-default.patch
@@ -1,7 +1,7 @@
-From 37e75cb71a8e8c9b5b29535c38ef536ea105dfe8 Mon Sep 17 00:00:00 2001
+From 0a8f42d23d461a5d6a217c86c20229f2355e8af2 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Wed, 23 Dec 2020 06:00:50 -0500
-Subject: [PATCH 43/76] enable split cache by default
+Subject: [PATCH 43/77] enable split cache by default
 
 ---
  net/base/features.cc | 2 +-
@@ -21,5 +21,5 @@ index c5cf07da5c77d..6012b399ae80e 100644
  const base::Feature kSplitHostCacheByNetworkIsolationKey{
      "SplitHostCacheByNetworkIsolationKey", base::FEATURE_DISABLED_BY_DEFAULT};
 -- 
-2.33.0
+2.31.1
 

--- a/patches/0044-enable-partitioning-connections-by-default.patch
+++ b/patches/0044-enable-partitioning-connections-by-default.patch
@@ -1,7 +1,7 @@
-From 51c4237e31ea07d5c8c6c9393d286e2f8a568178 Mon Sep 17 00:00:00 2001
+From 2bacd71300a2e3c1ea5952592933a871a420985b Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Mon, 8 Mar 2021 16:53:47 -0500
-Subject: [PATCH 44/76] enable partitioning connections by default
+Subject: [PATCH 44/77] enable partitioning connections by default
 
 ---
  net/base/features.cc | 12 ++++++------
@@ -46,5 +46,5 @@ index 6012b399ae80e..252701f0b7964 100644
  const base::Feature kExpectCTPruning{"ExpectCTPruning",
                                       base::FEATURE_ENABLED_BY_DEFAULT};
 -- 
-2.33.0
+2.31.1
 

--- a/patches/0045-enable-dubious-Do-Not-Track-feature-by-default.patch
+++ b/patches/0045-enable-dubious-Do-Not-Track-feature-by-default.patch
@@ -1,7 +1,7 @@
-From f2f1209b376bb6e217d756edb68d423380c5ba52 Mon Sep 17 00:00:00 2001
+From 740b8c51c129433ad9151ec82a49019d829d6b36 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Tue, 1 Aug 2017 11:16:11 -0400
-Subject: [PATCH 45/76] enable dubious Do Not Track feature by default
+Subject: [PATCH 45/77] enable dubious Do Not Track feature by default
 
 ---
  chrome/browser/ui/browser_ui_prefs.cc | 2 +-
@@ -21,5 +21,5 @@ index 914ad46bd50fb..7bbd3ba5f9057 100644
  #if !BUILDFLAG(IS_CHROMEOS_ASH) && !defined(OS_ANDROID)
    registry->RegisterBooleanPref(prefs::kPrintPreviewUseSystemDefaultPrinter,
 -- 
-2.33.0
+2.31.1
 

--- a/patches/0046-disable-autofill-assistant-by-default.patch
+++ b/patches/0046-disable-autofill-assistant-by-default.patch
@@ -1,7 +1,7 @@
-From c75d2d57b224e0ce9b96e2f7e27cf9f59857c7a3 Mon Sep 17 00:00:00 2001
+From e4871f4c1bee9c47925782315efd6c6889948bba Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Fri, 27 Nov 2020 02:43:37 -0500
-Subject: [PATCH 46/76] disable autofill assistant by default
+Subject: [PATCH 46/77] disable autofill assistant by default
 
 ---
  .../autofill_assistant/AutofillAssistantPreferencesUtil.java  | 2 +-
@@ -44,5 +44,5 @@ index 5388e868bcc60..a4b41838f24f7 100644
  // Used to configure the start heuristics for
  // |kAutofillAssistantInCctTriggering| and/or
 -- 
-2.33.0
+2.31.1
 

--- a/patches/0047-disable-autofill-server-communication-by-default.patch
+++ b/patches/0047-disable-autofill-server-communication-by-default.patch
@@ -1,7 +1,7 @@
-From 4263248bed004d89407d019b463774536eb092fe Mon Sep 17 00:00:00 2001
+From ddbeb4868a5174553d193620efd4cd632cc1ff1d Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Tue, 1 Dec 2020 00:56:57 -0500
-Subject: [PATCH 47/76] disable autofill server communication by default
+Subject: [PATCH 47/77] disable autofill server communication by default
 
 ---
  components/autofill/core/common/autofill_features.cc | 2 +-
@@ -21,5 +21,5 @@ index c836ebc6d56cc..021cf0288d677 100644
  // Controls attaching the autofill type predictions to their respective
  // element in the DOM.
 -- 
-2.33.0
+2.31.1
 

--- a/patches/0048-disable-component-updater-pings-by-default.patch
+++ b/patches/0048-disable-component-updater-pings-by-default.patch
@@ -1,7 +1,7 @@
-From ce55febac738e2462db27ba614dadaea21208b14 Mon Sep 17 00:00:00 2001
+From 7a63e2f9d7dad8de35177c1df5f4fcf8125d2726 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Fri, 27 Nov 2020 03:56:29 -0500
-Subject: [PATCH 48/76] disable component updater pings by default
+Subject: [PATCH 48/77] disable component updater pings by default
 
 ---
  .../component_updater_command_line_config_policy.h              | 2 +-
@@ -21,5 +21,5 @@ index 17606fe0c867b..11be0a70cb57b 100644
  
    // If non-zero, time interval in seconds until the first component
 -- 
-2.33.0
+2.31.1
 

--- a/patches/0049-mark-non-secure-origins-as-dangerous.patch
+++ b/patches/0049-mark-non-secure-origins-as-dangerous.patch
@@ -1,7 +1,7 @@
-From d80b3689fdf464cab6291b22ec9fbf068831c855 Mon Sep 17 00:00:00 2001
+From fe24de529f2eb80ddab15ceb7f9052bea3d96db7 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Fri, 20 Oct 2017 21:20:50 -0400
-Subject: [PATCH 49/76] mark non-secure origins as dangerous
+Subject: [PATCH 49/77] mark non-secure origins as dangerous
 
 ---
  components/security_state/core/security_state.cc | 2 +-
@@ -21,5 +21,5 @@ index fdcdf57e45abc..569dbf037bd2d 100644
      return NONE;
    }
 -- 
-2.33.0
+2.31.1
 

--- a/patches/0050-enable-strict-site-isolation-by-default-on-Android.patch
+++ b/patches/0050-enable-strict-site-isolation-by-default-on-Android.patch
@@ -1,7 +1,7 @@
-From e41a9fb13331582e55fe5e56d2cde67a2c03aec3 Mon Sep 17 00:00:00 2001
+From f1820a4d878f18ff3dcb8d92fa1aeb90608e50f1 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Thu, 2 May 2019 07:15:32 -0400
-Subject: [PATCH 50/76] enable strict site isolation by default on Android
+Subject: [PATCH 50/77] enable strict site isolation by default on Android
 
 ---
  chrome/browser/about_flags.cc    | 20 --------------------
@@ -58,5 +58,5 @@ index fd74a49b0b9d1..3b052de4b1725 100644
  
  #if BUILDFLAG(IS_CHROMEOS_ASH)
 -- 
-2.33.0
+2.31.1
 

--- a/patches/0051-most-private-WebRTC-IP-handling-policy-by-default.patch
+++ b/patches/0051-most-private-WebRTC-IP-handling-policy-by-default.patch
@@ -1,7 +1,7 @@
-From 6cbacffb5bc05c63f75bdaed4a3a2bc921cb03cb Mon Sep 17 00:00:00 2001
+From 9aa1e1445e06192aaaaa519d1db0507291ccbde2 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Thu, 21 May 2020 12:58:04 -0400
-Subject: [PATCH 51/76] most private WebRTC IP handling policy by default
+Subject: [PATCH 51/77] most private WebRTC IP handling policy by default
 
 ---
  chrome/browser/ui/browser_ui_prefs.cc | 2 +-
@@ -21,5 +21,5 @@ index 7bbd3ba5f9057..6972b26fb0634 100644
    registry->RegisterBooleanPref(prefs::kWebRtcEventLogCollectionAllowed, false);
    registry->RegisterListPref(prefs::kWebRtcLocalIpsAllowedUrls);
 -- 
-2.33.0
+2.31.1
 

--- a/patches/0052-disable-search-engine-permissions-by-default.patch
+++ b/patches/0052-disable-search-engine-permissions-by-default.patch
@@ -1,7 +1,7 @@
-From d4ccd3ac010be5d5a0d7b7e333837031cff1fbf6 Mon Sep 17 00:00:00 2001
+From 2d3165f6b37b9a99614050804b908d5eab74fc09 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Mon, 16 Aug 2021 18:59:43 -0400
-Subject: [PATCH 52/76] disable search engine permissions by default
+Subject: [PATCH 52/77] disable search engine permissions by default
 
 Disable the geolocation and notification permissions for the default
 search engine by default.
@@ -23,5 +23,5 @@ index 390de2f97e2df..47555f270a898 100644
  
  }  // namespace features
 -- 
-2.33.0
+2.31.1
 

--- a/patches/0053-stub-out-the-battery-status-API.patch
+++ b/patches/0053-stub-out-the-battery-status-API.patch
@@ -1,7 +1,7 @@
-From 81159d8d5621299ac00fa44c460982616929122c Mon Sep 17 00:00:00 2001
+From dfed30f8c65b503c42681389f28a9f8029ba2644 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Mon, 17 Jun 2019 11:29:21 -0400
-Subject: [PATCH 53/76] stub out the battery status API
+Subject: [PATCH 53/77] stub out the battery status API
 
 Pretend that the device is always plugged in and fully charged.
 ---
@@ -64,5 +64,5 @@ index ff9a33d51dc88..7879bdb4e0c1e 100644
  
  void BatteryManager::RegisterWithDispatcher() {
 -- 
-2.33.0
+2.31.1
 

--- a/patches/0054-always-use-local-new-tab-page.patch
+++ b/patches/0054-always-use-local-new-tab-page.patch
@@ -1,7 +1,7 @@
-From 0078e0a21db017fe55f7156094265650f70a86de Mon Sep 17 00:00:00 2001
+From 9d0b718f43c7da47073df21e2fe35526e466228a Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Mon, 17 Jun 2019 13:14:22 -0400
-Subject: [PATCH 54/76] always use local new tab page
+Subject: [PATCH 54/77] always use local new tab page
 
 ---
  chrome/browser/search/search.cc | 2 +-
@@ -21,5 +21,5 @@ index d9f60142da3aa..d7ae98daa140a 100644
  }
  
 -- 
-2.33.0
+2.31.1
 

--- a/patches/0055-disable-search-provider-logo.patch
+++ b/patches/0055-disable-search-provider-logo.patch
@@ -1,7 +1,7 @@
-From f7a0be327521f02c081396df11167cd90dcb5a75 Mon Sep 17 00:00:00 2001
+From 8c6ed7ceaa336fee15ad01fa56bef670ff9c1376 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Mon, 17 Jun 2019 12:03:52 -0400
-Subject: [PATCH 55/76] disable search provider logo
+Subject: [PATCH 55/77] disable search provider logo
 
 ---
  .../template_url_service_factory_android.cc   | 31 +------------------
@@ -50,5 +50,5 @@ index 67302ccc56dd1..bc5c2516368d0 100644
 +  return false;
  }
 -- 
-2.33.0
+2.31.1
 

--- a/patches/0056-stop-ignoring-download-location-prompt-setting.patch
+++ b/patches/0056-stop-ignoring-download-location-prompt-setting.patch
@@ -1,7 +1,7 @@
-From c7634256ce4bdff8319d6d180e2be3bf4320180b Mon Sep 17 00:00:00 2001
+From fea1977291e2c9d056b798ce8d0ade92cda4e992 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Fri, 28 Jun 2019 16:56:37 -0400
-Subject: [PATCH 56/76] stop ignoring download location prompt setting
+Subject: [PATCH 56/77] stop ignoring download location prompt setting
 
 ---
  .../dialogs/DownloadLocationDialogCoordinator.java | 14 --------------
@@ -33,5 +33,5 @@ index 77439697e091c..a3549b222ce29 100644
          if (mDialogModel != null) return;
  
 -- 
-2.33.0
+2.31.1
 

--- a/patches/0057-show-download-prompt-again-by-default.patch
+++ b/patches/0057-show-download-prompt-again-by-default.patch
@@ -1,7 +1,7 @@
-From bf5b81b518f7f94569bc2d2af84ad28c311a54de Mon Sep 17 00:00:00 2001
+From e8704cc7d1205176142fba37d2cbdc86afd76afb Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Fri, 28 Jun 2019 17:48:49 -0400
-Subject: [PATCH 57/76] show download prompt again by default
+Subject: [PATCH 57/77] show download prompt again by default
 
 ---
  .../download/dialogs/DownloadLocationDialogCoordinator.java  | 5 +----
@@ -26,5 +26,5 @@ index a3549b222ce29..9228de9030e1a 100644
                  DownloadLocationDialogProperties.FILE_NAME, new File(mSuggestedPath).getName());
          builder.with(DownloadLocationDialogProperties.SHOW_SUBTITLE, true);
 -- 
-2.33.0
+2.31.1
 

--- a/patches/0058-remove-data-reduction-preference.patch
+++ b/patches/0058-remove-data-reduction-preference.patch
@@ -1,7 +1,7 @@
-From ec4d468da3b57439608ecd388dc760a7ce1e2f6e Mon Sep 17 00:00:00 2001
+From 08f8f2e56d16d04236e1634e70cb54aaee501f21 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Fri, 2 Aug 2019 22:06:31 -0400
-Subject: [PATCH 58/76] remove data reduction preference
+Subject: [PATCH 58/77] remove data reduction preference
 
 ---
  .../org/chromium/chrome/browser/settings/MainSettings.java    | 4 +---
@@ -23,5 +23,5 @@ index 9bdf24bf274c8..989a1e8c5aef7 100644
  
      private Preference addPreferenceIfAbsent(String key) {
 -- 
-2.33.0
+2.31.1
 

--- a/patches/0059-remove-translate-offer-preference.patch
+++ b/patches/0059-remove-translate-offer-preference.patch
@@ -1,7 +1,7 @@
-From a0026645512fa1576758cbf4b189afe441cf90cc Mon Sep 17 00:00:00 2001
+From 7bc96463b937df32c61c719f8dd71448532e37f1 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Fri, 2 Aug 2019 21:11:17 -0400
-Subject: [PATCH 59/76] remove translate offer preference
+Subject: [PATCH 59/77] remove translate offer preference
 
 ---
  .../language/settings/LanguageSettings.java   | 21 +------------------
@@ -40,5 +40,5 @@ index 34581f9c147c6..ed8ea340d5749 100644
  
      /**
 -- 
-2.33.0
+2.31.1
 

--- a/patches/0060-set-default-search-engine-to-DuckDuckGo.patch
+++ b/patches/0060-set-default-search-engine-to-DuckDuckGo.patch
@@ -1,7 +1,7 @@
-From 026bded9a3fc7dd21909ee569164cd87a5b30489 Mon Sep 17 00:00:00 2001
+From 746a91dc77ea5a563995e1152de977aa83c801f1 Mon Sep 17 00:00:00 2001
 From: Zoraver Kang <zkang@wpi.edu>
 Date: Sat, 17 Aug 2019 15:53:50 -0400
-Subject: [PATCH 60/76] set default search engine to DuckDuckGo
+Subject: [PATCH 60/77] set default search engine to DuckDuckGo
 
 ---
  components/search_engines/template_url_prepopulate_data.cc | 2 +-
@@ -21,5 +21,5 @@ index f7495f041b71c..bcb964e8d5a2c 100644
          itr == t_urls.end() ? 0 : std::distance(t_urls.begin(), itr);
    }
 -- 
-2.33.0
+2.31.1
 

--- a/patches/0061-disable-trivial-subdomain-hiding.patch
+++ b/patches/0061-disable-trivial-subdomain-hiding.patch
@@ -1,7 +1,7 @@
-From 4600246ccdcbcc5c2aff4483a78866f4ac91ca65 Mon Sep 17 00:00:00 2001
+From 6df58a070dc53539b452330e8ef11c08cf95ad60 Mon Sep 17 00:00:00 2001
 From: JTL <jtl@teamclassified.ca>
 Date: Sat, 21 Dec 2019 04:04:24 +0000
-Subject: [PATCH 61/76] disable trivial subdomain hiding
+Subject: [PATCH 61/77] disable trivial subdomain hiding
 
 ---
  components/url_formatter/url_formatter.cc | 3 +--
@@ -22,5 +22,5 @@ index 7c28e01afc5d7..753c3a5282545 100644
                             HostComponentTransform(trim_trivial_subdomains),
                             &url_string, &new_parsed->host, adjustments);
 -- 
-2.33.0
+2.31.1
 

--- a/patches/0062-disable-learn-more-link-in-incognito-new-tab.patch
+++ b/patches/0062-disable-learn-more-link-in-incognito-new-tab.patch
@@ -1,7 +1,7 @@
-From ca441acdd949b14af1f7b34ecd79bc29ff76a4c1 Mon Sep 17 00:00:00 2001
+From c796a8885885f5cbbb9c6be91816a5ae0766acbc Mon Sep 17 00:00:00 2001
 From: A Mak <refragable@mailbox.org>
 Date: Sat, 8 Aug 2020 11:17:59 -0700
-Subject: [PATCH 62/76] disable learn more link in incognito new tab
+Subject: [PATCH 62/77] disable learn more link in incognito new tab
 
 ---
  .../chrome/browser/ntp/LegacyIncognitoDescriptionView.java  | 6 +++---
@@ -50,5 +50,5 @@ index dfbfa2efc4d1f..0dcf38dcb58c3 100644
          if (!learnMoreInSubtitle) {
              // Revert to the original text.
 -- 
-2.33.0
+2.31.1
 

--- a/patches/0063-disable-Omaha-update-check-support.patch
+++ b/patches/0063-disable-Omaha-update-check-support.patch
@@ -1,7 +1,7 @@
-From 249392e79690d67f048b5d37daf76d0d916d9dc5 Mon Sep 17 00:00:00 2001
+From 3b0bd40ddbfee4d90d35e065afa019e49a6afb1c Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Wed, 18 Nov 2020 19:13:27 -0500
-Subject: [PATCH 63/76] disable Omaha update check support
+Subject: [PATCH 63/77] disable Omaha update check support
 
 ---
  .../java/src/org/chromium/chrome/browser/omaha/OmahaBase.java   | 2 +-
@@ -35,5 +35,5 @@ index 2b342b05a0c44..26543522257f4 100644
      protected VersionNumberGetter() { }
  
 -- 
-2.33.0
+2.31.1
 

--- a/patches/0064-disable-GaiaAuthFetcher-code-due-to-upstream-bug.patch
+++ b/patches/0064-disable-GaiaAuthFetcher-code-due-to-upstream-bug.patch
@@ -1,7 +1,7 @@
-From 5918d2841a6332657455c7649ff8007dd3406352 Mon Sep 17 00:00:00 2001
+From 157b9e30fb10853f14c3700f2c1969459f46e54d Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Thu, 19 Nov 2020 07:59:29 -0500
-Subject: [PATCH 64/76] disable GaiaAuthFetcher code due to upstream bug
+Subject: [PATCH 64/77] disable GaiaAuthFetcher code due to upstream bug
 
 https://bugs.chromium.org/p/chromium/issues/detail?id=1150817
 ---
@@ -39,5 +39,5 @@ index b3d30604885b3..d2cc36b1ce392 100644
  
  // static
 -- 
-2.33.0
+2.31.1
 

--- a/patches/0065-remove-safety-check-menu.patch
+++ b/patches/0065-remove-safety-check-menu.patch
@@ -1,7 +1,7 @@
-From 63f762aa5a603a482ed5b7bccc72e576792d66af Mon Sep 17 00:00:00 2001
+From b02a6b92159fb889063fd21732239b92be234e33 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Tue, 25 May 2021 16:43:39 -0400
-Subject: [PATCH 65/76] remove safety check menu
+Subject: [PATCH 65/77] remove safety check menu
 
 ---
  .../src/org/chromium/chrome/browser/settings/MainSettings.java  | 2 ++
@@ -21,5 +21,5 @@ index 989a1e8c5aef7..8382638ca1abb 100644
              // We don't show the toolbar shortcut settings page if disabled from finch.
              // Note, we can still have the old data collection experiment running for which
 -- 
-2.33.0
+2.31.1
 

--- a/patches/0066-disable-unused-password-check-feature.patch
+++ b/patches/0066-disable-unused-password-check-feature.patch
@@ -1,7 +1,7 @@
-From d353a5173cb8c9d255dd3bbf55c77cdea47cf793 Mon Sep 17 00:00:00 2001
+From 680f9508c260d09b0c173a6172143d18fa520fb0 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Thu, 15 Apr 2021 11:33:17 -0400
-Subject: [PATCH 66/76] disable unused password check feature
+Subject: [PATCH 66/77] disable unused password check feature
 
 ---
  .../chrome/browser/password_check/PasswordCheckFactory.java  | 5 +----
@@ -24,5 +24,5 @@ index 8ecc1304ff4db..8549bc553a366 100644
  
      /**
 -- 
-2.33.0
+2.31.1
 

--- a/patches/0067-add-back-trichrome_chrome_apk-targets.patch
+++ b/patches/0067-add-back-trichrome_chrome_apk-targets.patch
@@ -1,7 +1,7 @@
-From f0a9036f086b496fef65b0192f3a78505e15cc3c Mon Sep 17 00:00:00 2001
+From 77c6b22177ea2b83c04bf77a6a180c4c312ae7a3 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Thu, 27 May 2021 07:30:02 -0400
-Subject: [PATCH 67/76] add back trichrome_chrome_apk targets
+Subject: [PATCH 67/77] add back trichrome_chrome_apk targets
 
 ---
  chrome/android/BUILD.gn | 46 ++++++++++++++++++++++++++++++++++++++++-
@@ -79,5 +79,5 @@ index a7f0f8079601b..f99c2b217e25f 100644
      "$root_gen_dir/chrome_public_test_apk_manifest/AndroidManifest.xml"
  chrome_public_test_vr_apk_manifest =
 -- 
-2.33.0
+2.31.1
 

--- a/patches/0068-disable-mobile-identity-consistency-by-default.patch
+++ b/patches/0068-disable-mobile-identity-consistency-by-default.patch
@@ -1,7 +1,7 @@
-From 5c1f7ae2405ea1b07be8b6b32359801d284f1abd Mon Sep 17 00:00:00 2001
+From 9078f5feeebbcd419ac9094f568372c9e6545255 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Fri, 28 May 2021 09:08:01 -0400
-Subject: [PATCH 68/76] disable mobile identity consistency by default
+Subject: [PATCH 68/77] disable mobile identity consistency by default
 
 ---
  components/signin/public/base/account_consistency_method.cc | 2 +-
@@ -21,5 +21,5 @@ index 05a44eba653d4..b5e69777fb212 100644
  const base::Feature kMobileIdentityConsistencyFRE{
      "MobileIdentityConsistencyFRE", base::FEATURE_DISABLED_BY_DEFAULT};
 -- 
-2.33.0
+2.31.1
 

--- a/patches/0069-JIT-less-toggle.patch
+++ b/patches/0069-JIT-less-toggle.patch
@@ -1,7 +1,7 @@
-From 81b4c835652e1b15a2f81c45486ad7f011d53ae8 Mon Sep 17 00:00:00 2001
+From fa68634d5a88c05ba6a011e8b67e03c65c0cf149 Mon Sep 17 00:00:00 2001
 From: hardenedfuchsiaoswhen <hardenedfuchsiaoswhen@protonmail.com>
 Date: Fri, 18 Jun 2021 03:34:20 +0000
-Subject: [PATCH 69/76] JIT-less toggle
+Subject: [PATCH 69/77] JIT-less toggle
 
 ---
  .../android/java/res/xml/privacy_preferences.xml   |  5 +++++
@@ -134,5 +134,5 @@ index 0c2ef1d8413ac..3b20f70657ffe 100644
 +    }
  }
 -- 
-2.33.0
+2.31.1
 

--- a/patches/0070-update-trichrome_library_apk-expectation-file.patch
+++ b/patches/0070-update-trichrome_library_apk-expectation-file.patch
@@ -1,7 +1,7 @@
-From 90fd11c08a63843c11041c26f4f8d958cd1fc3a1 Mon Sep 17 00:00:00 2001
+From 85db7e66cb59d69fbe73287c0d1fc00cf3530905 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Sat, 26 Jun 2021 22:55:16 -0400
-Subject: [PATCH 70/76] update trichrome_library_apk expectation file
+Subject: [PATCH 70/77] update trichrome_library_apk expectation file
 
 ---
  .../expectations/trichrome_library_apk.AndroidManifest.expected | 2 +-
@@ -21,5 +21,5 @@ index fd2f714f62b20..2964bc65fb7d4 100644
      platformBuildVersionName="12">
    <uses-feature android:glEsVersion="0x00020000"/>
 -- 
-2.33.0
+2.31.1
 

--- a/patches/0071-disable-trials-of-privacy-aware-analytics-advertisin.patch
+++ b/patches/0071-disable-trials-of-privacy-aware-analytics-advertisin.patch
@@ -1,7 +1,7 @@
-From 4322d351283fd8a43fa45afa78d5be139f0e9844 Mon Sep 17 00:00:00 2001
+From 0ada330a46352bb521310ff58de6f4c97c83c7ec Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Wed, 4 Aug 2021 03:29:04 -0400
-Subject: [PATCH 71/76] disable trials of privacy-aware analytics/advertising
+Subject: [PATCH 71/77] disable trials of privacy-aware analytics/advertising
  APIs
 
 ---
@@ -45,5 +45,5 @@ index f6094c3d70091..6df947ac2311a 100644
  }
  
 -- 
-2.33.0
+2.31.1
 

--- a/patches/0072-remove-unwanted-sync-and-services-link.patch
+++ b/patches/0072-remove-unwanted-sync-and-services-link.patch
@@ -1,7 +1,7 @@
-From 0becdb62a6cdcd322cc0c2ae2a813c5f465f251a Mon Sep 17 00:00:00 2001
+From cf07ce54224965ddb6a7b4079a1ad97fc9db60fe Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Sat, 7 Aug 2021 15:01:54 -0400
-Subject: [PATCH 72/76] remove unwanted sync and services link
+Subject: [PATCH 72/77] remove unwanted sync and services link
 
 ---
  .../chrome/browser/privacy/settings/PrivacySettings.java       | 3 +--
@@ -22,5 +22,5 @@ index 3e77e75739628..e0e06dbf90c91 100644
          updateSummaries();
      }
 -- 
-2.33.0
+2.31.1
 

--- a/patches/0073-Move-search-suggestions-back-to-privacy-section.patch
+++ b/patches/0073-Move-search-suggestions-back-to-privacy-section.patch
@@ -1,7 +1,7 @@
-From 2f3865c1200e4cf416e02159885762d7a1ce7bfd Mon Sep 17 00:00:00 2001
+From 6ae034c41a1842e7fa8db1b51d84509741e0b7a6 Mon Sep 17 00:00:00 2001
 From: fgei <fgei@gmail.com>
 Date: Fri, 20 Aug 2021 16:13:42 +0000
-Subject: [PATCH 73/76] Move search suggestions back to privacy section.
+Subject: [PATCH 73/77] Move search suggestions back to privacy section.
 
 ---
  .../java/res/xml/privacy_preferences.xml        |  5 +++++
@@ -74,5 +74,5 @@ index e0e06dbf90c91..9f4af0bfbd6c0 100644
                  (ChromeSwitchPreference) findPreference(PREF_CAN_MAKE_PAYMENT);
          if (canMakePaymentPref != null) {
 -- 
-2.33.0
+2.31.1
 

--- a/patches/0074-remove-unwanted-account-and-services-section.patch
+++ b/patches/0074-remove-unwanted-account-and-services-section.patch
@@ -1,7 +1,7 @@
-From df8b5a4cfef81858168e2deb9ea461ab466a7849 Mon Sep 17 00:00:00 2001
+From 3f35782ab9270a8ea335c42ff66eea48279eacc9 Mon Sep 17 00:00:00 2001
 From: fgei <fgei@gmail.com>
 Date: Fri, 20 Aug 2021 16:13:42 +0000
-Subject: [PATCH 74/76] remove unwanted account and services section
+Subject: [PATCH 74/77] remove unwanted account and services section
 
 ---
  .../src/org/chromium/chrome/browser/settings/MainSettings.java  | 2 ++
@@ -21,5 +21,5 @@ index 8382638ca1abb..2e3fd251fa0e4 100644
          new AdaptiveToolbarStatePredictor(null).recomputeUiState(uiState -> {
              // We don't show the toolbar shortcut settings page if disabled from finch.
 -- 
-2.33.0
+2.31.1
 

--- a/patches/0075-Hide-Sign-In-preference-when-disallowed.patch
+++ b/patches/0075-Hide-Sign-In-preference-when-disallowed.patch
@@ -1,7 +1,7 @@
-From 12993331deca9b57c274edaff8f7e2be532c9737 Mon Sep 17 00:00:00 2001
+From 1c64b080e6166457c06fd74def224585b2420430 Mon Sep 17 00:00:00 2001
 From: fgei <fgei@gmail.com>
 Date: Sun, 29 Aug 2021 19:31:00 +0000
-Subject: [PATCH 75/76] Hide Sign In preference when disallowed
+Subject: [PATCH 75/77] Hide Sign In preference when disallowed
 
 ---
  .../chromium/chrome/browser/sync/settings/SignInPreference.java  | 1 +
@@ -20,5 +20,5 @@ index f663e0217baf2..9be8eac293981 100644
      }
  
 -- 
-2.33.0
+2.31.1
 

--- a/patches/0076-disable-using-Play-services-fonts.patch
+++ b/patches/0076-disable-using-Play-services-fonts.patch
@@ -1,7 +1,7 @@
-From 73d79e87dbcc29a6c7328c2bf501c7454246e1cb Mon Sep 17 00:00:00 2001
+From 6feb11df2a1ebd568c355246bae105f91987125a Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Wed, 1 Sep 2021 02:09:14 -0400
-Subject: [PATCH 76/76] disable using Play services fonts
+Subject: [PATCH 76/77] disable using Play services fonts
 
 ---
  .../chromium/content/browser/font/AndroidFontLookupImpl.java    | 2 +-
@@ -21,5 +21,5 @@ index 405dca87b9a6e..7b7751512eccd 100644
                  // Avoid re-requesting this font in future.
                  mExpectedFonts.remove(fontUniqueName);
 -- 
-2.33.0
+2.31.1
 

--- a/patches/0077-Restore-Search-Ready-Omnibox-flag.patch
+++ b/patches/0077-Restore-Search-Ready-Omnibox-flag.patch
@@ -1,0 +1,164 @@
+From f0a1d308e47fcc825c315ac2c6953d1c52860818 Mon Sep 17 00:00:00 2001
+From: csagan5 <32685696+csagan5@users.noreply.github.com>
+Date: Thu, 10 Oct 2019 23:30:16 +0200
+Subject: [PATCH 77/77] Restore Search Ready Omnibox flag
+
+Revert "Cleanup Search Ready Omnibox flag since it has launched"
+This reverts commit ae458edcc8422d0815d0e82261e71fe10d7d6fc2.
+
+Disable search-ready omnibox by default
+---
+ chrome/browser/about_flags.cc                          |  3 +++
+ chrome/browser/flag-metadata.json                      |  5 +++++
+ chrome/browser/flag_descriptions.cc                    |  5 +++++
+ chrome/browser/flag_descriptions.h                     |  3 +++
+ chrome/browser/flags/android/chrome_feature_list.cc    |  4 ++++
+ chrome/browser/flags/android/chrome_feature_list.h     |  1 +
+ .../chrome/browser/flags/ChromeFeatureList.java        |  1 +
+ .../suggestions/DropdownItemViewInfoListBuilder.java   | 10 ++++++++--
+ 8 files changed, 30 insertions(+), 2 deletions(-)
+
+diff --git a/chrome/browser/about_flags.cc b/chrome/browser/about_flags.cc
+index e2439adb1b0fe..e73cc2e38e32b 100644
+--- a/chrome/browser/about_flags.cc
++++ b/chrome/browser/about_flags.cc
+@@ -3204,6 +3204,9 @@ const FeatureEntry kFeatureEntries[] = {
+      flag_descriptions::kUseLookalikesForNavigationSuggestionsDescription,
+      kOsAll,
+      FEATURE_VALUE_TYPE(net::features::kUseLookalikesForNavigationSuggestions)},
++    {"enable-search-ready-omnibox", flag_descriptions::kSearchReadyOmniboxName,
++     flag_descriptions::kSearchReadyOmniboxDescription, kOsAndroid,
++     FEATURE_VALUE_TYPE(chrome::android::kSearchReadyOmniboxFeature)},
+     {"username-first-flow", flag_descriptions::kUsernameFirstFlowName,
+      flag_descriptions::kUsernameFirstFlowDescription, kOsAll,
+      FEATURE_VALUE_TYPE(password_manager::features::kUsernameFirstFlow)},
+diff --git a/chrome/browser/flag-metadata.json b/chrome/browser/flag-metadata.json
+index a670bf1f6a828..49f2be1997d54 100644
+--- a/chrome/browser/flag-metadata.json
++++ b/chrome/browser/flag-metadata.json
+@@ -2291,6 +2291,11 @@
+     //  with neural net palm detection.
+     "expiry_milestone": 90
+   },
++  {
++    "name": "enable-search-ready-omnibox",
++    "owners": [ "mdjones" ],
++    "expiry_milestone": -1
++  },
+   {
+     "name": "enable-parallel-downloading",
+     "owners": [ "qinmin", "xingliu", "dtrainor" ],
+diff --git a/chrome/browser/flag_descriptions.cc b/chrome/browser/flag_descriptions.cc
+index d41f7a9563b5a..55c6585f7093f 100644
+--- a/chrome/browser/flag_descriptions.cc
++++ b/chrome/browser/flag_descriptions.cc
+@@ -3391,6 +3391,11 @@ const char kScrollCaptureName[] = "Scroll Capture";
+ const char kScrollCaptureDescription[] =
+     "Enables scrolling screenshot capture for web contents.";
+ 
++const char kSearchReadyOmniboxName[] = "Search Ready Omnibox";
++const char kSearchReadyOmniboxDescription[] =
++    "Clears the omnibox and adds a suggestion item to share, copy, or edit the "
++    "URL.";
++
+ const char kSetMarketUrlForTestingName[] = "Set market URL for testing";
+ const char kSetMarketUrlForTestingDescription[] =
+     "When enabled, sets the market URL for use in testing the update menu "
+diff --git a/chrome/browser/flag_descriptions.h b/chrome/browser/flag_descriptions.h
+index 1078cced42c52..bba5286f42cba 100644
+--- a/chrome/browser/flag_descriptions.h
++++ b/chrome/browser/flag_descriptions.h
+@@ -1938,6 +1938,9 @@ extern const char kSafeBrowsingUseLocalBlacklistsV2Description[];
+ extern const char kScrollCaptureName[];
+ extern const char kScrollCaptureDescription[];
+ 
++extern const char kSearchReadyOmniboxName[];
++extern const char kSearchReadyOmniboxDescription[];
++
+ extern const char kSetMarketUrlForTestingName[];
+ extern const char kSetMarketUrlForTestingDescription[];
+ 
+diff --git a/chrome/browser/flags/android/chrome_feature_list.cc b/chrome/browser/flags/android/chrome_feature_list.cc
+index 19cf18901df22..a40af00c7e5bd 100644
+--- a/chrome/browser/flags/android/chrome_feature_list.cc
++++ b/chrome/browser/flags/android/chrome_feature_list.cc
+@@ -240,6 +240,7 @@ const base::Feature* const kFeaturesExposedToJava[] = {
+     &kReachedCodeProfiler,
+     &kReaderModeInCCT,
+     &kReengagementNotification,
++    &kSearchReadyOmniboxFeature,
+     &kRelatedSearches,
+     &kRelatedSearchesAlternateUx,
+     &kRelatedSearchesInBar,
+@@ -679,6 +680,9 @@ const base::Feature kRelatedSearchesSimplifiedUx{
+ const base::Feature kRelatedSearchesUi{"RelatedSearchesUi",
+                                        base::FEATURE_DISABLED_BY_DEFAULT};
+ 
++const base::Feature kSearchReadyOmniboxFeature{
++    "SearchReadyOmnibox", base::FEATURE_DISABLED_BY_DEFAULT};
++
+ const base::Feature kServiceManagerForBackgroundPrefetch{
+     "ServiceManagerForBackgroundPrefetch", base::FEATURE_ENABLED_BY_DEFAULT};
+ 
+diff --git a/chrome/browser/flags/android/chrome_feature_list.h b/chrome/browser/flags/android/chrome_feature_list.h
+index 44dc79dd72822..f3576da19f8e0 100644
+--- a/chrome/browser/flags/android/chrome_feature_list.h
++++ b/chrome/browser/flags/android/chrome_feature_list.h
+@@ -120,6 +120,7 @@ extern const base::Feature kRelatedSearchesSimplifiedUx;
+ extern const base::Feature kRelatedSearchesUi;
+ extern const base::Feature kSearchEnginePromoExistingDevice;
+ extern const base::Feature kSearchEnginePromoNewDevice;
++extern const base::Feature kSearchReadyOmniboxFeature;
+ extern const base::Feature kServiceManagerForBackgroundPrefetch;
+ extern const base::Feature kServiceManagerForDownload;
+ extern const base::Feature kShareButtonInTopToolbar;
+diff --git a/chrome/browser/flags/android/java/src/org/chromium/chrome/browser/flags/ChromeFeatureList.java b/chrome/browser/flags/android/java/src/org/chromium/chrome/browser/flags/ChromeFeatureList.java
+index 88c228fdba065..06e07f0e2e56a 100644
+--- a/chrome/browser/flags/android/java/src/org/chromium/chrome/browser/flags/ChromeFeatureList.java
++++ b/chrome/browser/flags/android/java/src/org/chromium/chrome/browser/flags/ChromeFeatureList.java
+@@ -421,6 +421,7 @@ public abstract class ChromeFeatureList {
+     public static final String OMNIBOX_ADAPTIVE_SUGGESTIONS_COUNT =
+             "OmniboxAdaptiveSuggestionsCount";
+     public static final String OMNIBOX_ASSISTANT_VOICE_SEARCH = "OmniboxAssistantVoiceSearch";
++    public static final String SEARCH_READY_OMNIBOX = "SearchReadyOmnibox";
+     public static final String OMNIBOX_COMPACT_SUGGESTIONS = "OmniboxCompactSuggestions";
+     public static final String OMNIBOX_ENABLE_CLIPBOARD_PROVIDER_IMAGE_SUGGESTIONS =
+             "OmniboxEnableClipboardProviderImageSuggestions";
+diff --git a/chrome/browser/ui/android/omnibox/java/src/org/chromium/chrome/browser/omnibox/suggestions/DropdownItemViewInfoListBuilder.java b/chrome/browser/ui/android/omnibox/java/src/org/chromium/chrome/browser/omnibox/suggestions/DropdownItemViewInfoListBuilder.java
+index 8be324544eba6..a80fe939b1910 100644
+--- a/chrome/browser/ui/android/omnibox/java/src/org/chromium/chrome/browser/omnibox/suggestions/DropdownItemViewInfoListBuilder.java
++++ b/chrome/browser/ui/android/omnibox/java/src/org/chromium/chrome/browser/omnibox/suggestions/DropdownItemViewInfoListBuilder.java
+@@ -65,6 +65,7 @@ class DropdownItemViewInfoListBuilder {
+     private int mDropdownHeight;
+     private boolean mEnableAdaptiveSuggestionsCount;
+     private boolean mBuiltListHasFullyConcealedElements;
++    private EditUrlSuggestionProcessor mEditUrlSuggestionProcessor;
+ 
+     DropdownItemViewInfoListBuilder(@NonNull Supplier<Tab> tabSupplier, BookmarkState bookmarkState,
+             @NonNull ExploreIconProvider exploreIconProvider) {
+@@ -95,8 +96,9 @@ class DropdownItemViewInfoListBuilder {
+                 () -> mShareDelegateSupplier == null ? null : mShareDelegateSupplier.get();
+ 
+         mHeaderProcessor = new HeaderProcessor(context, host, delegate);
+-        registerSuggestionProcessor(new EditUrlSuggestionProcessor(
+-                context, host, delegate, iconBridgeSupplier, mActivityTabSupplier, shareSupplier));
++        mEditUrlSuggestionProcessor = new EditUrlSuggestionProcessor(
++                context, host, delegate, iconBridgeSupplier, mActivityTabSupplier, shareSupplier);
++        registerSuggestionProcessor(mEditUrlSuggestionProcessor);
+         registerSuggestionProcessor(
+                 new AnswerSuggestionProcessor(context, host, textProvider, imageFetcherSupplier));
+         registerSuggestionProcessor(
+@@ -218,6 +220,10 @@ class DropdownItemViewInfoListBuilder {
+ 
+     /** Signals that native initialization has completed. */
+     void onNativeInitialized() {
++        if (ChromeFeatureList.isEnabled(ChromeFeatureList.SEARCH_READY_OMNIBOX) == false) {
++            mPriorityOrderedSuggestionProcessors.remove(mEditUrlSuggestionProcessor);
++        }
++
+         mEnableAdaptiveSuggestionsCount =
+                 ChromeFeatureList.isEnabled(ChromeFeatureList.OMNIBOX_ADAPTIVE_SUGGESTIONS_COUNT);
+ 
+-- 
+2.31.1
+


### PR DESCRIPTION
Addresses #121. I have tested this and it seems to be working well. Right now, it defaults to disabling the search ready omnibox, but this can be changed easily if needed.