### PR TITLE
BACKPORT: Fix for External Favicon Links Leak

### DIFF
--- a/patches/0088-Cross-Origin-Favicons-1-Cache-browser-test.patch
+++ b/patches/0088-Cross-Origin-Favicons-1-Cache-browser-test.patch
@@ -1,0 +1,113 @@
+From 06cf2e06386a29906f069f3328becf446b7d5172 Mon Sep 17 00:00:00 2001
+From: Ari Chivukula <arichiv@chromium.org>
+Date: Wed, 10 Aug 2022 22:19:28 +0000
+Subject: [PATCH] [Cross-Origin Favicons] (1) Cache browser test
+
+Currently, if a.com is loaded and has a favicon at a.com/icon.png and
+then b.com is loaded and has the exact same favicon, the cache entry is
+shared which permits b.com to notice that a.com was visited. The end
+goal of this task is to prevent cross-origin cache leaks.
+
+This CL adds a test so that (when this is blocked in the future) we can
+detect the fix.
+
+This CL is part of a series:
+(1) Cache browser test
+(2) Add new cache check function
+(3) Stop cross-origin cache hits
+
+Bug: 1300214
+Change-Id: I92c930d127648d3a3eca226ff7b58951657f4a6f
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/3820104
+Reviewed-by: Scott Violet <sky@chromium.org>
+Auto-Submit: Ari Chivukula <arichiv@chromium.org>
+Commit-Queue: Ari Chivukula <arichiv@chromium.org>
+Cr-Commit-Position: refs/heads/main@{#1033741}
+---
+ .../content_favicon_driver_browsertest.cc     | 76 +++++++++++++++++++
+ 1 file changed, 76 insertions(+)
+
+diff --git a/chrome/browser/favicon/content_favicon_driver_browsertest.cc b/chrome/browser/favicon/content_favicon_driver_browsertest.cc
+index 64aca7b3b53ff..d1abc154f787b 100644
+--- a/chrome/browser/favicon/content_favicon_driver_browsertest.cc
++++ b/chrome/browser/favicon/content_favicon_driver_browsertest.cc
+@@ -1114,3 +1114,79 @@ IN_PROC_BROWSER_TEST_F(ContentFaviconDriverTest,
+   ASSERT_TRUE(url_loader_interceptor.was_loaded(icon_url));
+   url_loader_interceptor.Reset();
+ }
++
++// TODO(crbug.com/1300214): Different origins should not share the same cache.
++// Test that different origins share the underlying favicon cache over http.
++IN_PROC_BROWSER_TEST_F(ContentFaviconDriverTest, CrossOriginCacheHTTP) {
++  ASSERT_TRUE(embedded_test_server()->Start());
++  TestURLLoaderInterceptor url_loader_interceptor;
++  GURL icon_url = embedded_test_server()->GetURL("a.com", "/favicon/icon.png");
++  GURL url_a = embedded_test_server()->GetURL(
++      "a.com", "/favicon/page_with_favicon_by_url.html?url=" + icon_url.spec());
++  GURL url_b = embedded_test_server()->GetURL(
++      "b.com", "/favicon/page_with_favicon_by_url.html?url=" + icon_url.spec());
++
++  // Initial visit to a.com in order to populate the cache.
++  {
++    PendingTaskWaiter waiter(web_contents());
++    ui_test_utils::NavigateToURLWithDisposition(
++        browser(), url_a, WindowOpenDisposition::CURRENT_TAB,
++        ui_test_utils::BROWSER_TEST_WAIT_FOR_LOAD_STOP);
++    waiter.Wait();
++  }
++  EXPECT_TRUE(url_loader_interceptor.was_loaded(icon_url));
++  EXPECT_FALSE(url_loader_interceptor.did_bypass_cache(icon_url));
++  EXPECT_EQ(network::mojom::RequestDestination::kImage,
++            url_loader_interceptor.destination(icon_url));
++  url_loader_interceptor.Reset();
++
++  // Initial visit to b.com should reuse the existing cache.
++  {
++    PendingTaskWaiter waiter(web_contents());
++    ui_test_utils::NavigateToURLWithDisposition(
++        browser(), url_b, WindowOpenDisposition::CURRENT_TAB,
++        ui_test_utils::BROWSER_TEST_WAIT_FOR_LOAD_STOP);
++    waiter.Wait();
++  }
++  EXPECT_FALSE(url_loader_interceptor.was_loaded(icon_url));
++  EXPECT_FALSE(url_loader_interceptor.did_bypass_cache(icon_url));
++}
++
++// TODO(crbug.com/1300214): Different origins should not share the same cache.
++// Test that different origins share the underlying favicon cache over https.
++IN_PROC_BROWSER_TEST_F(ContentFaviconDriverTest, CrossOriginCacheHTTPS) {
++  net::EmbeddedTestServer ssl_server(net::EmbeddedTestServer::TYPE_HTTPS);
++  ssl_server.AddDefaultHandlers(GetChromeTestDataDir());
++  ASSERT_TRUE(ssl_server.Start());
++  TestURLLoaderInterceptor url_loader_interceptor;
++  GURL icon_url = ssl_server.GetURL("a.com", "/favicon/icon.png");
++  GURL url_a = ssl_server.GetURL(
++      "a.com", "/favicon/page_with_favicon_by_url.html?url=" + icon_url.spec());
++  GURL url_b = ssl_server.GetURL(
++      "b.com", "/favicon/page_with_favicon_by_url.html?url=" + icon_url.spec());
++
++  // Initial visit to a.com in order to populate the cache.
++  {
++    PendingTaskWaiter waiter(web_contents());
++    ui_test_utils::NavigateToURLWithDisposition(
++        browser(), url_a, WindowOpenDisposition::CURRENT_TAB,
++        ui_test_utils::BROWSER_TEST_WAIT_FOR_LOAD_STOP);
++    waiter.Wait();
++  }
++  EXPECT_TRUE(url_loader_interceptor.was_loaded(icon_url));
++  EXPECT_FALSE(url_loader_interceptor.did_bypass_cache(icon_url));
++  EXPECT_EQ(network::mojom::RequestDestination::kImage,
++            url_loader_interceptor.destination(icon_url));
++  url_loader_interceptor.Reset();
++
++  // Initial visit to b.com should reuse the existing cache.
++  {
++    PendingTaskWaiter waiter(web_contents());
++    ui_test_utils::NavigateToURLWithDisposition(
++        browser(), url_b, WindowOpenDisposition::CURRENT_TAB,
++        ui_test_utils::BROWSER_TEST_WAIT_FOR_LOAD_STOP);
++    waiter.Wait();
++  }
++  EXPECT_FALSE(url_loader_interceptor.was_loaded(icon_url));
++  EXPECT_FALSE(url_loader_interceptor.did_bypass_cache(icon_url));
++}

--- a/patches/0089-Cross-Origin-Favicons-2-Add-new-cache-check-function.patch
+++ b/patches/0089-Cross-Origin-Favicons-2-Add-new-cache-check-function.patch
@@ -1,0 +1,191 @@
+From b06d8345eb70fe7f80c2cab19c21a087e101cb17 Mon Sep 17 00:00:00 2001
+From: Ari Chivukula <arichiv@chromium.org>
+Date: Wed, 10 Aug 2022 23:41:51 +0000
+Subject: [PATCH] [Cross-Origin Favicons] (2) Add new cache check function
+
+Currently, if a.com is loaded and has a favicon at a.com/icon.png and
+then b.com is loaded and has the exact same favicon, the cache entry is
+shared which permits b.com to notice that a.com was visited. The end
+goal of this task is to prevent cross-origin cache leaks.
+
+This CL adds a new variant of GetFaviconIDForFaviconURL that filters
+results by page origin. This will be used in UpdateFaviconMappingsAndFetch
+in the next CL, but is just tested here.
+
+This CL is part of a series:
+(1) Cache browser test
+(2) Add new cache check function
+(3) Stop cross-origin cache hits
+
+Bug: 1300214
+Change-Id: Ic1513c63f0a09a32e3316d3569f0719990be833b
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/3822854
+Reviewed-by: Scott Violet <sky@chromium.org>
+Auto-Submit: Ari Chivukula <arichiv@chromium.org>
+Commit-Queue: Ari Chivukula <arichiv@chromium.org>
+Cr-Commit-Position: refs/heads/main@{#1033779}
+---
+ components/favicon/core/favicon_database.cc   | 27 +++++++++
+ components/favicon/core/favicon_database.h    | 20 ++++++-
+ .../favicon/core/favicon_database_unittest.cc | 60 +++++++++++++++++++
+ 3 files changed, 104 insertions(+), 3 deletions(-)
+
+diff --git a/components/favicon/core/favicon_database.cc b/components/favicon/core/favicon_database.cc
+index a8f5b1b801c15..aab95fb9cb344 100644
+--- a/components/favicon/core/favicon_database.cc
++++ b/components/favicon/core/favicon_database.cc
+@@ -29,6 +29,7 @@
+ #include "sql/statement.h"
+ #include "sql/transaction.h"
+ #include "third_party/sqlite/sqlite3.h"
++#include "url/origin.h"
+ 
+ #if BUILDFLAG(IS_APPLE)
+ #include "base/mac/backup_util.h"
+@@ -664,6 +665,32 @@ bool FaviconDatabase::GetFaviconLastUpdatedTime(favicon_base::FaviconID icon_id,
+   return true;
+ }
+ 
++favicon_base::FaviconID FaviconDatabase::GetFaviconIDForFaviconURL(
++    const GURL& icon_url,
++    favicon_base::IconType icon_type,
++    const url::Origin& page_origin) {
++  // Look to see if there even is any relevant cached entry.
++  auto const icon_id = GetFaviconIDForFaviconURL(icon_url, icon_type);
++  if (!icon_id) {
++    return icon_id;
++  }
++
++  // Check existing mappings to see if any are for the same origin.
++  sql::Statement statement(db_.GetCachedStatement(
++      SQL_FROM_HERE, "SELECT page_url FROM icon_mapping WHERE icon_id=?"));
++  statement.BindInt64(0, icon_id);
++  while (statement.Step()) {
++    const auto candidate_origin =
++        url::Origin::Create(GURL(statement.ColumnString(0)));
++    if (candidate_origin == page_origin) {
++      return icon_id;
++    }
++  }
++
++  // Act as if there is no entry in the cache if no mapping exists.
++  return 0;
++}
++
+ favicon_base::FaviconID FaviconDatabase::GetFaviconIDForFaviconURL(
+     const GURL& icon_url,
+     favicon_base::IconType icon_type) {
+diff --git a/components/favicon/core/favicon_database.h b/components/favicon/core/favicon_database.h
+index 07a0ca1e9c1ee..49363073a894b 100644
+--- a/components/favicon/core/favicon_database.h
++++ b/components/favicon/core/favicon_database.h
+@@ -22,6 +22,10 @@ class RefCountedMemory;
+ class Time;
+ }  // namespace base
+ 
++namespace url {
++class Origin;
++}  // namespace url
++
+ namespace favicon {
+ 
+ // The minimum number of days after which last_requested field gets updated.
+@@ -146,9 +150,19 @@ class FaviconDatabase {
+   // Returns true if successful.
+   bool TouchOnDemandFavicon(const GURL& icon_url, base::Time time);
+ 
+-  // Returns the id of the entry in the favicon database with the specified url
+-  // and icon type.
+-  // Returns 0 if no entry exists for the specified url.
++  // Returns the id of the entry in the favicon database with the specified
++  // `icon_url` and `icon_type` that has an existing mapping to `page_origin`
++  // (and 0 if no entry exists). See crbug.com/1300214 for more context.
++  favicon_base::FaviconID GetFaviconIDForFaviconURL(
++      const GURL& icon_url,
++      favicon_base::IconType icon_type,
++      const url::Origin& page_origin);
++
++  // Returns the id of the entry in the favicon database with the specified
++  // `icon_url` and `icon_type` (and 0 if no entry exists). This function does
++  // not respect cross-origin partitioning and returns an entry from the cache
++  // without verifying it was stored for the origin requesting it. This can leak
++  // navigation history, see crbug.com/1300214 for more context.
+   favicon_base::FaviconID GetFaviconIDForFaviconURL(
+       const GURL& icon_url,
+       favicon_base::IconType icon_type);
+diff --git a/components/favicon/core/favicon_database_unittest.cc b/components/favicon/core/favicon_database_unittest.cc
+index 4dd1041d58c3a..6fad0ed9f0cf6 100644
+--- a/components/favicon/core/favicon_database_unittest.cc
++++ b/components/favicon/core/favicon_database_unittest.cc
+@@ -25,6 +25,7 @@
+ #include "testing/gtest/include/gtest/gtest.h"
+ #include "third_party/sqlite/sqlite3.h"
+ #include "url/gurl.h"
++#include "url/origin.h"
+ 
+ using testing::AllOf;
+ using testing::ElementsAre;
+@@ -1447,4 +1448,63 @@ TEST_F(FaviconDatabaseTest, SetFaviconsOutOfDateBetween) {
+   EXPECT_EQ(base::Time(), GetLastUpdated(&db, icon3));
+ }
+ 
++// Test that GetFaviconIDForFaviconURL can filter by origin.
++TEST_F(FaviconDatabaseTest, GetFaviconIDForFaviconURLOriginFilter) {
++  // Setup DB with `kPageUrl1` mapped to `kIconUrl1`.
++  FaviconDatabase db;
++  ASSERT_EQ(sql::INIT_OK, db.Init(file_name_));
++  db.BeginTransaction();
++  scoped_refptr<base::RefCountedStaticMemory> favicon1(
++      new base::RefCountedStaticMemory(kBlob1, sizeof(kBlob1)));
++  const auto icon_id = db.AddFavicon(
++      kIconUrl1, favicon_base::IconType::kFavicon, favicon1,
++      FaviconBitmapType::ON_VISIT, base::Time::Now(), gfx::Size());
++  db.AddIconMapping(kPageUrl1, icon_id);
++  ASSERT_NE(0, icon_id);
++
++  // We should be able to find the `icon_id` via the non-filtered function.
++  auto icon_id_found =
++      db.GetFaviconIDForFaviconURL(kIconUrl1, favicon_base::IconType::kFavicon);
++  ASSERT_EQ(icon_id, icon_id_found);
++
++  // We should be able to find the `icon_id` via a the origin of `kPageUrl1`.
++  icon_id_found =
++      db.GetFaviconIDForFaviconURL(kIconUrl1, favicon_base::IconType::kFavicon,
++                                   url::Origin::Create(kPageUrl1));
++  ASSERT_EQ(icon_id, icon_id_found);
++
++  // We shouldn't be able to find the `icon_id` via a the origin of `kPageUrl2`.
++  icon_id_found =
++      db.GetFaviconIDForFaviconURL(kIconUrl1, favicon_base::IconType::kFavicon,
++                                   url::Origin::Create(kPageUrl2));
++  ASSERT_EQ(0, icon_id_found);
++
++  // We shouldn't be able to find the `icon_id` via a the origin of `kPageUrl3`.
++  icon_id_found =
++      db.GetFaviconIDForFaviconURL(kIconUrl1, favicon_base::IconType::kFavicon,
++                                   url::Origin::Create(kPageUrl3));
++  ASSERT_EQ(0, icon_id_found);
++
++  // If we map `kPageUrl2` then the situation changes.
++  db.AddIconMapping(kPageUrl2, icon_id);
++
++  // We should be able to find the `icon_id` via a the origin of `kPageUrl1`.
++  icon_id_found =
++      db.GetFaviconIDForFaviconURL(kIconUrl1, favicon_base::IconType::kFavicon,
++                                   url::Origin::Create(kPageUrl1));
++  ASSERT_EQ(icon_id, icon_id_found);
++
++  // We should be able to find the `icon_id` via a the origin of `kPageUrl2`.
++  icon_id_found =
++      db.GetFaviconIDForFaviconURL(kIconUrl1, favicon_base::IconType::kFavicon,
++                                   url::Origin::Create(kPageUrl2));
++  ASSERT_EQ(icon_id, icon_id_found);
++
++  // We shouldn't be able to find the `icon_id` via a the origin of `kPageUrl3`.
++  icon_id_found =
++      db.GetFaviconIDForFaviconURL(kIconUrl1, favicon_base::IconType::kFavicon,
++                                   url::Origin::Create(kPageUrl3));
++  ASSERT_EQ(0, icon_id_found);
++}
++
+ }  // namespace favicon

--- a/patches/0090-Cross-Origin-Favicons-3-Stop-cross-origin-cache-hits.patch
+++ b/patches/0090-Cross-Origin-Favicons-3-Stop-cross-origin-cache-hits.patch
@@ -1,0 +1,179 @@
+From 6c407f9ee3fed64f94032bff9ae32916132c5b66 Mon Sep 17 00:00:00 2001
+From: Ari Chivukula <arichiv@chromium.org>
+Date: Thu, 11 Aug 2022 00:39:04 +0000
+Subject: [PATCH] [Cross-Origin Favicons] (3) Stop cross-origin cache hits
+
+Currently, if a.com is loaded and has a favicon at a.com/icon.png and
+then b.com is loaded and has the exact same favicon, the cache entry is
+shared which permits b.com to notice that a.com was visited. The end
+goal of this task is to prevent cross-origin cache leaks.
+
+This CL integrates the new variant of GetFaviconIDForFaviconURL into
+UpdateFaviconMappingsAndFetch so that we filter the results per-pageurl
+based on the origin. This should fully resolve the task, although the db
+itself isn't fully partitioned.
+
+This CL is part of a series:
+(1) Cache browser test
+(2) Add new cache check function
+(3) Stop cross-origin cache hits
+
+Bug: 1300214
+Change-Id: I9bf04982abea136a00e2b5252726a1cdef8e8550
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/3822882
+Reviewed-by: Scott Violet <sky@chromium.org>
+Auto-Submit: Ari Chivukula <arichiv@chromium.org>
+Commit-Queue: Ari Chivukula <arichiv@chromium.org>
+Cr-Commit-Position: refs/heads/main@{#1033798}
+---
+ .../content_favicon_driver_browsertest.cc     | 10 +++----
+ components/favicon/core/favicon_backend.cc    | 24 +++++++++++----
+ .../favicon/core/favicon_backend_unittest.cc  | 29 ++++++++++++++++++-
+ 3 files changed, 50 insertions(+), 13 deletions(-)
+
+diff --git a/chrome/browser/favicon/content_favicon_driver_browsertest.cc b/chrome/browser/favicon/content_favicon_driver_browsertest.cc
+index d1abc154f787b..9ac168b98ae81 100644
+--- a/chrome/browser/favicon/content_favicon_driver_browsertest.cc
++++ b/chrome/browser/favicon/content_favicon_driver_browsertest.cc
+@@ -1115,7 +1115,6 @@ IN_PROC_BROWSER_TEST_F(ContentFaviconDriverTest,
+   url_loader_interceptor.Reset();
+ }
+ 
+-// TODO(crbug.com/1300214): Different origins should not share the same cache.
+ // Test that different origins share the underlying favicon cache over http.
+ IN_PROC_BROWSER_TEST_F(ContentFaviconDriverTest, CrossOriginCacheHTTP) {
+   ASSERT_TRUE(embedded_test_server()->Start());
+@@ -1140,7 +1139,7 @@ IN_PROC_BROWSER_TEST_F(ContentFaviconDriverTest, CrossOriginCacheHTTP) {
+             url_loader_interceptor.destination(icon_url));
+   url_loader_interceptor.Reset();
+ 
+-  // Initial visit to b.com should reuse the existing cache.
++  // Initial visit to b.com shouldn't reuse the existing cache.
+   {
+     PendingTaskWaiter waiter(web_contents());
+     ui_test_utils::NavigateToURLWithDisposition(
+@@ -1148,11 +1147,10 @@ IN_PROC_BROWSER_TEST_F(ContentFaviconDriverTest, CrossOriginCacheHTTP) {
+         ui_test_utils::BROWSER_TEST_WAIT_FOR_LOAD_STOP);
+     waiter.Wait();
+   }
+-  EXPECT_FALSE(url_loader_interceptor.was_loaded(icon_url));
++  EXPECT_TRUE(url_loader_interceptor.was_loaded(icon_url));
+   EXPECT_FALSE(url_loader_interceptor.did_bypass_cache(icon_url));
+ }
+ 
+-// TODO(crbug.com/1300214): Different origins should not share the same cache.
+ // Test that different origins share the underlying favicon cache over https.
+ IN_PROC_BROWSER_TEST_F(ContentFaviconDriverTest, CrossOriginCacheHTTPS) {
+   net::EmbeddedTestServer ssl_server(net::EmbeddedTestServer::TYPE_HTTPS);
+@@ -1179,7 +1177,7 @@ IN_PROC_BROWSER_TEST_F(ContentFaviconDriverTest, CrossOriginCacheHTTPS) {
+             url_loader_interceptor.destination(icon_url));
+   url_loader_interceptor.Reset();
+ 
+-  // Initial visit to b.com should reuse the existing cache.
++  // Initial visit to b.com shouldn't reuse the existing cache.
+   {
+     PendingTaskWaiter waiter(web_contents());
+     ui_test_utils::NavigateToURLWithDisposition(
+@@ -1187,6 +1185,6 @@ IN_PROC_BROWSER_TEST_F(ContentFaviconDriverTest, CrossOriginCacheHTTPS) {
+         ui_test_utils::BROWSER_TEST_WAIT_FOR_LOAD_STOP);
+     waiter.Wait();
+   }
+-  EXPECT_FALSE(url_loader_interceptor.was_loaded(icon_url));
++  EXPECT_TRUE(url_loader_interceptor.was_loaded(icon_url));
+   EXPECT_FALSE(url_loader_interceptor.did_bypass_cache(icon_url));
+ }
+diff --git a/components/favicon/core/favicon_backend.cc b/components/favicon/core/favicon_backend.cc
+index 118132b66b575..5e8dec2adc2b1 100644
+--- a/components/favicon/core/favicon_backend.cc
++++ b/components/favicon/core/favicon_backend.cc
+@@ -17,6 +17,7 @@
+ #include "components/favicon_base/select_favicon_frames.h"
+ #include "third_party/skia/include/core/SkBitmap.h"
+ #include "ui/gfx/codec/png_codec.h"
++#include "url/origin.h"
+ 
+ namespace favicon {
+ 
+@@ -211,20 +212,31 @@ UpdateFaviconMappingsResult FaviconBackend::UpdateFaviconMappingsAndFetch(
+     favicon_base::IconType icon_type,
+     const std::vector<int>& desired_sizes) {
+   UpdateFaviconMappingsResult result;
+-  const favicon_base::FaviconID favicon_id =
+-      db_->GetFaviconIDForFaviconURL(icon_url, icon_type);
++  const auto favicon_id = db_->GetFaviconIDForFaviconURL(icon_url, icon_type);
+   if (!favicon_id)
+     return result;
++  bool per_origin_favicon_id_found = false;
+ 
+   for (const GURL& page_url : page_urls) {
+-    bool mappings_updated =
+-        SetFaviconMappingsForPageAndRedirects(page_url, icon_type, favicon_id);
++    // We check per-origin so that we don't cross-origin load from the cache.
++    // See crbug.com/1300214 for more context.
++    const auto per_origin_favicon_id = db_->GetFaviconIDForFaviconURL(
++        icon_url, icon_type, url::Origin::Create(page_url));
++    if (!per_origin_favicon_id)
++      continue;
++    per_origin_favicon_id_found = true;
++    bool mappings_updated = SetFaviconMappingsForPageAndRedirects(
++        page_url, icon_type, per_origin_favicon_id);
+     if (mappings_updated)
+       result.updated_page_urls.insert(page_url);
+   }
+ 
+-  result.bitmap_results =
+-      GetFaviconBitmapResultsForBestMatch({favicon_id}, desired_sizes);
++  // We add the favicon if at least one origin saw it *or* if this was loaded
++  // without linking the favicon to any page url (used by history service).
++  if (per_origin_favicon_id_found || page_urls.empty()) {
++    result.bitmap_results =
++        GetFaviconBitmapResultsForBestMatch({favicon_id}, desired_sizes);
++  }
+   return result;
+ }
+ 
+diff --git a/components/favicon/core/favicon_backend_unittest.cc b/components/favicon/core/favicon_backend_unittest.cc
+index 2469e0396c90d..dced788364681 100644
+--- a/components/favicon/core/favicon_backend_unittest.cc
++++ b/components/favicon/core/favicon_backend_unittest.cc
+@@ -378,7 +378,7 @@ TEST_F(FaviconBackendTest, SetFaviconsSameFaviconURLForTwoPages) {
+   GURL icon_url("http://www.google.com/favicon.ico");
+   GURL icon_url_new("http://www.google.com/favicon2.ico");
+   GURL page_url1("http://www.google.com");
+-  GURL page_url2("http://www.google.ca");
++  GURL page_url2("http://www.google.com/page");
+   std::vector<SkBitmap> bitmaps;
+   bitmaps.push_back(CreateBitmap(SK_ColorBLUE, kSmallEdgeSize));
+   bitmaps.push_back(CreateBitmap(SK_ColorRED, kLargeEdgeSize));
+@@ -1270,4 +1270,31 @@ TEST_F(FaviconBackendTest, GetFaviconsForUrlExpired) {
+   EXPECT_TRUE(bitmap_results_out[0].expired);
+ }
+ 
++// Test that a favicon isn't loaded cross-origin.
++TEST_F(FaviconBackendTest, FaviconCacheWillNotLoadCrossOrigin) {
++  GURL icon_url("http://www.google.com/favicon.ico");
++  GURL page_url1("http://www.google.com");
++  GURL page_url2("http://www.google.ca");
++  std::vector<SkBitmap> bitmaps;
++  bitmaps.push_back(CreateBitmap(SK_ColorBLUE, kSmallEdgeSize));
++  bitmaps.push_back(CreateBitmap(SK_ColorRED, kLargeEdgeSize));
++
++  // Store `icon_url` for `page_url1`, but just attempt load for `page_url2`.
++  SetFavicons({page_url1}, IconType::kFavicon, icon_url, bitmaps);
++  backend_->UpdateFaviconMappingsAndFetch(
++      {page_url2}, icon_url, IconType::kFavicon, GetEdgeSizesSmallAndLarge());
++
++  // Check that the same FaviconID is mapped just to `page_url1`.
++  std::vector<IconMapping> icon_mappings;
++  EXPECT_TRUE(
++      backend_->db()->GetIconMappingsForPageURL(page_url1, &icon_mappings));
++  EXPECT_EQ(1u, icon_mappings.size());
++  favicon_base::FaviconID favicon_id = icon_mappings[0].icon_id;
++  EXPECT_NE(0, favicon_id);
++
++  icon_mappings.clear();
++  EXPECT_FALSE(
++      backend_->db()->GetIconMappingsForPageURL(page_url2, &icon_mappings));
++}
++
+ }  // namespace favicon


### PR DESCRIPTION
Recently, a fix has been published for
https://bugs.chromium.org/p/chromium/issues/detail?id=1300214, regarding leakage of browsing history through external favicon leaks.