### PR TITLE
[UNTESTED] Update to 103.0.5060.129

### DIFF
--- a/args.gn
+++ b/args.gn
@@ -3,8 +3,8 @@ target_os = "android"
 target_cpu = "arm64"
 
 android_channel = "stable"
-android_default_version_name = "103.0.5060.71"
-android_default_version_code = "506007100"
+android_default_version_name = "103.0.5060.129"
+android_default_version_code = "506012900"
 
 is_component_build = false
 is_debug = false


### PR DESCRIPTION
Changes in string rebranding patch is needed to apply the patches cleanly. See the following diff:
https://chromium.googlesource.com/chromium/src/+/refs/tags/103.0.5060.71..103.0.5060.129
