### PR TITLE
Use Google Chrome branding for client hints

### DIFF
--- a/patches/0001-disable-checkout_nacl.patch
+++ b/patches/0001-disable-checkout_nacl.patch
@@ -1,7 +1,7 @@
-From b7b9297d33ad742e56511a449c59e3f171fd02d4 Mon Sep 17 00:00:00 2001
+From 76b65fbe0f5428a028be7aa0bc072091889c9213 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Sat, 21 Nov 2020 01:30:06 -0500
-Subject: [PATCH 01/78] disable checkout_nacl
+Subject: [PATCH 01/79] disable checkout_nacl
 
 ---
  DEPS | 2 +-
@@ -21,5 +21,5 @@ index b42bc22cda6db..1b787bd46e43b 100644
    # By default, do not check out src-internal. This can be overridden e.g. with
    # custom_vars.
 -- 
-2.34.1
+2.31.1
 

--- a/patches/0002-use-64-bit-WebView-processes.patch
+++ b/patches/0002-use-64-bit-WebView-processes.patch
@@ -1,7 +1,7 @@
-From dfde924ab5a07033ca787b5a078cf5d9d6bc0777 Mon Sep 17 00:00:00 2001
+From 820a4b9cee47f886bec7bf5ce6da1d99289f6ebf Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Thu, 26 Jan 2017 01:30:12 -0500
-Subject: [PATCH 02/78] use 64-bit WebView processes
+Subject: [PATCH 02/79] use 64-bit WebView processes
 
 ---
  android_webview/nonembedded/java/AndroidManifest.xml | 1 -
@@ -20,5 +20,5 @@ index ce91769d5ce28..419141d4bd936 100644
          {# This part is shared between stand-alone WebView and Monochrome #}
          {% macro common(manifest_package, webview_lib) %}
 -- 
-2.34.1
+2.31.1
 

--- a/patches/0003-switch-to-fstack-protector-strong.patch
+++ b/patches/0003-switch-to-fstack-protector-strong.patch
@@ -1,7 +1,7 @@
-From 7c57b00d2560c36ede24fca4d657696a998918b9 Mon Sep 17 00:00:00 2001
+From 8dd73021599b303cb21081ff8950a59b447a624f Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Wed, 26 Dec 2018 10:20:24 -0500
-Subject: [PATCH 03/78] switch to -fstack-protector-strong
+Subject: [PATCH 03/79] switch to -fstack-protector-strong
 
 ---
  build/config/compiler/BUILD.gn | 6 +-----
@@ -30,5 +30,5 @@ index f4421666b3d10..93f71eed6e7f2 100644
      }
  
 -- 
-2.34.1
+2.31.1
 

--- a/patches/0004-enable-fwrapv-in-Clang-for-non-UBSan-builds.patch
+++ b/patches/0004-enable-fwrapv-in-Clang-for-non-UBSan-builds.patch
@@ -1,7 +1,7 @@
-From 050d05134368bc2bc6affa49095b409db6fb96b4 Mon Sep 17 00:00:00 2001
+From 017f5240f141d86573233c7dfd8c2508281e9314 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Thu, 22 Dec 2016 07:15:34 -0500
-Subject: [PATCH 04/78] enable -fwrapv in Clang for non-UBSan builds
+Subject: [PATCH 04/79] enable -fwrapv in Clang for non-UBSan builds
 
 ---
  build/config/compiler/BUILD.gn | 4 ++++
@@ -23,5 +23,5 @@ index 93f71eed6e7f2..076adf274b560 100644
      if (fatal_linker_warnings && !is_apple && current_os != "aix") {
        ldflags += [ "-Wl,--fatal-warnings" ]
 -- 
-2.34.1
+2.31.1
 

--- a/patches/0005-enable-ftrivial-auto-var-init-zero.patch
+++ b/patches/0005-enable-ftrivial-auto-var-init-zero.patch
@@ -1,7 +1,7 @@
-From 564448de8d47572a686f4f295d5042cbd5adc4dd Mon Sep 17 00:00:00 2001
+From 18d63e1fd801c978d295f1b0302e64077a21ac89 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Wed, 8 Apr 2020 20:48:17 -0400
-Subject: [PATCH 05/78] enable -ftrivial-auto-var-init=zero
+Subject: [PATCH 05/79] enable -ftrivial-auto-var-init=zero
 
 ---
  build/config/compiler/BUILD.gn | 4 ++++
@@ -23,5 +23,5 @@ index 076adf274b560..dcfb48fdae137 100644
      if (fatal_linker_warnings && !is_apple && current_os != "aix") {
        ldflags += [ "-Wl,--fatal-warnings" ]
 -- 
-2.34.1
+2.31.1
 

--- a/patches/0006-disable-broken-warning-for-auto-var-init.patch
+++ b/patches/0006-disable-broken-warning-for-auto-var-init.patch
@@ -1,7 +1,7 @@
-From cb51b9be4325485490b28eff3e43ab7205218830 Mon Sep 17 00:00:00 2001
+From 543b910705f844bf799e3d7480b214dbb59b87d0 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Thu, 21 May 2020 14:07:54 -0400
-Subject: [PATCH 06/78] disable broken warning for auto var init
+Subject: [PATCH 06/79] disable broken warning for auto var init
 
 ---
  build/config/compiler/BUILD.gn | 2 +-
@@ -21,5 +21,5 @@ index dcfb48fdae137..ac90336cbe213 100644
  
      # Linker warnings.
 -- 
-2.34.1
+2.31.1
 

--- a/patches/0007-Vanadium-branding.patch
+++ b/patches/0007-Vanadium-branding.patch
@@ -1,7 +1,7 @@
-From 0f34fb442bffb809354b44c8cc604a6b9d1166e2 Mon Sep 17 00:00:00 2001
+From 1a70cce0e062d47381a3a1d43d329c76ddc2a7d4 Mon Sep 17 00:00:00 2001
 From: fgei <fgei@gmail.com>
 Date: Tue, 19 Oct 2021 02:21:18 +0000
-Subject: [PATCH 07/78] Vanadium branding
+Subject: [PATCH 07/79] Vanadium branding
 
 Current incantation of the recolor command:
 
@@ -174,7 +174,7 @@ new file mode 100644
 index 0000000000000000000000000000000000000000..d9d6661c938b2907e30da3ae87cdb2894db5592d
 GIT binary patch
 literal 11327
-zc-jF!EWp!=P)<h;3K|Lk000e1NJLTq006@P006@X1ONa4m3D0*00002VoOIv0RM-N
+zcmV-FEWp!=P)<h;3K|Lk000e1NJLTq006@P006@X1ONa4m3D0*00002VoOIv0RM-N
 z%)bBtEBHx7K~#9!?VWj)99MnsKlfJkKKmk#mXTyhSd#Y*%Ra`5ZCUog#tV)yF&KC+
 z<|GDU90K9Jge8O+2<PDNut@^%ybwqX4mOD~#x|Rm=jGuAZ?Y}P+NBwdW}lwvwYsb7
 zzCWs$s-B*i?&)QO$#0HE)79N|Z~eaax7^?T-QN}0Q9VgAq==9~B1y1@DNLZ1EKwAS
@@ -395,14 +395,14 @@ zJ0a3!Go$*HoHB+u);$m(um^Pmpo6HZ%F^*i{~yS0JYSiOkN*Gw002ovPDHLkV1iRV
 Bx8MK(
 
 literal 0
-Hc-jL100001
+HcmV?d00001
 
 diff --git a/chrome/android/java/res_vanadium/drawable-hdpi/product_logo_name.png b/chrome/android/java/res_vanadium/drawable-hdpi/product_logo_name.png
 new file mode 100644
 index 0000000000000000000000000000000000000000..8678cbbb730de9c3ff9d3dba7d928d60f28bd550
 GIT binary patch
 literal 1998
-zc-jHZ2Qm1GP)<h;3K|Lk000e1NJLTq005f+001Be1ONa4uVuoq00002VoOIv0RM-N
+zcmV;<2Qm1GP)<h;3K|Lk000e1NJLTq005f+001Be1ONa4uVuoq00002VoOIv0RM-N
 z%)bBt2Zu>SK~!ko<=J0sWOWq>@Xx*Tue$}h(?xgL^$(e{1YKD$ttiGof~^Vx9)MOu
 zG$zJ$V+<<#(2`(G2$D7sv-n`r`s9OR+7Oj!jP4K>9x$+jvMdlpCd<G5<L-9a?Y7g-
 zOlN%PbUM?eP`V|f@STVG{k!LP&i9^kf9KpA+yX)cp|aCLam8fei-l{8d&(cGTp%zN
@@ -443,14 +443,14 @@ zza1|{8eS^B9}!%))KF3pS28cMJ#j<i+Hm*uwq56aHaKx+;rQJ1`Nz)uvHbcbt!9+#
 gs)YxeZ9!A;U++Vmx7pctfdBvi07*qoM6N<$g5_ZC5&!@I
 
 literal 0
-Hc-jL100001
+HcmV?d00001
 
 diff --git a/chrome/android/java/res_vanadium/drawable-mdpi/fre_product_logo.png b/chrome/android/java/res_vanadium/drawable-mdpi/fre_product_logo.png
 new file mode 100644
 index 0000000000000000000000000000000000000000..40b88b5225ddff2fb47116a99a38999218e744ec
 GIT binary patch
 literal 6794
-zc-jGq8g=D~P)<h;3K|Lk000e1NJLTq004pj004pr1ONa4APU%a00002VoOIv0RM-N
+zcmV;58g=D~P)<h;3K|Lk000e1NJLTq004pj004pr1ONa4APU%a00002VoOIv0RM-N
 z%)bBt8be7$K~#9!)tz~iB*lH_KM{G<)z|bjJ@>)D%!mO-Fw7-DAPmTokc7~a^mM>3
 zZzcS8pLT_9R@Sb(&)T)*U3n#2eztCw(_%quSrW30g+~aD#AO%`F)++9!yMhycU9M2
 zm6esTe`IDI-BsOnwFSR?U7eMc85!}--xa_3MWpxuOOYgpLdU@%#5jW(oWUeO8V!Yp
@@ -583,14 +583,14 @@ zhj>D$5MmkU-7e!>Q2kdIXfIhW74NXI16-hOVT5&Tll`hE8(I@M7MRpEgsm*{#hgm!
 s;^t9aPfn=Q!52i_!lZI+YPsnD1F3svQs!l<l>h($07*qoM6N<$g1%n2wg3PC
 
 literal 0
-Hc-jL100001
+HcmV?d00001
 
 diff --git a/chrome/android/java/res_vanadium/drawable-mdpi/product_logo_name.png b/chrome/android/java/res_vanadium/drawable-mdpi/product_logo_name.png
 new file mode 100644
 index 0000000000000000000000000000000000000000..5f92063170520afa34dd48fa6610ea122439e916
 GIT binary patch
 literal 1200
-zc-jH51W)^kP)<h;3K|Lk000e1NJLTq003tI000#T1ONa4@uE1m00002VoOIv0RM-N
+zcmV;h1W)^kP)<h;3K|Lk000e1NJLTq003tI000#T1ONa4@uE1m00002VoOIv0RM-N
 z%)bBt1Zhb`K~z}7&DURyTy+%(@Xx(>_FsX@O}84i3U(VMgzx}UVwc9o;1FXpBtoWy
 z2j6rWUf_X*Ex|`ac1+~Kw;kh?hR6=+gBnd1V-!O{cS$sAG|)-^n3k4yW}(~d?#%4H
 zJk0Ig(t_M=8p?UO_x{fBob&yjbAEqr@Ss2<(bv_zXSLeh+uv!6mFS39qGs}1Psy+Z
@@ -616,14 +616,14 @@ z^+sAqN|1`A|9R&d!QRnoG_`We?y>N~$>SGZU49|`b6{BT;s2taFnJGY>5Ee&#m%|^
 O0000<MNUMnLSTZ4d0|-q
 
 literal 0
-Hc-jL100001
+HcmV?d00001
 
 diff --git a/chrome/android/java/res_vanadium/drawable-xhdpi/fre_product_logo.png b/chrome/android/java/res_vanadium/drawable-xhdpi/fre_product_logo.png
 new file mode 100644
 index 0000000000000000000000000000000000000000..07ecccb90a3786c3c3d7ac33a3f8cb2d2ee555b2
 GIT binary patch
 literal 16100
-zc-jHvJ{!S_P)<h;3K|Lk000e1NJLTq009I5009ID1ONa4WC4PK00002VoOIv0RM-N
+zcmV<AJ{!S_P)<h;3K|Lk000e1NJLTq009I5009ID1ONa4WC4PK00002VoOIv0RM-N
 z%)bBtKAlNKK~#9!?Y()N9A|y!|9+mT>T52|jP6^OWZ9N1VOvH9-zHeb#!fgw4%lQv
 z$ijkcSV%%nLjpgJCFC%egaq>2WV4%1AUFXM8<TL^1|O0SNyfU5(Tp@#&(+g+RXzJh
 zbx&7!Rrhqy^fjzM^HOW3y6UOt_&(q3`99xAyqU#AATUW`(?ymf-K5CSOD`ws#wNu|
@@ -935,14 +935,14 @@ zHcQ#BHdrh4<*AJ_B6{r&$*>;S8h$!F714vru|u<1B12pyR4S0QllFOiQcu_e_IP%D
 q!#O!IXc-t}kqB(e_H@WD3jY_Ejr#a36nZuQ0000<MNUMnLSTZIDYe}I
 
 literal 0
-Hc-jL100001
+HcmV?d00001
 
 diff --git a/chrome/android/java/res_vanadium/drawable-xhdpi/product_logo_name.png b/chrome/android/java/res_vanadium/drawable-xhdpi/product_logo_name.png
 new file mode 100644
 index 0000000000000000000000000000000000000000..ee268c83d97f8d6b73eac0dbe25a204dcc91d4da
 GIT binary patch
 literal 2609
-zc-jFm3eNS3P)<h;3K|Lk000e1NJLTq007Pa001fo1ONa4QNyg;00002VoOIv0RM-N
+zcmV-13eNS3P)<h;3K|Lk000e1NJLTq007Pa001fo1ONa4QNyg;00002VoOIv0RM-N
 z%)bBt3F=8iK~#9!?VEp$9Az2DKl9G)>|MKe?OY3KEzmHhZ7oJh_b?bl5q6Cl$`8$6
 zVyeMtyrsqjL?Wkupu|7C13_#I&?Eea{E9vN5hVoEGmQ!{$}OUR0>T#Bv=rLj-0j}p
 z?#}Mc_{YxP?flr@59Y4e+;@|^n`hsd?>o=)KF|BS&-<SA1?mt~siI;sg@r%{tPPb<
@@ -995,14 +995,14 @@ zR{4SA1I10^GC3}7F0I#ApB+75niI9R&DV<0m-ZK5R*5d?U#*rgcSy_XegEQref)de
 TPbPHy00000NkvXXu0mjf*Ld(I
 
 literal 0
-Hc-jL100001
+HcmV?d00001
 
 diff --git a/chrome/android/java/res_vanadium/drawable-xxhdpi/fre_product_logo.png b/chrome/android/java/res_vanadium/drawable-xxhdpi/fre_product_logo.png
 new file mode 100644
 index 0000000000000000000000000000000000000000..4f300d7f849b005ba63163d63a643f3aeb737aea
 GIT binary patch
 literal 26693
-zc-jCpK+3;~P)<h;3K|Lk000e1NJLTq00D*o00D*w1ONa4)rszI00002VoOIv0RM-N
+zcmV)WK(4=uP)<h;3K|Lk000e1NJLTq00D*o00D*w1ONa4)rszI00002VoOIv0RM-N
 z%)bBtXZ}e<K~#9!?Y(!LBu9Ps|E}tuxOs2)a#YSbC6rMH1Ok&yFg9R#z!)AIunpLL
 z%wufxke!VaVEiK*3?>O1Bmol20R<$TPP(+WySF*bPV7*>KYC`TXQroTW_M<HW_CaQ
 zy4&5E>h9|5`qVenx4tD_$?8A=kjBJDrvsA(Bz>49u+a!}I!}@z!wwdh;UrRoh%-qC
@@ -1318,7 +1318,7 @@ zdcKKqUq4ciB!{qTmJ6-Wr*uL*_0Tg2KpGerq@K0fPBJ*qNO3#8zT<uz$-B{8IEHn3
 z5G2ug55gx)5<nM6+b~wufriD%p(7mSsG}z7$fu09GoisrTOZ*OCh77ir8C53+`>W=
 zkzqAfmrLe(DVH+jn;lOl#X&6e8Z#xe261c>!<(Mk&NjB?#DU0|Pqs$oYlT2#m^;{1
 zK?R!U{p?|;N#x^dybFzK_VRna>lZ-L&9j^!*y2l}ydlV7{<7cbp@$x1m@r|YaDTh3
-zcPoBe8^Jv+(B;#`0T3wf*90>}crP?X+R4?Rf+UIHeT13ued0h?E@(BTlWdKlRiKF9
+zcPoBe8^Jv+(B;#`1T#c<FEmBk$<?5OB#GdCgqiVu;y_j|Xf>vj0rV#e*ldlVRiKF9
 zzd)QAF{Fisg^lsB*(9T4{U12UP(|6GGsHFgDzj_+8dobLmCYQl<C+R8l1(=UnIKeS
 z{=C+pg0lxv`oY}h?#>J}7UE&M3C6_6;YUo+U*RQ9^M1}{x^BBzHZL@$Igj@-U7=i*
 zMSh7u)-+JI3Kc*jsgl3QkS0w!_ly!XY&^QwRcjOkL5}l%)#Lk`1Pd5^jQ$FN%#Fip
@@ -1518,14 +1518,14 @@ zmdO6dLevV2PCKFk1e8tyg&_<~Vak+T6mgOyRl46yrqzfT&dhB~rQ@;TuHku8A=pF*
 gCy1=|1GgRie-#m>m)v0)5&!@I07*qoM6N<$f-sBn4*&oF
 
 literal 0
-Hc-jL100001
+HcmV?d00001
 
 diff --git a/chrome/android/java/res_vanadium/drawable-xxhdpi/product_logo_name.png b/chrome/android/java/res_vanadium/drawable-xxhdpi/product_logo_name.png
 new file mode 100644
 index 0000000000000000000000000000000000000000..fc327262fd9479d15200e5ebca3f5335a1ce12c4
 GIT binary patch
 literal 4270
-zc-jH35K-@mP)<h;3K|Lk000e1NJLTq00A`s002J-1ONa4EBcpR00002VoOIv0RM-N
+zcmV;f5K-@mP)<h;3K|Lk000e1NJLTq00A`s002J-1ONa4EBcpR00002VoOIv0RM-N
 z%)bBt5NAn5K~#9!?VVe28`pWqe`j}b;Y}oD-6h)*Bwyq{=mJ@mRC}5zU^<Q`Gqz+Z
 zeTeH!(@;q|(_}iGkvxslNj>RMO&_Z1q%mnH(^#G+rXu^L^(CS+aZ^=^B}kQ%Sh6F*
 zvUQ^rkst|@xGb>S2P_r~VlR*kg0O`@W(W{x&+fOoe|+aV-{q{>jujFrDn4X#q|wQs
@@ -1610,14 +1610,14 @@ z*2`;HlJ4qiTN*q=E}fs&#<Ev(?_^F){hCug1Ockg5ozLPfoK}+P1Fbf4>8lX6)B~&
 QLI3~&07*qoM6N<$f)Jt_fB*mh
 
 literal 0
-Hc-jL100001
+HcmV?d00001
 
 diff --git a/chrome/android/java/res_vanadium/drawable-xxxhdpi/fre_product_logo.png b/chrome/android/java/res_vanadium/drawable-xxxhdpi/fre_product_logo.png
 new file mode 100644
 index 0000000000000000000000000000000000000000..52abcdfc19c13770971730c8bd4d8267a633ac22
 GIT binary patch
 literal 39011
-zc-jC^K(D`vP)<h;3K|Lk000e1NJLTq00IaA00IaI1ONa4q4nPA00002VoOIv0RM-N
+zcmV)xK$E|TP)<h;3K|Lk000e1NJLTq00IaA00IaI1ONa4q4nPA00002VoOIv0RM-N
 z%)bBtfB;EEK~#9!?45U<Bu9Dozg686H{RY}4!S!@r;~KbIR}u)29a!IW57g%jcpvk
 z*v7^YkWF#`1I9MI7>j5yK}Z5cKmiFPp?tcy;WqD1?ojU^J+qT~W_o64cEa{=KGN+>
 zcXd})S3UjYN4%U)f<TbQL}8<$6GAeJKr%ppX#$u?G&IiV3C4(GBH78~gpi!VA)*ZN
@@ -1933,8 +1933,8 @@ zAtnhgKOCs$P3V5aDezV6u~v$0uvy^wynth#$$`xf0p8CnqrUc_F4zn*#b5GChFJ2r
 z5hb(i=REEqMHn5c!e*%UTlq2X-i@Ux&b;~)*1AtUB%suzu^jo8u(a1K;J{=qAA117
 z!d2dV!`cB!f;4BKm+9y$SJ-pk0t(y1o7z1i&Jz9n36_gjL?sA@`8W?U($2}F`^bTV
 z^*q4G8L4AsDl%NlAW4$cryp=XCOmKGVtYX)jYXxF-uwru!(BsBK0`UJ2P|A3BeDFE
-zIs2oD-DjQFsTzblrrE-d0)GVe?1;5;Ce}w1@(@6b=d!PkgkKf_P(ZK0JNPkQAX1Y2
-z)rS{2RiwYbee9^i+Az-!&Lu+z1Kopup!8T}iM?7oQTE-texSSu)rnT+D|xwRPGr^q
+zIs2oD-DjQFsTzblrrE-d0)GVe?1;5;Ce}w1@(@6b=d!PkgkKgr_%UA~Qj+}DhZi_i
+zq`$y@?5M-qFwYLoB|`=P(m*Z01Kopup!8T}iM?7oQTE-texSSu)rnT+D|xwRPGr^q
 z`z$M*w=~KW&L>Us;`GKAKG~)~Vz9s&L|t5z>Vtp^9`EkwI?z~Rh~FcD>5+l8Sx1}?
 zVbJG`3k~+WAA=8)tRsnx%@UU}LNaTnZj>J=wL>V^mhRuZ^8;>%L~kO3C~N8M%tG>J
 zYzkl0znn2?c~vXqS%%i>{DG6baFD%D{YlEziPbrW{PZ~RW^pJyKhBHT$FxTkmqIeg
@@ -2250,10 +2250,10 @@ zNnf2<2ZGFV7&#Sq5%Z!T1<mSWRjmw#kO+8If0gm=neZqf49^qbZ}*j=R=9KSn<z@G
 zn)^McHOPA^sDi&u5(K#pjhLToy$*y};u&O8e^us?f!Vg1)8lQqts>(H3O~?ZpZV_@
 zMhPtE{r9o@a93U_SF><=;`KaiOfp=|8F8xs02mNSL_t)@9;S%-$<jO{M3Mu<xaf5!
 z-X6znqawCtY1penWNDyH=!?M(v5(C%+R<JKy$m;Z<=nSYfkBm!j$*;VNtQOkb4ZaS
-z?ehm75hTqs81((-@J*wvbGYX=VO3)p0mBzO=nCPyI~0n*$AjxL@0;;S!YZM1cI8q%
-zfsHB>2nzEmmb);6MFxY**vc63wl3>#LJ*5*h%xx*)<0!XB-+}Wjv(UVFZ9nRne#2y
-ztANVy_tM|hvca+Nh${Ji;W3jqTe*w{;w`C6+=~ccbAWk5pHqL?2_kbx5Cn_J>xRD;
-zV-Bq|I<zKHsS-owY>LIdTVx1uEkPFiQm!7M0|%I9*H=bg-x=}09kTzV6?l#OVUjtY
+z?ehm75hTqs81((-@J*wvbGYX=VO3)p3gNsv6pFydgX=TzoAF7)Dxq?A<x)L?jVcld
+z3iB$KyD)=A27}Ak${6vsF6(YW5Q}GsG5F`!KV?uP+S;3rAmZXL^v@@m^DWk^fXeUp
+z(%;px!Ljg&D*1omF_So3xr_zkEvZc0iwIzIfO$fnQ-9eBB6CL&1dGV)hQAhL4y`jf
+zv?fuh5<}%|ip9TMWC(CAK^FW{t{$NS2bcjR7ux7%*H=bg-x=}09kTzV6?l#OVUjtY
 z(OfkYyCYTdGH^RytVYcJ>X;kPWuBx9Z{edH8j?dy(|7mo*VtAk@CO}35EOP&T&Ld|
 zXBOEho$5K1O8)Mag~H>i2H%iBYLXzrbAXtiJJAy~bPh6&cBi`DN_R>QF}>Y%Dd&PA
 zu;cox)E)7?lHs;TIIIO!^OJYe5#)a_hhuKMlwC}b@Xd`LprLb!DMC-CUZoOxR(Tsh
@@ -2370,14 +2370,14 @@ z_ovCc>JVL~6Nel*qf8EkA(UZKq##1!Qp6RmDdR~WZ@xb2TgT;pb#Gjxe1+ay)NW^0
 f`ch_Jq&DIIbfZ@m$+<~>00000NkvXXu0mjf!$8AO
 
 literal 0
-Hc-jL100001
+HcmV?d00001
 
 diff --git a/chrome/android/java/res_vanadium/drawable-xxxhdpi/product_logo_name.png b/chrome/android/java/res_vanadium/drawable-xxxhdpi/product_logo_name.png
 new file mode 100644
 index 0000000000000000000000000000000000000000..5f16990a7eb67c441bfc62d50a4e92f95c0f4f22
 GIT binary patch
 literal 5925
-zc-jFa7ux8FP)<h;3K|Lk000e1NJLTq00Eo;002}71ONa49E3^V00002VoOIv0RM-N
+zcmV+=7ux8FP)<h;3K|Lk000e1NJLTq00Eo;002}71ONa49E3^V00002VoOIv0RM-N
 z%)bBt7T!rjK~#9!?VW3I99NZqzuVpO(9<5-ma!dTYwU!O1cx9c1V|NBN`~dR6d=Qr
 z;9Wu?k?a=B0u`Gjfm)z~9jXYhOTeO*uml3JYO~8D0oK~=BfOGWu#f~N!5-W3Te4>)
 zjYgVh_x_lkQTI&G^c`g+&6xhCT<%dn=AQ0*`kZ_3x#x;^P>w=|ETAD!nMOe;4fx2R
@@ -2494,7 +2494,7 @@ zntO)Bsb@2f>)9Xy)CEPqd3ZD)!gH8BJZeXNYNm&WN0I*rsl^JT&aD`J00000NkvXX
 Hu0mjf>GD|)
 
 literal 0
-Hc-jL100001
+HcmV?d00001
 
 diff --git a/chrome/android/java/res_vanadium_base/DIR_METADATA b/chrome/android/java/res_vanadium_base/DIR_METADATA
 new file mode 100644
@@ -2524,7 +2524,7 @@ new file mode 100644
 index 0000000000000000000000000000000000000000..9533ce927dbb3f4d3849d9a2c062ff31850ae454
 GIT binary patch
 literal 2578
-zc-jFH3hniYP)<h;3K|Lk000e1NJLTq002k;002k`1ONa4|Kxkj00002VoOIv0RM-N
+zcmV+t3hniYP)<h;3K|Lk000e1NJLTq002k;002k`1ONa4|Kxkj00002VoOIv0RM-N
 z%)bBt3Cl@DK~!ko&6;g&9K{*Oe>1yxw$JbO8P_4Po#2Ed#34XHNoYhVQYlDKP@zf@
 zQc+t$^PyEskqT=10YutL<)xL{(l30d1VJe&MXDf_hLlDD6d<%Nae@tbabi31OJdIN
 zcelIK4?BCeciy|(%Zu9QboTA+?#yrg^UO0dI}873CN6Rw>VE|!0D;tB_gDcA3Wb9@
@@ -2576,14 +2576,14 @@ zXXB@sW|~>%NnwTFPc9S4yIy9tcp`dZ$9=x*cD58r()wd%HYdv}pnUV*K$DqAt8PAy
 o?sU%izlC<8Z|MbZHC}-I7X>G&nZLZnpa1{>07*qoM6N<$f{)wb@Bjb+
 
 literal 0
-Hc-jL100001
+HcmV?d00001
 
 diff --git a/chrome/android/java/res_vanadium_base/mipmap-mdpi/app_icon.png b/chrome/android/java/res_vanadium_base/mipmap-mdpi/app_icon.png
 new file mode 100644
 index 0000000000000000000000000000000000000000..5c340f7a0936223c14d858784e18e38443264df5
 GIT binary patch
 literal 1532
-zc-jH{1q1qtP)<h;3K|Lk000e1NJLTq001xm001xu1ONa4{R=S+00002VoOIv0RM-N
+zcmV<Y1q1qtP)<h;3K|Lk000e1NJLTq001xm001xu1ONa4{R=S+00002VoOIv0RM-N
 z%)bBt1+_^;K~z}7wU}LO6jc<*fAhK9FSj4Gl@^fFmXCf&_%0<7pdv9*FyTp!k%UB(
 zB1RJR!53qA-~}{B5jF7z2vK}6qQ*dCNDwS7U<+0QrBIr*wA609Eo^tUyEEg%%<SjP
 zwqQIrnPl#q^Z(y_&bjxVJMce?FiS17nfeA`SnWR(2#82ki_~VRNmwpc;R9nrzZ>h+
@@ -2615,14 +2615,14 @@ zm1+;i!}o^%y8HLd?$8i^0)&aWZc4NGS7FwHIpmUy2MLG~A;c6RqC~U(MwktOtz}*V
 i?5f^Os2P5PnDQ@s4<gB_=JK-u0000<MNUMnLSTa0>e?Ux
 
 literal 0
-Hc-jL100001
+HcmV?d00001
 
 diff --git a/chrome/android/java/res_vanadium_base/mipmap-xhdpi/app_icon.png b/chrome/android/java/res_vanadium_base/mipmap-xhdpi/app_icon.png
 new file mode 100644
 index 0000000000000000000000000000000000000000..2110d524c9c403b80301dd34709d4f6fcc430f28
 GIT binary patch
 literal 3727
-zc-jGv4sh{_P)<h;3K|Lk000e1NJLTq003YB003YJ1ONa4NRhv@00002VoOIv0RM-N
+zcmV;A4sh{_P)<h;3K|Lk000e1NJLTq003YB003YJ1ONa4NRhv@00002VoOIv0RM-N
 z%)bBt4oFEvK~#9!?VM?BT-SBSe{Y!?awu{rky<E9q83w|B}<lV$yH+4ixMM+<2Y^|
 zApX!GY10O^fueDP26ciKU4p_6)EGe>%L$UY1q@{Y?80_qYqjHgk+Nu`EZGz#$|NO{
 z5*KkB&b)c=_QShx8@`!&Z%Ety&@+(c&0FsM|Ia<=-gD2pm+=4c@rv@Hl~`P|DEj_C
@@ -2696,14 +2696,14 @@ z9k%K%AG1#Yxqn*%9UWbMYjPp9L%?(fLrhE;_#FIcjJeuX<!lB}<Wj@nvNy-CEq8V~
 tXMdbzt~W?J>%)T!-Glpw=5&Y9{{mHf#%w_K>9PO-002ovPDHLkV1nv5AYT9g
 
 literal 0
-Hc-jL100001
+HcmV?d00001
 
 diff --git a/chrome/android/java/res_vanadium_base/mipmap-xxhdpi/app_icon.png b/chrome/android/java/res_vanadium_base/mipmap-xxhdpi/app_icon.png
 new file mode 100644
 index 0000000000000000000000000000000000000000..f4894e5b5b5047708bad46853f06c3bd68e54aa0
 GIT binary patch
 literal 6160
-zc-jFF81LtaP)<h;3K|Lk000e1NJLTq0058x0058(1ONa4O;0K_00002VoOIv0RM-N
+zcmV+r81LtaP)<h;3K|Lk000e1NJLTq0058x0058(1ONa4O;0K_00002VoOIv0RM-N
 z%)bBt7s*LPK~#9!?VWj$9MyTif89OTUfN4qUAvM%Vzo#}kw8e`00IoMAyC-Zv11cE
 z#ARa2c9khRNmU%jE?jneRKQ1U2OQsb0CQs(64)FD34sBFBqRhvNGt6n?Xv9LGu@p(
 z`g%RnJ<~JOqr>HIYIgg4{oZfB?|b)a_>25S{vu5j=_Gi*exgUPS<jU0zmn^?14Vaj
@@ -2824,14 +2824,14 @@ ze;qSGZcNx~(z;hnFCCERG|Xu(gX37CIo5#0=as%T&i%$B5IZ^CZx(=KhUWMH@_Mq@
 iy8!i)|Hl}MBmWOUsYCM~E)RwP0000<MNUMnLSTZfrRkLb
 
 literal 0
-Hc-jL100001
+HcmV?d00001
 
 diff --git a/chrome/android/java/res_vanadium_base/mipmap-xxxhdpi/app_icon.png b/chrome/android/java/res_vanadium_base/mipmap-xxxhdpi/app_icon.png
 new file mode 100644
 index 0000000000000000000000000000000000000000..1e02f37a1a940619f19cb73eb3605e14e8b0cfef
 GIT binary patch
 literal 9104
-zc-jGwBX8V^P)<h;3K|Lk000e1NJLTq006)M006)U1ONa4_|>G000002VoOIv0RM-N
+zcmV;BBX8V^P)<h;3K|Lk000e1NJLTq006)M006)U1ONa4_|>G000002VoOIv0RM-N
 z%)bBtBS}d_K~#9!?VWd&9MzrgKNY%rva)7I5-1QPB!UbAga|emY{2&6*v9dAkKb7z
 zN1ns_t?_y9t@rKPn>hB`hPAy8Zygq6!ai)+0}j{(BQi(`fk8+JWsPP=(nu3JR(O9@
 zPTf`ARXqdCZ_b3O>AH36`@O$#e>W7oA#cbV@`k)2|5Zhp?h0g7SADuG8&~A%u0UN8
@@ -3009,7 +3009,7 @@ z&TnT3ZAJm_ecYKSLdb8y_m^AzAbV#p&N$%xk2#Y?sB;t)z0T1Ll>ZM}!uj~k+35iQ
 O0000<MNUMnLSTY_yT{`I
 
 literal 0
-Hc-jL100001
+HcmV?d00001
 
 diff --git a/chrome/android/java/res_vanadium_base/values/channel_constants.xml b/chrome/android/java/res_vanadium_base/values/channel_constants.xml
 new file mode 100644
@@ -3031,5 +3031,5 @@ index 0000000000000..4fd77a8db6bc4
 +    <string name="dino_widget_title" translatable="false">Vanadium dino</string>
 +</resources>
 -- 
-2.34.1
+2.31.1
 

--- a/patches/0008-Vanadium-branding-for-WebView.patch
+++ b/patches/0008-Vanadium-branding-for-WebView.patch
@@ -1,7 +1,7 @@
-From c118d9f3f86947298ed682b45302065c796eb100 Mon Sep 17 00:00:00 2001
+From b0120d8c6b79d1d8685cac2aa68342274221b8b5 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Sun, 16 Feb 2020 13:40:14 -0500
-Subject: [PATCH 08/78] Vanadium branding for WebView
+Subject: [PATCH 08/79] Vanadium branding for WebView
 
 ---
  android_webview/nonembedded/java/AndroidManifest.xml | 2 +-
@@ -21,5 +21,5 @@ index 419141d4bd936..ece012dcbfaaa 100644
                   android:name="{{ application_name|default('org.chromium.android_webview.nonembedded.WebViewApkApplication') }}"
                   android:multiArch="true"
 -- 
-2.34.1
+2.31.1
 

--- a/patches/0010-Remove-logo-from-chrome-version.patch
+++ b/patches/0010-Remove-logo-from-chrome-version.patch
@@ -1,7 +1,7 @@
-From f7ac8bf46a244fb3b60e4b06ff8ad5f741fee7bb Mon Sep 17 00:00:00 2001
+From 386decb4f1950058ea55a86573952eeb4d2e80be Mon Sep 17 00:00:00 2001
 From: A Mak <refragable@mailbox.org>
 Date: Sat, 25 Jul 2020 17:56:47 -0700
-Subject: [PATCH 10/78] Remove logo from chrome://version
+Subject: [PATCH 10/79] Remove logo from chrome://version
 
 ---
  components/version_ui/resources/about_version.html | 7 -------
@@ -26,5 +26,5 @@ index 1caa96b60599c..d1158ca6b8836 100644
          <div id="company">$i18n{company}</div>
          <div id="copyright">$i18n{copyright}</div>
 -- 
-2.34.1
+2.31.1
 

--- a/patches/0011-redirect-settings-help-icon.patch
+++ b/patches/0011-redirect-settings-help-icon.patch
@@ -1,7 +1,7 @@
-From 4bfbfb5a4cd29583f0f1efd678fc645c7447e3e4 Mon Sep 17 00:00:00 2001
+From af8b254f5492d8b06c82b3a6ba48bb4fd4edd754 Mon Sep 17 00:00:00 2001
 From: Zoraver Kang <zkang@wpi.edu>
 Date: Fri, 16 Aug 2019 02:03:45 -0400
-Subject: [PATCH 11/78] redirect settings help icon
+Subject: [PATCH 11/79] redirect settings help icon
 
 ---
  .../chrome/browser/feedback/HelpAndFeedbackLauncherImpl.java    | 2 +-
@@ -21,5 +21,5 @@ index ccf04eb1168ed..5734f98f8bdde 100644
  
      private static HelpAndFeedbackLauncher sInstance;
 -- 
-2.34.1
+2.31.1
 

--- a/patches/0012-remove-Google-prefix-from-storage-settings-label.patch
+++ b/patches/0012-remove-Google-prefix-from-storage-settings-label.patch
@@ -1,7 +1,7 @@
-From 50303e18c899d397c01fc16d3feca06d52b76949 Mon Sep 17 00:00:00 2001
+From 10e38deaa8489fb510fbbb1fc7094025c97efde0 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Wed, 8 Apr 2020 09:51:35 -0400
-Subject: [PATCH 12/78] remove Google prefix from storage settings label
+Subject: [PATCH 12/79] remove Google prefix from storage settings label
 
 ---
  chrome/browser/ui/android/strings/android_chrome_strings.grd | 2 +-
@@ -21,5 +21,5 @@ index 04d63e2501238..a8ca475b99d92 100644
        <message name="IDS_STORAGE_MANAGEMENT_UNIMPORTANT_SITE_DATA_DESCRIPTION" desc="Text to describe the data stored by unimportant or infrequent sites.">
          Stored data that Vanadium doesn't think is important (e.g. sites with no saved settings or that you don't visit often)
 -- 
-2.34.1
+2.31.1
 

--- a/patches/0013-remove-Help-feedback-menu-entry.patch
+++ b/patches/0013-remove-Help-feedback-menu-entry.patch
@@ -1,7 +1,7 @@
-From b48ddadb25d274e2f68f81e78e0a72fe712bda31 Mon Sep 17 00:00:00 2001
+From c627849271ee86bcb0a2fb9204106ab83a92886e Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Thu, 15 Apr 2021 02:14:37 -0400
-Subject: [PATCH 13/78] remove Help & feedback menu entry
+Subject: [PATCH 13/79] remove Help & feedback menu entry
 
 ---
  .../browser/app/appmenu/AppMenuPropertiesDelegateImpl.java      | 2 ++
@@ -21,5 +21,5 @@ index 4457f4e8b71b9..8f6b2fdc8fd01 100644
          menu.findItem(R.id.enter_vr_id).setVisible(isCurrentTabNotNull && shouldShowEnterVr());
  
 -- 
-2.34.1
+2.31.1
 

--- a/patches/0014-hide-passwords.google.com-link-when-not-supported.patch
+++ b/patches/0014-hide-passwords.google.com-link-when-not-supported.patch
@@ -1,7 +1,7 @@
-From 9ee9a22291bf5c5bcb5d79352c4b77f29bd94450 Mon Sep 17 00:00:00 2001
+From c2f9871ab6a26eee6adf984f1439fc5be2a14dc0 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Sun, 13 Aug 2017 19:33:04 -0400
-Subject: [PATCH 14/78] hide passwords.google.com link when not supported
+Subject: [PATCH 14/79] hide passwords.google.com link when not supported
 
 ---
  .../browser/password_manager/settings/PasswordSettings.java   | 4 ++++
@@ -30,5 +30,5 @@ index bfb49665d2e48..79d90f55af2a1 100644
              return; // Don't add the Manage Account link if it's present.
          }
 -- 
-2.34.1
+2.31.1
 

--- a/patches/0015-disable-first-run-welcome-page.patch
+++ b/patches/0015-disable-first-run-welcome-page.patch
@@ -1,7 +1,7 @@
-From 3e2294034ba77bd26579f42214d4bb192fba3a2b Mon Sep 17 00:00:00 2001
+From 89c39808695a46475f73511fc12e947418db854d Mon Sep 17 00:00:00 2001
 From: csagan5 <32685696+csagan5@users.noreply.github.com>
 Date: Sun, 26 Nov 2017 22:51:43 +0100
-Subject: [PATCH 15/78] disable first run welcome page
+Subject: [PATCH 15/79] disable first run welcome page
 
 ---
  .../org/chromium/chrome/browser/firstrun/FirstRunUtils.java | 3 ---
@@ -64,5 +64,5 @@ index 13bec9f270f5b..ac3a3c0f7caf2 100644
  
      /**
 -- 
-2.34.1
+2.31.1
 

--- a/patches/0016-disable-seed-based-field-trials.patch
+++ b/patches/0016-disable-seed-based-field-trials.patch
@@ -1,7 +1,7 @@
-From 11a18c4238c86841b6afe75458a86bf4578b275a Mon Sep 17 00:00:00 2001
+From aa109aa25725dc25598fb60190bad151262e6d4a Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Tue, 25 Dec 2018 16:19:51 -0500
-Subject: [PATCH 16/78] disable seed-based field trials
+Subject: [PATCH 16/79] disable seed-based field trials
 
 ---
  components/variations/service/variations_field_trial_creator.cc | 2 ++
@@ -23,5 +23,5 @@ index 30d8b8a0d9b74..fa5b348880d2c 100644
  
    platform_field_trials->SetupFeatureControllingFieldTrials(
 -- 
-2.34.1
+2.31.1
 

--- a/patches/0017-disable-fetching-variations.patch
+++ b/patches/0017-disable-fetching-variations.patch
@@ -1,7 +1,7 @@
-From 8067cf5c959d07efdfe6fe4dde6d296c18a17e22 Mon Sep 17 00:00:00 2001
+From a8ce9614b9d70bdfd0aa5b3a82b50fc00a31da7e Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Wed, 18 Nov 2020 19:08:58 -0500
-Subject: [PATCH 17/78] disable fetching variations
+Subject: [PATCH 17/79] disable fetching variations
 
 ---
  .../org/chromium/chrome/browser/init/AsyncInitTaskRunner.java   | 2 +-
@@ -21,5 +21,5 @@ index fe18f3f8daa09..11dca026defb9 100644
  
      @VisibleForTesting
 -- 
-2.34.1
+2.31.1
 

--- a/patches/0018-disable-WebView-variations-support.patch
+++ b/patches/0018-disable-WebView-variations-support.patch
@@ -1,7 +1,7 @@
-From 77cfb735e0ef93d6ee3710306c6cc8ed9a13b3b4 Mon Sep 17 00:00:00 2001
+From d30e40a599a8a198e3aca26e4ce30e0ae71de117 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Thu, 10 Dec 2020 10:09:18 -0500
-Subject: [PATCH 18/78] disable WebView variations support
+Subject: [PATCH 18/79] disable WebView variations support
 
 ---
  .../com/android/webview/chromium/WebViewChromiumAwInit.java   | 4 ----
@@ -37,5 +37,5 @@ index bed9ebc8f535c..9b786db8f9ed7 100644
  
              setSingleton(this);
 -- 
-2.34.1
+2.31.1
 

--- a/patches/0019-disable-navigation-error-correction-by-default.patch
+++ b/patches/0019-disable-navigation-error-correction-by-default.patch
@@ -1,7 +1,7 @@
-From ebfe50569fb44226b7475940b2726608e8af085d Mon Sep 17 00:00:00 2001
+From 2885d29d7f0afec7d5c727c85a5cbc6c87a56b2b Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Wed, 23 Nov 2016 08:29:58 -0500
-Subject: [PATCH 19/78] disable navigation error correction by default
+Subject: [PATCH 19/79] disable navigation error correction by default
 
 ---
  chrome/browser/net/profile_network_context_service.cc | 2 +-
@@ -21,5 +21,5 @@ index a0b46c8619458..d19a67d7da475 100644
    registry->RegisterBooleanPref(prefs::kQuicAllowed, true);
    registry->RegisterBooleanPref(prefs::kGloballyScopeHTTPAuthCacheEnabled,
 -- 
-2.34.1
+2.31.1
 

--- a/patches/0020-disable-contextual-search-by-default.patch
+++ b/patches/0020-disable-contextual-search-by-default.patch
@@ -1,7 +1,7 @@
-From 1ffe8c05c83f8f3725fb64ef37ea71d6bfe7cad0 Mon Sep 17 00:00:00 2001
+From fdabbc81a9f27b94e1113c2fb3e12b6802b8c241 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Wed, 23 Nov 2016 09:26:51 -0500
-Subject: [PATCH 20/78] disable contextual search by default
+Subject: [PATCH 20/79] disable contextual search by default
 
 ---
  .../browser/contextualsearch/ContextualSearchFieldTrial.java    | 2 +-
@@ -35,5 +35,5 @@ index 77c15d82fb04e..b64c47dcaff8b 100644
    registry->RegisterBooleanPref(
        prefs::kContextualSearchWasFullyPrivacyEnabled, false,
 -- 
-2.34.1
+2.31.1
 

--- a/patches/0021-disable-network-prediction-by-default.patch
+++ b/patches/0021-disable-network-prediction-by-default.patch
@@ -1,7 +1,7 @@
-From 1e443e4809f726ef77daee9fe08ed026ffb5402c Mon Sep 17 00:00:00 2001
+From dcf1d3fde0e647fb53e0dc6e3a3b8545d066ff3a Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Wed, 23 Nov 2016 08:31:44 -0500
-Subject: [PATCH 21/78] disable network prediction by default
+Subject: [PATCH 21/79] disable network prediction by default
 
 ---
  chrome/browser/net/prediction_options.h | 2 +-
@@ -21,5 +21,5 @@ index 2ae6a1093090d..7fc83de1aa0fa 100644
  
  enum class NetworkPredictionStatus {
 -- 
-2.34.1
+2.31.1
 

--- a/patches/0022-disable-metrics-by-default.patch
+++ b/patches/0022-disable-metrics-by-default.patch
@@ -1,7 +1,7 @@
-From 2e15874c6b7b0025488b1ff6124b0ac286a523e5 Mon Sep 17 00:00:00 2001
+From 468956ed482ef572d2045847201a7eb2522ee3c5 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Thu, 24 Nov 2016 11:41:00 -0500
-Subject: [PATCH 22/78] disable metrics by default
+Subject: [PATCH 22/79] disable metrics by default
 
 ---
  .../chromium/chrome/browser/firstrun/FirstRunActivityBase.java  | 2 +-
@@ -21,5 +21,5 @@ index cf90b983fe886..bd2324e697745 100644
      private boolean mNativeInitialized;
  
 -- 
-2.34.1
+2.31.1
 

--- a/patches/0023-disable-hyperlink-auditing-by-default.patch
+++ b/patches/0023-disable-hyperlink-auditing-by-default.patch
@@ -1,7 +1,7 @@
-From 57a4b5baa8a796445737e66bed2d6eaf5520d554 Mon Sep 17 00:00:00 2001
+From 4312630c8379f557d026184181862ba5a98d89a6 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Sat, 26 Nov 2016 14:57:22 -0500
-Subject: [PATCH 23/78] disable hyperlink auditing by default
+Subject: [PATCH 23/79] disable hyperlink auditing by default
 
 ---
  chrome/browser/chrome_content_browser_client.cc | 2 +-
@@ -21,5 +21,5 @@ index 4ba206e769e7e..f61aa9453cca2 100644
    // user policy in addition to the same named ones in Local State (which are
    // used for mapping the command-line flags).
 -- 
-2.34.1
+2.31.1
 

--- a/patches/0024-disable-showing-popular-sites-by-default.patch
+++ b/patches/0024-disable-showing-popular-sites-by-default.patch
@@ -1,7 +1,7 @@
-From 22916221721430e4f4fcfc7febe12ec6a1bf8fa0 Mon Sep 17 00:00:00 2001
+From ddf65377e7323c0e39698c0ea0f48fd95241f53c Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Tue, 6 Mar 2018 00:27:41 -0500
-Subject: [PATCH 24/78] disable showing popular sites by default
+Subject: [PATCH 24/79] disable showing popular sites by default
 
 ---
  components/ntp_tiles/features.cc | 4 ++--
@@ -27,5 +27,5 @@ index 4ce3356827cec..4414615ff6ac6 100644
  
  }  // namespace ntp_tiles
 -- 
-2.34.1
+2.31.1
 

--- a/patches/0025-disable-article-suggestions-feature-by-default.patch
+++ b/patches/0025-disable-article-suggestions-feature-by-default.patch
@@ -1,7 +1,7 @@
-From 553266d84606e884f3073f202ae0594bc7eab8b6 Mon Sep 17 00:00:00 2001
+From 9d61e26241efc08bfb9df66724f8e0d585d33091 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Thu, 8 Mar 2018 22:43:12 -0500
-Subject: [PATCH 25/78] disable article suggestions feature by default
+Subject: [PATCH 25/79] disable article suggestions feature by default
 
 ---
  components/feed/core/shared_prefs/pref_names.cc | 4 ++--
@@ -37,5 +37,5 @@ index c5ea510f1e580..688887dc4ba76 100644
  const base::Feature kRemoteSuggestionsEmulateM58FetchingSchedule{
      "RemoteSuggestionsEmulateM58FetchingSchedule",
 -- 
-2.34.1
+2.31.1
 

--- a/patches/0026-disable-prefetching-suggested-pages-by-default.patch
+++ b/patches/0026-disable-prefetching-suggested-pages-by-default.patch
@@ -1,7 +1,7 @@
-From 9283a11221d7b02ade25caa2a8179ddddc97fe40 Mon Sep 17 00:00:00 2001
+From d808418c3004041fc0f3402d0bbb2515d1d7a772 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Fri, 12 Jul 2019 04:10:21 -0400
-Subject: [PATCH 26/78] disable prefetching suggested pages by default
+Subject: [PATCH 26/79] disable prefetching suggested pages by default
 
 ---
  components/offline_pages/core/offline_page_feature.cc | 2 +-
@@ -21,5 +21,5 @@ index d1a9a4fca3778..21b689819c4b5 100644
  const base::Feature kOfflinePagesCTV2Feature{"OfflinePagesCTV2",
                                               base::FEATURE_DISABLED_BY_DEFAULT};
 -- 
-2.34.1
+2.31.1
 

--- a/patches/0027-disable-content-feed-suggestions-by-default.patch
+++ b/patches/0027-disable-content-feed-suggestions-by-default.patch
@@ -1,7 +1,7 @@
-From 89c6cd01a34eb1077ec326b447544bb26e11a5ed Mon Sep 17 00:00:00 2001
+From 75d7aca8334815ccf0ce82259c011ca3cfd3defb Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Sun, 22 Mar 2020 01:23:48 -0400
-Subject: [PATCH 27/78] disable content feed suggestions by default
+Subject: [PATCH 27/79] disable content feed suggestions by default
 
 ---
  .../org/chromium/chrome/browser/flags/CachedFeatureFlags.java | 2 +-
@@ -41,5 +41,5 @@ index 5b60beb424fcf..313f32595a797 100644
  const base::Feature kInterestFeedV2Autoplay{"InterestFeedV2Autoplay",
                                              base::FEATURE_DISABLED_BY_DEFAULT};
 -- 
-2.34.1
+2.31.1
 

--- a/patches/0028-disable-sensors-access-by-default.patch
+++ b/patches/0028-disable-sensors-access-by-default.patch
@@ -1,7 +1,7 @@
-From 6ca4d4d5251a4ee0524068aad340c13ece301ecd Mon Sep 17 00:00:00 2001
+From 52802685b2b892214af9b11277d1540a94ceabee Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Sun, 16 Jun 2019 15:57:29 -0400
-Subject: [PATCH 28/78] disable sensors access by default
+Subject: [PATCH 28/79] disable sensors access by default
 
 ---
  .../content_settings/core/browser/content_settings_registry.cc  | 2 +-
@@ -21,5 +21,5 @@ index beeb57851306b..9a92553a1d7d5 100644
             ValidSettings(CONTENT_SETTING_ALLOW, CONTENT_SETTING_BLOCK),
             WebsiteSettingsInfo::SINGLE_ORIGIN_ONLY_SCOPE,
 -- 
-2.34.1
+2.31.1
 

--- a/patches/0029-block-playing-protected-media-by-default.patch
+++ b/patches/0029-block-playing-protected-media-by-default.patch
@@ -1,7 +1,7 @@
-From b404c7d084a4111cf82ade156fd21fd5d3e1c3e6 Mon Sep 17 00:00:00 2001
+From 471cef75f5e749e6b11dd62b884388aa4d7872e3 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Tue, 1 Dec 2020 00:29:28 -0500
-Subject: [PATCH 29/78] block playing protected media by default
+Subject: [PATCH 29/79] block playing protected media by default
 
 ---
  .../core/browser/content_settings_registry.cc       | 13 +------------
@@ -32,5 +32,5 @@ index 9a92553a1d7d5..47404a09e5eed 100644
    Register(ContentSettingsType::PROTECTED_MEDIA_IDENTIFIER,
             "protected-media-identifier", protected_media_identifier_setting,
 -- 
-2.34.1
+2.31.1
 

--- a/patches/0030-disable-third-party-cookies-by-default.patch
+++ b/patches/0030-disable-third-party-cookies-by-default.patch
@@ -1,7 +1,7 @@
-From 95b5067391879e7538c3fee57c23cbf620b05f8c Mon Sep 17 00:00:00 2001
+From fe951529d160aa3c036584970b982538a5ddf78a Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Sun, 16 Jun 2019 16:01:31 -0400
-Subject: [PATCH 30/78] disable third party cookies by default
+Subject: [PATCH 30/79] disable third party cookies by default
 
 ---
  components/content_settings/core/browser/cookie_settings.cc | 2 +-
@@ -21,5 +21,5 @@ index 3d766d54fc75a..b069465216c14 100644
  }
  
 -- 
-2.34.1
+2.31.1
 

--- a/patches/0031-disable-background-sync-by-default.patch
+++ b/patches/0031-disable-background-sync-by-default.patch
@@ -1,7 +1,7 @@
-From cd135cfebc17573ca7ed62647cd084a4e394317e Mon Sep 17 00:00:00 2001
+From 654c4d5b0a15b2e3b52675437314c377a6deb407 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Sun, 16 Jun 2019 21:57:26 -0400
-Subject: [PATCH 31/78] disable background sync by default
+Subject: [PATCH 31/79] disable background sync by default
 
 ---
  .../content_settings/core/browser/content_settings_registry.cc  | 2 +-
@@ -21,5 +21,5 @@ index 47404a09e5eed..6d05320274c31 100644
             ValidSettings(CONTENT_SETTING_ALLOW, CONTENT_SETTING_BLOCK),
             WebsiteSettingsInfo::SINGLE_ORIGIN_ONLY_SCOPE,
 -- 
-2.34.1
+2.31.1
 

--- a/patches/0032-disable-payment-support-by-default.patch
+++ b/patches/0032-disable-payment-support-by-default.patch
@@ -1,7 +1,7 @@
-From 6cd79e00940bb1e20fe2d45848c4dba1e7c91481 Mon Sep 17 00:00:00 2001
+From 60e3721ad6a2780ecea0171e340a588862420406 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Tue, 18 Jun 2019 22:28:53 -0400
-Subject: [PATCH 32/78] disable payment support by default
+Subject: [PATCH 32/79] disable payment support by default
 
 ---
  components/payments/core/payment_prefs.cc | 2 +-
@@ -21,5 +21,5 @@ index 9590d9494ed10..787ff68af12aa 100644
  }
  
 -- 
-2.34.1
+2.31.1
 

--- a/patches/0033-disable-media-router-media-remoting-by-default.patch
+++ b/patches/0033-disable-media-router-media-remoting-by-default.patch
@@ -1,7 +1,7 @@
-From f899683b3f39d90487081924efce6a5d01d2c164 Mon Sep 17 00:00:00 2001
+From 9f78c8eaa17a3a4d77ddad41ba158bc9f08536eb Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Thu, 4 Jul 2019 18:11:27 -0400
-Subject: [PATCH 33/78] disable media router media remoting by default
+Subject: [PATCH 33/79] disable media router media remoting by default
 
 ---
  chrome/browser/profiles/profile.cc | 2 +-
@@ -21,5 +21,5 @@ index b64c47dcaff8b..64b73d9f54e0d 100644
        media_router::prefs::kMediaRouterTabMirroringSources);
  #endif
 -- 
-2.34.1
+2.31.1
 

--- a/patches/0034-disable-media-router-by-default.patch
+++ b/patches/0034-disable-media-router-by-default.patch
@@ -1,7 +1,7 @@
-From ec3347987329167edf78c0a5845137247225ee94 Mon Sep 17 00:00:00 2001
+From 20fa7caa3ed62eaa0727398ce5e75b638d305227 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Thu, 4 Jul 2019 19:08:52 -0400
-Subject: [PATCH 34/78] disable media router by default
+Subject: [PATCH 34/79] disable media router by default
 
 ---
  chrome/browser/media/router/media_router_feature.cc | 2 +-
@@ -35,5 +35,5 @@ index d8df8be6d9d54..f8e3f7e21268b 100644
    registry->RegisterBooleanPref(prefs::kShowCastIconInToolbar, false);
  #endif  // !defined(OS_ANDROID)
 -- 
-2.34.1
+2.31.1
 

--- a/patches/0035-disable-offering-translations-by-default.patch
+++ b/patches/0035-disable-offering-translations-by-default.patch
@@ -1,7 +1,7 @@
-From a4f9a819c81611e3e6feac357cfcee638f243364 Mon Sep 17 00:00:00 2001
+From 97b82afa43c68c7a58fcd3a312ee2cec1b813fef Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Fri, 12 Jul 2019 03:58:01 -0400
-Subject: [PATCH 35/78] disable offering translations by default
+Subject: [PATCH 35/79] disable offering translations by default
 
 ---
  chrome/browser/ui/browser_ui_prefs.cc | 2 +-
@@ -21,5 +21,5 @@ index 20bb8b5bd368b..914ad46bd50fb 100644
    registry->RegisterStringPref(prefs::kCloudPrintEmail, std::string());
    registry->RegisterBooleanPref(prefs::kCloudPrintProxyEnabled, true);
 -- 
-2.34.1
+2.31.1
 

--- a/patches/0036-disable-browser-sign-in-feature-by-default.patch
+++ b/patches/0036-disable-browser-sign-in-feature-by-default.patch
@@ -1,7 +1,7 @@
-From 1acfe23cf70c073b545c0447d4b9c166e43d1d52 Mon Sep 17 00:00:00 2001
+From 4a58cd96663aebe4ccf3508aa22d4742ec3eba82 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Fri, 12 Jul 2019 04:23:18 -0400
-Subject: [PATCH 36/78] disable browser sign in feature by default
+Subject: [PATCH 36/79] disable browser sign in feature by default
 
 ---
  chrome/browser/signin/account_consistency_mode_manager.cc       | 2 +-
@@ -35,5 +35,5 @@ index 51ca2abc2b158..160c45365126a 100644
  }
  
 -- 
-2.34.1
+2.31.1
 

--- a/patches/0037-disable-browser-autologin-by-default.patch
+++ b/patches/0037-disable-browser-autologin-by-default.patch
@@ -1,7 +1,7 @@
-From 51431d0d5a05b01443febda3128b1b7058eb90a5 Mon Sep 17 00:00:00 2001
+From cc2029755501c1a96beb8b42ef8c7fd768b03df6 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Sun, 22 Mar 2020 03:07:08 -0400
-Subject: [PATCH 37/78] disable browser autologin by default
+Subject: [PATCH 37/79] disable browser autologin by default
 
 ---
  .../signin/internal/identity_manager/primary_account_manager.cc | 2 +-
@@ -21,5 +21,5 @@ index 160c45365126a..1c901546a9b9e 100644
    registry->RegisterBooleanPref(prefs::kSigninAllowed, false);
    registry->RegisterBooleanPref(prefs::kSignedInWithCredentialProvider, false);
 -- 
-2.34.1
+2.31.1
 

--- a/patches/0038-disable-safe-browsing-reporting-opt-in-by-default.patch
+++ b/patches/0038-disable-safe-browsing-reporting-opt-in-by-default.patch
@@ -1,7 +1,7 @@
-From 14672bfa07c04267f0d718979f5792a456f0fe7b Mon Sep 17 00:00:00 2001
+From 225070d575fc8d91431e7703b59c305a6cdd581a Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Fri, 12 Jul 2019 05:22:11 -0400
-Subject: [PATCH 38/78] disable safe browsing reporting opt-in by default
+Subject: [PATCH 38/79] disable safe browsing reporting opt-in by default
 
 ---
  components/safe_browsing/core/common/safe_browsing_prefs.cc | 2 +-
@@ -21,5 +21,5 @@ index 3db4c28fc01e5..cccc3f266fd61 100644
        prefs::kSafeBrowsingEnabled, true,
        user_prefs::PrefRegistrySyncable::SYNCABLE_PREF);
 -- 
-2.34.1
+2.31.1
 

--- a/patches/0039-disable-unused-safe-browsing-option-by-default.patch
+++ b/patches/0039-disable-unused-safe-browsing-option-by-default.patch
@@ -1,7 +1,7 @@
-From acb521d887a2c65688b6b390c8ac01ab302dcc3e Mon Sep 17 00:00:00 2001
+From 4dfe1eaf090e8d9fb9a3f4bede9480f79ca7d235 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Thu, 12 Mar 2020 13:01:02 -0400
-Subject: [PATCH 39/78] disable unused safe browsing option by default
+Subject: [PATCH 39/79] disable unused safe browsing option by default
 
 Safe Browsing is currently a no-op due to the lack of Play Services, and
 support for using the local database backend hasn't been implemented.
@@ -25,5 +25,5 @@ index cccc3f266fd61..d7fdf16095d5c 100644
    registry->RegisterBooleanPref(prefs::kSafeBrowsingEnhanced, false);
    registry->RegisterBooleanPref(prefs::kSafeBrowsingProceedAnywayDisabled,
 -- 
-2.34.1
+2.31.1
 

--- a/patches/0040-disable-media-DRM-preprovisioning-by-default.patch
+++ b/patches/0040-disable-media-DRM-preprovisioning-by-default.patch
@@ -1,7 +1,7 @@
-From b31a2b0fafa03b710f1149b14522c1896b387f4c Mon Sep 17 00:00:00 2001
+From 5a94a973b73660e75e27f7039ba745201d9553c6 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Thu, 21 May 2020 12:27:29 -0400
-Subject: [PATCH 40/78] disable media DRM preprovisioning by default
+Subject: [PATCH 40/79] disable media DRM preprovisioning by default
 
 This switches to fetching on-demand, which can only happen if DRM media
 support is enabled.
@@ -23,5 +23,5 @@ index 5f43904c668ff..1f404dda1cba4 100644
  // Determines if MediaDrmOriginIdManager should attempt to pre-provision origin
  // IDs at startup (whenever a profile is loaded). Also used by tests that
 -- 
-2.34.1
+2.31.1
 

--- a/patches/0041-enable-prefetch-privacy-changes-by-default.patch
+++ b/patches/0041-enable-prefetch-privacy-changes-by-default.patch
@@ -1,7 +1,7 @@
-From ce5bbd68318f9da8d25e56465716a22ca103a60e Mon Sep 17 00:00:00 2001
+From 3c3d5c2e8babbbdab3ee02f45cba64bec7678dab Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Fri, 23 Oct 2020 23:59:13 -0400
-Subject: [PATCH 41/78] enable prefetch privacy changes by default
+Subject: [PATCH 41/79] enable prefetch privacy changes by default
 
 ---
  third_party/blink/common/features.cc | 2 +-
@@ -21,5 +21,5 @@ index 35effca2b0365..20ee68874d475 100644
  // Decodes jpeg 4:2:0 formatted images to YUV instead of RGBX and stores in this
  // format in the image decode cache. See crbug.com/919627 for details on the
 -- 
-2.34.1
+2.31.1
 

--- a/patches/0042-enable-user-agent-freeze-by-default.patch
+++ b/patches/0042-enable-user-agent-freeze-by-default.patch
@@ -1,7 +1,7 @@
-From e533c356f200ed1335029d9588392a27ccd8f37c Mon Sep 17 00:00:00 2001
+From 221763b4fd7b28ca88267732b329716f2e6b1a25 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Wed, 3 Mar 2021 13:42:41 -0500
-Subject: [PATCH 42/78] enable user agent freeze by default
+Subject: [PATCH 42/79] enable user agent freeze by default
 
 ---
  third_party/blink/common/features.cc | 2 +-
@@ -21,5 +21,5 @@ index 20ee68874d475..b517e35fbfc3c 100644
  // Enables the frequency capping for detecting overlay popups. Overlay-popups
  // are the interstitials that pop up and block the main content of the page.
 -- 
-2.34.1
+2.31.1
 

--- a/patches/0043-enable-split-cache-by-default.patch
+++ b/patches/0043-enable-split-cache-by-default.patch
@@ -1,7 +1,7 @@
-From e7c369fb6bb44bf8a7f3489c8cf9be29fb38aa1b Mon Sep 17 00:00:00 2001
+From dd8ad48ac5cb072f249b00227bbf5b7e4732568f Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Wed, 23 Dec 2020 06:00:50 -0500
-Subject: [PATCH 43/78] enable split cache by default
+Subject: [PATCH 43/79] enable split cache by default
 
 ---
  net/base/features.cc | 2 +-
@@ -21,5 +21,5 @@ index 549f376be5224..39240192c87ea 100644
  const base::Feature kSplitHostCacheByNetworkIsolationKey{
      "SplitHostCacheByNetworkIsolationKey", base::FEATURE_DISABLED_BY_DEFAULT};
 -- 
-2.34.1
+2.31.1
 

--- a/patches/0044-enable-partitioning-connections-by-default.patch
+++ b/patches/0044-enable-partitioning-connections-by-default.patch
@@ -1,7 +1,7 @@
-From aecd752c1099c1691566edcfe361da4f4ecc5ec0 Mon Sep 17 00:00:00 2001
+From dd6ea355ef0a83929375bce6e9913edcdf0dcd02 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Mon, 8 Mar 2021 16:53:47 -0500
-Subject: [PATCH 44/78] enable partitioning connections by default
+Subject: [PATCH 44/79] enable partitioning connections by default
 
 ---
  net/base/features.cc | 12 ++++++------
@@ -46,5 +46,5 @@ index 39240192c87ea..fb45fb3c7a040 100644
  const base::Feature kExpectCTPruning{"ExpectCTPruning",
                                       base::FEATURE_ENABLED_BY_DEFAULT};
 -- 
-2.34.1
+2.31.1
 

--- a/patches/0045-enable-dubious-Do-Not-Track-feature-by-default.patch
+++ b/patches/0045-enable-dubious-Do-Not-Track-feature-by-default.patch
@@ -1,7 +1,7 @@
-From bf0824ac24936043cb148bbde1a2c69eb4e56a78 Mon Sep 17 00:00:00 2001
+From f18ce05c7c40384dad60ec07b177effb7fbcc0df Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Tue, 1 Aug 2017 11:16:11 -0400
-Subject: [PATCH 45/78] enable dubious Do Not Track feature by default
+Subject: [PATCH 45/79] enable dubious Do Not Track feature by default
 
 ---
  chrome/browser/ui/browser_ui_prefs.cc | 2 +-
@@ -21,5 +21,5 @@ index 914ad46bd50fb..7bbd3ba5f9057 100644
  #if !BUILDFLAG(IS_CHROMEOS_ASH) && !defined(OS_ANDROID)
    registry->RegisterBooleanPref(prefs::kPrintPreviewUseSystemDefaultPrinter,
 -- 
-2.34.1
+2.31.1
 

--- a/patches/0046-disable-autofill-assistant-by-default.patch
+++ b/patches/0046-disable-autofill-assistant-by-default.patch
@@ -1,7 +1,7 @@
-From 1771abf47f77f9333f2be6208be951289e01cdfa Mon Sep 17 00:00:00 2001
+From 1dbd5decc084c0fd54c168f52e0ea1f368e80b86 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Fri, 27 Nov 2020 02:43:37 -0500
-Subject: [PATCH 46/78] disable autofill assistant by default
+Subject: [PATCH 46/79] disable autofill assistant by default
 
 ---
  .../autofill_assistant/AutofillAssistantPreferencesUtil.java  | 2 +-
@@ -44,5 +44,5 @@ index 5388e868bcc60..a4b41838f24f7 100644
  // Used to configure the start heuristics for
  // |kAutofillAssistantInCctTriggering| and/or
 -- 
-2.34.1
+2.31.1
 

--- a/patches/0047-disable-autofill-server-communication-by-default.patch
+++ b/patches/0047-disable-autofill-server-communication-by-default.patch
@@ -1,7 +1,7 @@
-From 8ebaf7630a9a1cbf70110bf46bd291dd9ddd1bab Mon Sep 17 00:00:00 2001
+From 86dfd50fc349006c353f3e2ba6999072668a4d9c Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Tue, 1 Dec 2020 00:56:57 -0500
-Subject: [PATCH 47/78] disable autofill server communication by default
+Subject: [PATCH 47/79] disable autofill server communication by default
 
 ---
  components/autofill/core/common/autofill_features.cc | 2 +-
@@ -21,5 +21,5 @@ index ed46a4fd74ecd..0f2dc1a483cfb 100644
  // Controls attaching the autofill type predictions to their respective
  // element in the DOM.
 -- 
-2.34.1
+2.31.1
 

--- a/patches/0048-disable-component-updater-pings-by-default.patch
+++ b/patches/0048-disable-component-updater-pings-by-default.patch
@@ -1,7 +1,7 @@
-From 0f5ea5430a0c6bae19c784206acd76dadf32a70d Mon Sep 17 00:00:00 2001
+From cf3e550b9dc3f897d11165ab6b5a6afa9950d622 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Fri, 27 Nov 2020 03:56:29 -0500
-Subject: [PATCH 48/78] disable component updater pings by default
+Subject: [PATCH 48/79] disable component updater pings by default
 
 ---
  .../component_updater_command_line_config_policy.h              | 2 +-
@@ -21,5 +21,5 @@ index 7c69d8ae08f14..4f94d14db5e7a 100644
  
    // If non-zero, time interval in seconds until the first component
 -- 
-2.34.1
+2.31.1
 

--- a/patches/0049-mark-non-secure-origins-as-dangerous.patch
+++ b/patches/0049-mark-non-secure-origins-as-dangerous.patch
@@ -1,7 +1,7 @@
-From d4a1fbfe0f8c8b856d4be2ba4906b757595d38f5 Mon Sep 17 00:00:00 2001
+From e6bc7bb65312a25ccd7e3299c363c793ffa133b5 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Fri, 20 Oct 2017 21:20:50 -0400
-Subject: [PATCH 49/78] mark non-secure origins as dangerous
+Subject: [PATCH 49/79] mark non-secure origins as dangerous
 
 ---
  components/security_state/core/security_state.cc | 2 +-
@@ -21,5 +21,5 @@ index fdcdf57e45abc..569dbf037bd2d 100644
      return NONE;
    }
 -- 
-2.34.1
+2.31.1
 

--- a/patches/0050-enable-strict-site-isolation-by-default-on-Android.patch
+++ b/patches/0050-enable-strict-site-isolation-by-default-on-Android.patch
@@ -1,7 +1,7 @@
-From 6465bd5bca27a9045c2c1710a6b3f5e361d1fb63 Mon Sep 17 00:00:00 2001
+From d56cbf20d1c699cded13e475065734bacb6a751e Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Thu, 2 May 2019 07:15:32 -0400
-Subject: [PATCH 50/78] enable strict site isolation by default on Android
+Subject: [PATCH 50/79] enable strict site isolation by default on Android
 
 ---
  chrome/browser/about_flags.cc    | 10 ----------
@@ -49,5 +49,5 @@ index afffbd98c5f29..b5ff357f3b31c 100644
  #if BUILDFLAG(IS_CHROMEOS_ASH)
  // Enables or disables SmartDim on Chrome OS.
 -- 
-2.34.1
+2.31.1
 

--- a/patches/0051-most-private-WebRTC-IP-handling-policy-by-default.patch
+++ b/patches/0051-most-private-WebRTC-IP-handling-policy-by-default.patch
@@ -1,7 +1,7 @@
-From fee1ff1f7c915c1059567660daf9d074110113a3 Mon Sep 17 00:00:00 2001
+From 8c6ff5abe2acc8c8683012dfae793461eeee3d12 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Thu, 21 May 2020 12:58:04 -0400
-Subject: [PATCH 51/78] most private WebRTC IP handling policy by default
+Subject: [PATCH 51/79] most private WebRTC IP handling policy by default
 
 ---
  chrome/browser/ui/browser_ui_prefs.cc | 2 +-
@@ -21,5 +21,5 @@ index 7bbd3ba5f9057..6972b26fb0634 100644
    registry->RegisterBooleanPref(prefs::kWebRtcEventLogCollectionAllowed, false);
    registry->RegisterListPref(prefs::kWebRtcLocalIpsAllowedUrls);
 -- 
-2.34.1
+2.31.1
 

--- a/patches/0052-disable-search-engine-permissions-by-default.patch
+++ b/patches/0052-disable-search-engine-permissions-by-default.patch
@@ -1,7 +1,7 @@
-From b76f2079880383236f21db712b56808620b1952c Mon Sep 17 00:00:00 2001
+From a701e29733d34bb41a90504a719dc148bc38b1b1 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Mon, 16 Aug 2021 18:59:43 -0400
-Subject: [PATCH 52/78] disable search engine permissions by default
+Subject: [PATCH 52/79] disable search engine permissions by default
 
 Disable the geolocation and notification permissions for the default
 search engine by default.
@@ -23,5 +23,5 @@ index 390de2f97e2df..47555f270a898 100644
  
  }  // namespace features
 -- 
-2.34.1
+2.31.1
 

--- a/patches/0053-stub-out-the-battery-status-API.patch
+++ b/patches/0053-stub-out-the-battery-status-API.patch
@@ -1,7 +1,7 @@
-From 9babccc29568d4f0638c2296e5f5c4ee6a6e6838 Mon Sep 17 00:00:00 2001
+From 3524d012c467feb4f1d2177e5eeec171a429eff6 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Mon, 17 Jun 2019 11:29:21 -0400
-Subject: [PATCH 53/78] stub out the battery status API
+Subject: [PATCH 53/79] stub out the battery status API
 
 Pretend that the device is always plugged in and fully charged.
 ---
@@ -64,5 +64,5 @@ index ff9a33d51dc88..7879bdb4e0c1e 100644
  
  void BatteryManager::RegisterWithDispatcher() {
 -- 
-2.34.1
+2.31.1
 

--- a/patches/0054-always-use-local-new-tab-page.patch
+++ b/patches/0054-always-use-local-new-tab-page.patch
@@ -1,7 +1,7 @@
-From 1d4d45e7ee6ef913184a6ac2644d162bbb49ba7f Mon Sep 17 00:00:00 2001
+From 931c00a57d34a394086b2545d452fe4c33202944 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Mon, 17 Jun 2019 13:14:22 -0400
-Subject: [PATCH 54/78] always use local new tab page
+Subject: [PATCH 54/79] always use local new tab page
 
 ---
  chrome/browser/search/search.cc | 2 +-
@@ -21,5 +21,5 @@ index d9f60142da3aa..d7ae98daa140a 100644
  }
  
 -- 
-2.34.1
+2.31.1
 

--- a/patches/0055-disable-search-provider-logo.patch
+++ b/patches/0055-disable-search-provider-logo.patch
@@ -1,7 +1,7 @@
-From 3a66538c4d88259dc2d80206919eca6fbe7b6f01 Mon Sep 17 00:00:00 2001
+From c01edcc2e3720de6be15406de4b8fdb9a39073aa Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Mon, 17 Jun 2019 12:03:52 -0400
-Subject: [PATCH 55/78] disable search provider logo
+Subject: [PATCH 55/79] disable search provider logo
 
 ---
  .../template_url_service_factory_android.cc   | 31 +------------------
@@ -50,5 +50,5 @@ index 67302ccc56dd1..bc5c2516368d0 100644
 +  return false;
  }
 -- 
-2.34.1
+2.31.1
 

--- a/patches/0056-stop-ignoring-download-location-prompt-setting.patch
+++ b/patches/0056-stop-ignoring-download-location-prompt-setting.patch
@@ -1,7 +1,7 @@
-From dacb9ba0e209ac20116bacecc3e5dad6f87c5e4a Mon Sep 17 00:00:00 2001
+From 0d431fb8ba027896e8efc1dd85b49c75b1091846 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Fri, 28 Jun 2019 16:56:37 -0400
-Subject: [PATCH 56/78] stop ignoring download location prompt setting
+Subject: [PATCH 56/79] stop ignoring download location prompt setting
 
 ---
  .../DownloadLocationDialogCoordinator.java        | 15 ---------------
@@ -34,5 +34,5 @@ index c8d406b43e5c2..95d2545cfbd4e 100644
          if (mDialogModel != null) return;
  
 -- 
-2.34.1
+2.31.1
 

--- a/patches/0057-show-download-prompt-again-by-default.patch
+++ b/patches/0057-show-download-prompt-again-by-default.patch
@@ -1,7 +1,7 @@
-From 4e7cf6f6c4bc957fbe0713b30cb24f3d9a81a68e Mon Sep 17 00:00:00 2001
+From 7f2e29b3f9ca2c21c075baacad65c216cc3cc61b Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Fri, 28 Jun 2019 17:48:49 -0400
-Subject: [PATCH 57/78] show download prompt again by default
+Subject: [PATCH 57/79] show download prompt again by default
 
 ---
  .../download/dialogs/DownloadLocationDialogCoordinator.java  | 5 +----
@@ -26,5 +26,5 @@ index 95d2545cfbd4e..d0af8b9291184 100644
                  DownloadLocationDialogProperties.FILE_NAME, new File(mSuggestedPath).getName());
          builder.with(DownloadLocationDialogProperties.SHOW_SUBTITLE, true);
 -- 
-2.34.1
+2.31.1
 

--- a/patches/0058-remove-data-reduction-preference.patch
+++ b/patches/0058-remove-data-reduction-preference.patch
@@ -1,7 +1,7 @@
-From 08ffa8f2f749f84b9bb9cbb51f8e4177759a8f9d Mon Sep 17 00:00:00 2001
+From 64a3ad589a605d78cf2fb1ebf9ed1f76a8210680 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Fri, 2 Aug 2019 22:06:31 -0400
-Subject: [PATCH 58/78] remove data reduction preference
+Subject: [PATCH 58/79] remove data reduction preference
 
 ---
  .../org/chromium/chrome/browser/settings/MainSettings.java    | 4 +---
@@ -23,5 +23,5 @@ index 39f3c5c3aa135..4042e0a2f404c 100644
  
      private Preference addPreferenceIfAbsent(String key) {
 -- 
-2.34.1
+2.31.1
 

--- a/patches/0059-remove-translate-offer-preference.patch
+++ b/patches/0059-remove-translate-offer-preference.patch
@@ -1,7 +1,7 @@
-From a11021b757819d4c67cda0d45bde0f8ae9a1f377 Mon Sep 17 00:00:00 2001
+From 1c2cb9f04b33e5e6f77aa22ae82a7f40ae2f049e Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Fri, 2 Aug 2019 21:11:17 -0400
-Subject: [PATCH 59/78] remove translate offer preference
+Subject: [PATCH 59/79] remove translate offer preference
 
 ---
  .../language/settings/LanguageSettings.java   | 21 +------------------
@@ -40,5 +40,5 @@ index 3dbe063ee0342..673a3e2c0e072 100644
  
      /**
 -- 
-2.34.1
+2.31.1
 

--- a/patches/0060-set-default-search-engine-to-DuckDuckGo.patch
+++ b/patches/0060-set-default-search-engine-to-DuckDuckGo.patch
@@ -1,7 +1,7 @@
-From 7c7fb45113bd8b959095ce6c1675d3db76f9b7ab Mon Sep 17 00:00:00 2001
+From a3f69e540c2883c8849d39cd118ff1e20853a863 Mon Sep 17 00:00:00 2001
 From: Zoraver Kang <zkang@wpi.edu>
 Date: Sat, 17 Aug 2019 15:53:50 -0400
-Subject: [PATCH 60/78] set default search engine to DuckDuckGo
+Subject: [PATCH 60/79] set default search engine to DuckDuckGo
 
 ---
  components/search_engines/template_url_prepopulate_data.cc | 2 +-
@@ -21,5 +21,5 @@ index d7b54c34fb780..0937ad43f0921 100644
          itr == t_urls.end() ? 0 : std::distance(t_urls.begin(), itr);
    }
 -- 
-2.34.1
+2.31.1
 

--- a/patches/0061-disable-trivial-subdomain-hiding.patch
+++ b/patches/0061-disable-trivial-subdomain-hiding.patch
@@ -1,7 +1,7 @@
-From fd318924b5b77737920902622c728f7679c74218 Mon Sep 17 00:00:00 2001
+From aeb3c3ab3ae693cd2b7a03d243b2a66c59d0573f Mon Sep 17 00:00:00 2001
 From: JTL <jtl@teamclassified.ca>
 Date: Sat, 21 Dec 2019 04:04:24 +0000
-Subject: [PATCH 61/78] disable trivial subdomain hiding
+Subject: [PATCH 61/79] disable trivial subdomain hiding
 
 ---
  components/url_formatter/url_formatter.cc | 3 +--
@@ -22,5 +22,5 @@ index 9d02e998264a9..740c98b6d7ec0 100644
                             HostComponentTransform(trim_trivial_subdomains),
                             &url_string, &new_parsed->host, adjustments);
 -- 
-2.34.1
+2.31.1
 

--- a/patches/0062-disable-learn-more-link-in-incognito-new-tab.patch
+++ b/patches/0062-disable-learn-more-link-in-incognito-new-tab.patch
@@ -1,7 +1,7 @@
-From 5a7d184da469405542209da850e84edf6895369d Mon Sep 17 00:00:00 2001
+From aaa1eadaa4a70487fe57dda94b16ab5015fe70fc Mon Sep 17 00:00:00 2001
 From: A Mak <refragable@mailbox.org>
 Date: Sat, 8 Aug 2020 11:17:59 -0700
-Subject: [PATCH 62/78] disable learn more link in incognito new tab
+Subject: [PATCH 62/79] disable learn more link in incognito new tab
 
 ---
  .../chrome/browser/ntp/LegacyIncognitoDescriptionView.java  | 6 +++---
@@ -46,5 +46,5 @@ index 92f04af2dee1f..ce3a83e6e89be 100644
  
      private boolean isNarrowScreen() {
 -- 
-2.34.1
+2.31.1
 

--- a/patches/0063-disable-Omaha-update-check-support.patch
+++ b/patches/0063-disable-Omaha-update-check-support.patch
@@ -1,7 +1,7 @@
-From 9bccf514c632b452d743b168273b1825860080ef Mon Sep 17 00:00:00 2001
+From 7f3030df2f80011208ee59229f730592a80441c4 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Wed, 18 Nov 2020 19:13:27 -0500
-Subject: [PATCH 63/78] disable Omaha update check support
+Subject: [PATCH 63/79] disable Omaha update check support
 
 ---
  .../java/src/org/chromium/chrome/browser/omaha/OmahaBase.java   | 2 +-
@@ -35,5 +35,5 @@ index 6d21fb304fdd7..2e3ee0da03312 100644
      protected VersionNumberGetter() { }
  
 -- 
-2.34.1
+2.31.1
 

--- a/patches/0064-disable-GaiaAuthFetcher-code-due-to-upstream-bug.patch
+++ b/patches/0064-disable-GaiaAuthFetcher-code-due-to-upstream-bug.patch
@@ -1,7 +1,7 @@
-From e4380d568e380a28eddf3118e5676a1517b2318f Mon Sep 17 00:00:00 2001
+From 0ad17c31d3281bfb1c7c11b9977695afc04c1d9d Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Thu, 19 Nov 2020 07:59:29 -0500
-Subject: [PATCH 64/78] disable GaiaAuthFetcher code due to upstream bug
+Subject: [PATCH 64/79] disable GaiaAuthFetcher code due to upstream bug
 
 https://bugs.chromium.org/p/chromium/issues/detail?id=1150817
 ---
@@ -39,5 +39,5 @@ index b3d30604885b3..d2cc36b1ce392 100644
  
  // static
 -- 
-2.34.1
+2.31.1
 

--- a/patches/0065-remove-safety-check-menu.patch
+++ b/patches/0065-remove-safety-check-menu.patch
@@ -1,7 +1,7 @@
-From 142f30a6570babb899b9b26791bb3890dfaba3fe Mon Sep 17 00:00:00 2001
+From 6e1f60f0c755229c832b2a60283dd70a49d52bfb Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Tue, 25 May 2021 16:43:39 -0400
-Subject: [PATCH 65/78] remove safety check menu
+Subject: [PATCH 65/79] remove safety check menu
 
 ---
  .../src/org/chromium/chrome/browser/settings/MainSettings.java  | 2 ++
@@ -21,5 +21,5 @@ index 4042e0a2f404c..90a20992b5c61 100644
              // We don't show the toolbar shortcut settings page if disabled from finch.
              // Note, we can still have the old data collection experiment running for which
 -- 
-2.34.1
+2.31.1
 

--- a/patches/0066-disable-unused-password-check-feature.patch
+++ b/patches/0066-disable-unused-password-check-feature.patch
@@ -1,7 +1,7 @@
-From ec7dc05c9343805e0f59ddd2bc894f3df1ca941c Mon Sep 17 00:00:00 2001
+From 2730cc9ab05071e6855cc430fffb4ea8838ad6c0 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Thu, 15 Apr 2021 11:33:17 -0400
-Subject: [PATCH 66/78] disable unused password check feature
+Subject: [PATCH 66/79] disable unused password check feature
 
 ---
  .../chrome/browser/password_check/PasswordCheckFactory.java  | 5 +----
@@ -24,5 +24,5 @@ index 8ecc1304ff4db..8549bc553a366 100644
  
      /**
 -- 
-2.34.1
+2.31.1
 

--- a/patches/0067-add-back-trichrome_chrome_apk-targets.patch
+++ b/patches/0067-add-back-trichrome_chrome_apk-targets.patch
@@ -1,7 +1,7 @@
-From c3ed68714d3b4cabf1b92c3078b3e747e5f7e3b1 Mon Sep 17 00:00:00 2001
+From b479045951b3d14b0451e6ad93d26a140147e99b Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Thu, 27 May 2021 07:30:02 -0400
-Subject: [PATCH 67/78] add back trichrome_chrome_apk targets
+Subject: [PATCH 67/79] add back trichrome_chrome_apk targets
 
 ---
  chrome/android/BUILD.gn | 46 ++++++++++++++++++++++++++++++++++++++++-
@@ -79,5 +79,5 @@ index 7b086be95ed42..bcf270825caa8 100644
      "$root_gen_dir/chrome_public_unit_test_apk_manifest/AndroidManifest.xml"
  chrome_public_test_apk_manifest =
 -- 
-2.34.1
+2.31.1
 

--- a/patches/0068-disable-mobile-identity-consistency-by-default.patch
+++ b/patches/0068-disable-mobile-identity-consistency-by-default.patch
@@ -1,7 +1,7 @@
-From 00bb136c2b7694a62b6e3ba6853b9be4d16f1a38 Mon Sep 17 00:00:00 2001
+From 565761527545220c59df8694291d4b6258156433 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Fri, 28 May 2021 09:08:01 -0400
-Subject: [PATCH 68/78] disable mobile identity consistency by default
+Subject: [PATCH 68/79] disable mobile identity consistency by default
 
 ---
  components/signin/public/base/account_consistency_method.cc | 2 +-
@@ -21,5 +21,5 @@ index 720a38efa01e6..e0450d6a30064 100644
  
  #if defined(OS_IOS)
 -- 
-2.34.1
+2.31.1
 

--- a/patches/0069-JIT-less-toggle.patch
+++ b/patches/0069-JIT-less-toggle.patch
@@ -1,7 +1,7 @@
-From 8aab4ae9bffb21ada77a052febc89123d0031074 Mon Sep 17 00:00:00 2001
+From 3bee989abb62ebf32329bf3a67040984341f0625 Mon Sep 17 00:00:00 2001
 From: Your Name <you@example.com>
 Date: Mon, 15 Nov 2021 11:17:06 +0000
-Subject: [PATCH 69/78] JIT-less toggle
+Subject: [PATCH 69/79] JIT-less toggle
 
 ---
  chrome/android/java/res/xml/privacy_preferences.xml  |  5 +++++
@@ -132,5 +132,5 @@ index 0c2ef1d8413ac..d601895bc9743 100644
 +    }
  }
 -- 
-2.34.1
+2.31.1
 

--- a/patches/0070-update-trichrome_library_apk-expectation-file.patch
+++ b/patches/0070-update-trichrome_library_apk-expectation-file.patch
@@ -1,7 +1,7 @@
-From dac7926db7575532ecee0c62e2b53148b2e7f89f Mon Sep 17 00:00:00 2001
+From 338d4f665626cecc089fb755d93b748e45e9ca87 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Sat, 26 Jun 2021 22:55:16 -0400
-Subject: [PATCH 70/78] update trichrome_library_apk expectation file
+Subject: [PATCH 70/79] update trichrome_library_apk expectation file
 
 ---
  .../expectations/trichrome_library_apk.AndroidManifest.expected | 2 +-
@@ -21,5 +21,5 @@ index fd2f714f62b20..2964bc65fb7d4 100644
      platformBuildVersionName="12">
    <uses-feature android:glEsVersion="0x00020000"/>
 -- 
-2.34.1
+2.31.1
 

--- a/patches/0071-disable-trials-of-privacy-aware-analytics-advertisin.patch
+++ b/patches/0071-disable-trials-of-privacy-aware-analytics-advertisin.patch
@@ -1,7 +1,7 @@
-From 04f8b6daad64126d2c570fa6f43073247b8e2601 Mon Sep 17 00:00:00 2001
+From 7e403b922e63cce09970f16f7fbb63b244c459fa Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Wed, 4 Aug 2021 03:29:04 -0400
-Subject: [PATCH 71/78] disable trials of privacy-aware analytics/advertising
+Subject: [PATCH 71/79] disable trials of privacy-aware analytics/advertising
  APIs
 
 ---
@@ -31,5 +31,5 @@ index f6094c3d70091..6df947ac2311a 100644
  }
  
 -- 
-2.34.1
+2.31.1
 

--- a/patches/0072-remove-unwanted-sync-and-services-link.patch
+++ b/patches/0072-remove-unwanted-sync-and-services-link.patch
@@ -1,7 +1,7 @@
-From 7c10c93aaa1fc64293983b741c91a73052ab4ebf Mon Sep 17 00:00:00 2001
+From a26773abbc1470a9996177ad5a810d9a10f71e99 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Sat, 7 Aug 2021 15:01:54 -0400
-Subject: [PATCH 72/78] remove unwanted sync and services link
+Subject: [PATCH 72/79] remove unwanted sync and services link
 
 ---
  .../chrome/browser/privacy/settings/PrivacySettings.java       | 3 +--
@@ -22,5 +22,5 @@ index 5b54b48ae3214..dcdeedb791fdd 100644
          updatePreferences();
      }
 -- 
-2.34.1
+2.31.1
 

--- a/patches/0073-Move-search-suggestions-back-to-privacy-section.patch
+++ b/patches/0073-Move-search-suggestions-back-to-privacy-section.patch
@@ -1,7 +1,7 @@
-From 7e39af63794f9257f8a79943313e0d2b3a3bf0e4 Mon Sep 17 00:00:00 2001
+From c3131c7f35daef883668f55bf0e009a5e8bf3b44 Mon Sep 17 00:00:00 2001
 From: fgei <fgei@gmail.com>
 Date: Fri, 20 Aug 2021 16:13:42 +0000
-Subject: [PATCH 73/78] Move search suggestions back to privacy section.
+Subject: [PATCH 73/79] Move search suggestions back to privacy section.
 
 ---
  .../java/res/xml/privacy_preferences.xml        |  5 +++++
@@ -74,5 +74,5 @@ index dcdeedb791fdd..c0d10a607cddc 100644
                  (ChromeSwitchPreference) findPreference(PREF_CAN_MAKE_PAYMENT);
          if (canMakePaymentPref != null) {
 -- 
-2.34.1
+2.31.1
 

--- a/patches/0074-remove-unwanted-account-and-services-section.patch
+++ b/patches/0074-remove-unwanted-account-and-services-section.patch
@@ -1,7 +1,7 @@
-From 8d1924f84211a0cdcf705dd27b42bb52eee2df1c Mon Sep 17 00:00:00 2001
+From 5c4f18e8f126ec17e5dccd0fa2358ed1e04a971a Mon Sep 17 00:00:00 2001
 From: fgei <fgei@gmail.com>
 Date: Fri, 20 Aug 2021 16:13:42 +0000
-Subject: [PATCH 74/78] remove unwanted account and services section
+Subject: [PATCH 74/79] remove unwanted account and services section
 
 ---
  .../src/org/chromium/chrome/browser/settings/MainSettings.java  | 2 ++
@@ -21,5 +21,5 @@ index 90a20992b5c61..3838ea6dcb2c8 100644
          new AdaptiveToolbarStatePredictor(null).recomputeUiState(uiState -> {
              // We don't show the toolbar shortcut settings page if disabled from finch.
 -- 
-2.34.1
+2.31.1
 

--- a/patches/0075-Hide-Sign-In-preference-when-disallowed.patch
+++ b/patches/0075-Hide-Sign-In-preference-when-disallowed.patch
@@ -1,7 +1,7 @@
-From 31d8531a1d14429e8c7a15da7e483b91f52f222c Mon Sep 17 00:00:00 2001
+From 59d2b82154c52ae5c772531f7497bcef1ce238b9 Mon Sep 17 00:00:00 2001
 From: fgei <fgei@gmail.com>
 Date: Sun, 29 Aug 2021 19:31:00 +0000
-Subject: [PATCH 75/78] Hide Sign In preference when disallowed
+Subject: [PATCH 75/79] Hide Sign In preference when disallowed
 
 ---
  .../chromium/chrome/browser/sync/settings/SignInPreference.java  | 1 +
@@ -20,5 +20,5 @@ index d4dc12d18d296..a9f4a19adab0f 100644
      }
  
 -- 
-2.34.1
+2.31.1
 

--- a/patches/0076-disable-using-Play-services-fonts.patch
+++ b/patches/0076-disable-using-Play-services-fonts.patch
@@ -1,7 +1,7 @@
-From dd4a5ec5dcfb059e913737a51e92fdfc956adb06 Mon Sep 17 00:00:00 2001
+From d2b643fbe24ce0bc60fe415d0ed9d09b36dce8e5 Mon Sep 17 00:00:00 2001
 From: Daniel Micay <danielmicay@gmail.com>
 Date: Wed, 1 Sep 2021 02:09:14 -0400
-Subject: [PATCH 76/78] disable using Play services fonts
+Subject: [PATCH 76/79] disable using Play services fonts
 
 ---
  .../chromium/content/browser/font/AndroidFontLookupImpl.java    | 2 +-
@@ -21,5 +21,5 @@ index 405dca87b9a6e..7b7751512eccd 100644
                  // Avoid re-requesting this font in future.
                  mExpectedFonts.remove(fontUniqueName);
 -- 
-2.34.1
+2.31.1
 

--- a/patches/0077-Remove-privacy-trials-preference.patch
+++ b/patches/0077-Remove-privacy-trials-preference.patch
@@ -1,7 +1,7 @@
-From 4f0213007e8ec75a0529ade3659b63bbacd59fa1 Mon Sep 17 00:00:00 2001
+From 4d70380a57edc0940f423d3142b0344964bb5eea Mon Sep 17 00:00:00 2001
 From: fgei <fgei@gmail.com>
 Date: Fri, 15 Oct 2021 13:49:33 +0000
-Subject: [PATCH 77/78] Remove privacy trials preference
+Subject: [PATCH 77/79] Remove privacy trials preference
 
 ---
  .../chrome/browser/privacy/settings/PrivacySettings.java        | 2 ++
@@ -21,5 +21,5 @@ index c0d10a607cddc..dad9f2d25ddbd 100644
          safeBrowsingPreference.setSummary(
                  SafeBrowsingSettingsFragment.getSafeBrowsingSummaryString(getContext()));
 -- 
-2.34.1
+2.31.1
 

--- a/patches/0078-Disable-Play-services-FIDO2-unconditionally.patch
+++ b/patches/0078-Disable-Play-services-FIDO2-unconditionally.patch
@@ -1,7 +1,7 @@
-From 13e008b33cf8f186986a34cd4aa86ac2f4261739 Mon Sep 17 00:00:00 2001
+From 7009bf418a34048880966c4a35cdc6ce8f008cf4 Mon Sep 17 00:00:00 2001
 From: Your Name <you@example.com>
 Date: Thu, 4 Nov 2021 12:31:05 +0000
-Subject: [PATCH 78/78] Disable Play services' FIDO2 unconditionally
+Subject: [PATCH 78/79] Disable Play services' FIDO2 unconditionally
 
 This is needed for the time being due to this code being broken with the
 current Chromium and AOSP 12.
@@ -36,5 +36,5 @@ index b309a2de64f36..f3d4397849e89 100644
  
      // Handles a PendingIntent from the GMSCore Fido library.
 -- 
-2.34.1
+2.31.1
 

--- a/patches/0079-use-Google-Chrome-branding-for-client-hints.patch
+++ b/patches/0079-use-Google-Chrome-branding-for-client-hints.patch
@@ -1,0 +1,24 @@
+From 22c397f84047dd69b7180ff3b5dcdfa0c5324aea Mon Sep 17 00:00:00 2001
+From: Zoraver Kang <Zoraver@users.noreply.github.com>
+Date: Sun, 10 Oct 2021 21:59:16 -0400
+Subject: [PATCH 79/79] use Google Chrome branding for client hints
+
+---
+ components/embedder_support/user_agent_utils.cc | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/components/embedder_support/user_agent_utils.cc b/components/embedder_support/user_agent_utils.cc
+index da052d0533802..eb0ad313387cd 100644
+--- a/components/embedder_support/user_agent_utils.cc
++++ b/components/embedder_support/user_agent_utils.cc
+@@ -136,6 +136,7 @@ const blink::UserAgentBrandList GetUserAgentBrandList(
+   int major_version_number;
+   base::StringToInt(major_version, &major_version_number);
+   absl::optional<std::string> brand;
++  brand = "Google Chrome";
+ #if !BUILDFLAG(CHROMIUM_BRANDING)
+   brand = version_info::GetProductName();
+ #endif
+-- 
+2.31.1
+


### PR DESCRIPTION
Addresses #119 and replaces #123. Tested using <https://browserleaks.com/client-hints>.

Before:

| Name | Value |
| ----- | ----- |
| Sec-CH-UA | `" Not A;Brand";v="99","Chromium";v="96"` |
| brands | `[{"brand":" Not A;Brand","version":"99"},{"brand":"Chromium","version":"96"}]` |

After:

| Name | Value |
| ----- | ----- |
| Sec-CH-UA | `" Not A;Brand";v="99",Chromium";v="96","Google Chrome";v="96"` |
| brands | `[{"brand":" Not A;Brand","version":"99"},{"brand":"Chromium","version":"96"},{"brand":"Google Chrome","version":"96"}]` |