### PR TITLE
Handle web search action in browser

### DIFF
--- a/patches/0088-Handle-web-search-action-in-browser.patch
+++ b/patches/0088-Handle-web-search-action-in-browser.patch
@@ -1,0 +1,73 @@
+From 2e1bb79f06436b6d41870141f15530324e19dadd Mon Sep 17 00:00:00 2001
+From: quh4gko8 <88831734+quh4gko8@users.noreply.github.com>
+Date: Tue, 12 Jul 2022 11:16:46 +0000
+Subject: [PATCH] Handle web search action in browser
+
+---
+ .../java/src/org/chromium/base/PackageManagerUtils.java  | 9 +++++++++
+ chrome/android/java/AndroidManifest.xml                  | 4 ++++
+ .../src/org/chromium/chrome/browser/IntentHandler.java   | 1 +
+ .../chromium/chrome/browser/LaunchIntentDispatcher.java  | 3 ++-
+ 4 files changed, 16 insertions(+), 1 deletion(-)
+
+diff --git a/base/android/java/src/org/chromium/base/PackageManagerUtils.java b/base/android/java/src/org/chromium/base/PackageManagerUtils.java
+index 7aa7921e6ec3f..ce223c58ca979 100644
+--- a/base/android/java/src/org/chromium/base/PackageManagerUtils.java
++++ b/base/android/java/src/org/chromium/base/PackageManagerUtils.java
+@@ -27,6 +27,15 @@ public class PackageManagerUtils {
+                                                         .addCategory(Intent.CATEGORY_BROWSABLE)
+                                                         .setData(Uri.fromParts("http", "", null));
+ 
++    public static boolean canSelfHandleIntentActivities(Intent intent) {
++        for (ResolveInfo ri: queryIntentActivities(intent, PackageManager.GET_RESOLVED_FILTER)) {
++            if (ContextUtils.getApplicationContext()
++                    .getPackageName().equals(ri.activityInfo.packageName)) {
++                return true;
++            }
++        }
++        return false;
++    }
+     /**
+      * Retrieve information about the Activity that will handle the given Intent.
+      *
+diff --git a/chrome/android/java/AndroidManifest.xml b/chrome/android/java/AndroidManifest.xml
+index 15c4f76eff3d7..dcff907aef1f2 100644
+--- a/chrome/android/java/AndroidManifest.xml
++++ b/chrome/android/java/AndroidManifest.xml
+@@ -324,6 +324,10 @@ by a child template that "extends" this file.
+             <intent-filter>
+                 <action android:name="android.intent.action.SEARCH" />
+             </intent-filter>
++            <intent-filter>  # DOWNSTREAM
++              <action android:name="android.intent.action.WEB_SEARCH"/>
++              <category android:name="android.intent.category.DEFAULT" />
++            </intent-filter>  # DOWNSTREAM
+             <intent-filter>
+                 <action android:name="com.sec.android.airview.HOVER" />
+             </intent-filter>
+diff --git a/chrome/android/java/src/org/chromium/chrome/browser/IntentHandler.java b/chrome/android/java/src/org/chromium/chrome/browser/IntentHandler.java
+index 544a555fe895c..477573460b46e 100644
+--- a/chrome/android/java/src/org/chromium/chrome/browser/IntentHandler.java
++++ b/chrome/android/java/src/org/chromium/chrome/browser/IntentHandler.java
+@@ -738,6 +738,7 @@ public class IntentHandler {
+         String query = null;
+         final String action = intent.getAction();
+         if (Intent.ACTION_SEARCH.equals(action)
++                || Intent.ACTION_WEB_SEARCH.equals(action)
+                 || MediaStore.INTENT_ACTION_MEDIA_SEARCH.equals(action)) {
+             query = IntentUtils.safeGetStringExtra(intent, SearchManager.QUERY);
+         }
+diff --git a/chrome/android/java/src/org/chromium/chrome/browser/LaunchIntentDispatcher.java b/chrome/android/java/src/org/chromium/chrome/browser/LaunchIntentDispatcher.java
+index 0e8f7c46e4d65..30663e58b6146 100644
+--- a/chrome/android/java/src/org/chromium/chrome/browser/LaunchIntentDispatcher.java
++++ b/chrome/android/java/src/org/chromium/chrome/browser/LaunchIntentDispatcher.java
+@@ -207,7 +207,8 @@ public class LaunchIntentDispatcher implements IntentHandler.IntentHandlerDelega
+                     PackageManagerUtils
+                             .queryIntentActivities(searchIntent, PackageManager.GET_RESOLVED_FILTER)
+                             .size();
+-            if (resolvers == 0) {
++            if (resolvers == 0
++                    || PackageManagerUtils.canSelfHandleIntentActivities(searchIntent)) {
+                 // Phone doesn't have a WEB_SEARCH action handler, open Search Activity with
+                 // the given query.
+                 Intent searchActivityIntent = new Intent(Intent.ACTION_MAIN);

--- a/patches/0089-Support-opening-external-web-search-in-incognito.patch
+++ b/patches/0089-Support-opening-external-web-search-in-incognito.patch
@@ -1,0 +1,47 @@
+From dbb2f439c324b2a5ae775abc84907bc52fa2a0bf Mon Sep 17 00:00:00 2001
+From: fgei <fgei@gmail.com>
+Date: Sat, 3 Sep 2022 08:15:59 +0200
+Subject: [PATCH] Support opening external web search in incognito
+
+---
+ .../chrome/browser/searchwidget/SearchActivity.java       | 8 ++++++++
+ 1 file changed, 8 insertions(+)
+
+diff --git a/chrome/android/java/src/org/chromium/chrome/browser/searchwidget/SearchActivity.java b/chrome/android/java/src/org/chromium/chrome/browser/searchwidget/SearchActivity.java
+index 0dc357fefe4e0..1d5fb516fb03f 100644
+--- a/chrome/android/java/src/org/chromium/chrome/browser/searchwidget/SearchActivity.java
++++ b/chrome/android/java/src/org/chromium/chrome/browser/searchwidget/SearchActivity.java
+@@ -4,11 +4,14 @@
+ 
+ package org.chromium.chrome.browser.searchwidget;
+ 
++import static org.chromium.chrome.browser.preferences.ChromePreferenceKeys.PREF_OPEN_LINKS_IN_INCOGNITO;
++
+ import android.app.Activity;
+ import android.app.SearchManager;
+ import android.content.Intent;
+ import android.graphics.Rect;
+ import android.net.Uri;
++import android.provider.Browser;
+ import android.text.TextUtils;
+ import android.view.LayoutInflater;
+ import android.view.View;
+@@ -45,6 +48,7 @@ import org.chromium.chrome.browser.omnibox.OverrideUrlLoadingDelegate;
+ import org.chromium.chrome.browser.omnibox.SearchEngineLogoUtils;
+ import org.chromium.chrome.browser.omnibox.UrlFocusChangeListener;
+ import org.chromium.chrome.browser.omnibox.voice.VoiceRecognitionHandler;
++import org.chromium.chrome.browser.preferences.SharedPreferencesManager;
+ import org.chromium.chrome.browser.privacy.settings.PrivacyPreferencesManagerImpl;
+ import org.chromium.chrome.browser.profiles.Profile;
+ import org.chromium.chrome.browser.tab.Tab;
+@@ -486,6 +490,10 @@ public class SearchActivity extends AsyncInitializationActivity
+         }
+         if (isFromSearchWidget()) {
+             intent.putExtra(SearchWidgetProvider.EXTRA_FROM_SEARCH_WIDGET, true);
++        } else if (SharedPreferencesManager.getInstance().readBoolean(PREF_OPEN_LINKS_IN_INCOGNITO, false)) {
++            intent.putExtra(IntentHandler.EXTRA_OPEN_NEW_INCOGNITO_TAB, true);
++            intent.putExtra(Browser.EXTRA_APPLICATION_ID, getPackageName());
++            intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+         }
+         intent.putExtra(EXTRA_FROM_SEARCH_ACTIVITY, true);
+         IntentUtils.addTrustedIntentExtras(intent);


### PR DESCRIPTION
Use existing handling to redirect to its own SearchActivity if opened by external app.

Update: will need to replace the PackageManager API usage with its API 33 variant