### PR TITLE
Improvements and bugfixes on Vanadium

### DIFF
--- a/args.gn
+++ b/args.gn
@@ -6,6 +6,9 @@ android_channel = "stable"
 android_default_version_name = "110.0.5481.154"
 android_default_version_code = "548115400"
 
+ext_version_enabled = true
+ext_version_increment = "1"
+
 is_component_build = false
 is_debug = false
 is_official_build = true

--- a/patches/0090-Add-missing-null-check-for-password-manager-autofill.patch
+++ b/patches/0090-Add-missing-null-check-for-password-manager-autofill.patch
@@ -1,0 +1,25 @@
+From 7fa1dfbf6f67be39a9ba3d7e908c3d359aa7bc88 Mon Sep 17 00:00:00 2001
+From: fgei <fgei@gmail.com>
+Date: Mon, 20 Feb 2023 07:06:53 +0000
+Subject: [PATCH] Add missing null check for password manager autofill
+
+---
+ .../autofill/content/renderer/password_autofill_agent.cc     | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/components/autofill/content/renderer/password_autofill_agent.cc b/components/autofill/content/renderer/password_autofill_agent.cc
+index 9059de25cca78..17c54ee3590a3 100644
+--- a/components/autofill/content/renderer/password_autofill_agent.cc
++++ b/components/autofill/content/renderer/password_autofill_agent.cc
+@@ -804,7 +804,10 @@ void PasswordAutofillAgent::UpdateStateForTextChange(
+ 
+ void PasswordAutofillAgent::TrackAutofilledElement(
+     const blink::WebFormControlElement& element) {
+-  autofill_agent_->TrackAutofilledElement(element);
++  AutofillAgent* agent = autofill_agent_.get();
++  if (agent) {
++    agent->TrackAutofilledElement(element);
++  }
+ }
+ 
+ bool PasswordAutofillAgent::FillSuggestion(

--- a/patches/0091-Drop-workaround-with-android-autofill-in-compatibili.patch
+++ b/patches/0091-Drop-workaround-with-android-autofill-in-compatibili.patch
@@ -1,0 +1,25 @@
+From f60c5651c7085764e6b8b94d8ff417d1599c9142 Mon Sep 17 00:00:00 2001
+From: fgei <fgei@gmail.com>
+Date: Fri, 24 Feb 2023 10:20:37 +0100
+Subject: [PATCH] Drop workaround with android autofill in compatibility mode
+
+This causes the autofill popup to show when url is tapped. Drop in favor
+of native android autofill support compatibility with other autofill
+implementations.
+---
+ .../java/src/org/chromium/chrome/browser/omnibox/UrlBar.java    | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/chrome/browser/ui/android/omnibox/java/src/org/chromium/chrome/browser/omnibox/UrlBar.java b/chrome/browser/ui/android/omnibox/java/src/org/chromium/chrome/browser/omnibox/UrlBar.java
+index b3ff6e999110c..c0c80396a5f3b 100644
+--- a/chrome/browser/ui/android/omnibox/java/src/org/chromium/chrome/browser/omnibox/UrlBar.java
++++ b/chrome/browser/ui/android/omnibox/java/src/org/chromium/chrome/browser/omnibox/UrlBar.java
+@@ -407,7 +407,7 @@ public abstract class UrlBar extends AutocompleteEditText {
+             // the domain changes. We restore this behavior by mimicking the relevant part of
+             // TextView.notifyListeningManagersAfterTextChanged().
+             // https://cs.android.com/android/platform/superproject/+/5d123b67756dffcfdebdb936ab2de2b29c799321:frameworks/base/core/java/android/widget/TextView.java;l=10618;drc=master;bpv=0
+-            ApiHelperForO.notifyValueChangedForAutofill(this);
++            //ApiHelperForO.notifyValueChangedForAutofill(this);
+         }
+     }
+ 

--- a/patches/0092-Enable-android-autofill-on-http-authentication-dialo.patch
+++ b/patches/0092-Enable-android-autofill-on-http-authentication-dialo.patch
@@ -1,0 +1,22 @@
+From 3aae0d75c587df715d5754140b3e7f955559c9e4 Mon Sep 17 00:00:00 2001
+From: fgei <fgei@gmail.com>
+Date: Mon, 20 Feb 2023 07:10:30 +0000
+Subject: [PATCH] Enable android autofill on http authentication dialog
+
+---
+ .../chromium/chrome/browser/login/ChromeHttpAuthHandler.java    | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/chrome/android/java/src/org/chromium/chrome/browser/login/ChromeHttpAuthHandler.java b/chrome/android/java/src/org/chromium/chrome/browser/login/ChromeHttpAuthHandler.java
+index 3b87576c9ed6b..a97f7cff21c49 100644
+--- a/chrome/android/java/src/org/chromium/chrome/browser/login/ChromeHttpAuthHandler.java
++++ b/chrome/android/java/src/org/chromium/chrome/browser/login/ChromeHttpAuthHandler.java
+@@ -102,7 +102,7 @@ public class ChromeHttpAuthHandler extends EmptyTabObserver implements LoginProm
+         mTab.addObserver(this);
+         String messageBody = ChromeHttpAuthHandlerJni.get().getMessageBody(
+                 mNativeChromeHttpAuthHandler, ChromeHttpAuthHandler.this);
+-        mLoginPrompt = new LoginPrompt(activity, messageBody, null, this);
++        mLoginPrompt = new LoginPrompt(activity, messageBody, tab.getOriginalUrl(), this);
+         // In case the autofill data arrives before the prompt is created.
+         if (mAutofillUsername != null && mAutofillPassword != null) {
+             mLoginPrompt.onAutofillDataAvailable(mAutofillUsername, mAutofillPassword);

--- a/patches/0093-Enable-new-password-manager-autofill-UI-by-default.patch
+++ b/patches/0093-Enable-new-password-manager-autofill-UI-by-default.patch
@@ -1,0 +1,25 @@
+From 2eb0a8052fdceb94082260f0ebf03f73212d00ea Mon Sep 17 00:00:00 2001
+From: fgei <fgei@gmail.com>
+Date: Mon, 20 Feb 2023 07:07:52 +0000
+Subject: [PATCH] Enable new password manager autofill UI by default
+
+This instead uses a keyboard accessory on top of virutal keyboard to
+avoid UX issues of drop-down suggestions obscuring other dialogs, such
+as switching keyboard
+---
+ components/autofill/core/common/autofill_features.cc | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/components/autofill/core/common/autofill_features.cc b/components/autofill/core/common/autofill_features.cc
+index 52e41bf79037a..bd326a440a57d 100644
+--- a/components/autofill/core/common/autofill_features.cc
++++ b/components/autofill/core/common/autofill_features.cc
+@@ -329,7 +329,7 @@ BASE_FEATURE(kAutofillHighlightOnlyChangedValuesInPreviewMode,
+ // instead of the regular popup.
+ BASE_FEATURE(kAutofillKeyboardAccessory,
+              "AutofillKeyboardAccessory",
+-             base::FEATURE_DISABLED_BY_DEFAULT);
++             base::FEATURE_ENABLED_BY_DEFAULT);
+ 
+ // When enabled, Autofill will use new logic to strip both prefixes
+ // and suffixes when setting FormStructure::parseable_name_

--- a/patches/0094-Support-both-password-manager-and-android-autofill-f.patch
+++ b/patches/0094-Support-both-password-manager-and-android-autofill-f.patch
@@ -1,0 +1,76 @@
+From 29aa0dff1b451866b71d6069031064bed2820d65 Mon Sep 17 00:00:00 2001
+From: fgei <fgei@gmail.com>
+Date: Mon, 20 Feb 2023 07:06:53 +0000
+Subject: [PATCH] Support both password manager and android autofill
+ functionality
+
+---
+ .../autofill/content/renderer/autofill_agent.cc    |  2 --
+ .../content/renderer/password_autofill_agent.cc    |  9 ---------
+ .../core/browser/browser_autofill_manager.cc       | 13 +++++++++++++
+ 3 files changed, 13 insertions(+), 11 deletions(-)
+
+diff --git a/components/autofill/content/renderer/autofill_agent.cc b/components/autofill/content/renderer/autofill_agent.cc
+index 5de7ea121a277..b3769ef9977fa 100644
+--- a/components/autofill/content/renderer/autofill_agent.cc
++++ b/components/autofill/content/renderer/autofill_agent.cc
+@@ -440,7 +440,6 @@ void AutofillAgent::OnTextFieldDidChange(const WebInputElement& element) {
+   if (password_autofill_agent_->TextDidChangeInTextField(element)) {
+     is_popup_possibly_visible_ = true;
+     element_ = element;
+-    return;
+   }
+ 
+   ShowSuggestions(element, {.requires_caret_at_end = true});
+@@ -808,7 +807,6 @@ void AutofillAgent::ShowSuggestions(const WebFormControlElement& element,
+           input_element, ShowAll(options.show_full_suggestion_list),
+           GenerationShowing(is_generation_popup_possibly_visible_))) {
+     is_popup_possibly_visible_ = true;
+-    return;
+   }
+ 
+   if (is_generation_popup_possibly_visible_)
+diff --git a/components/autofill/content/renderer/password_autofill_agent.cc b/components/autofill/content/renderer/password_autofill_agent.cc
+index 17c54ee3590a3..f711e5d486929 100644
+--- a/components/autofill/content/renderer/password_autofill_agent.cc
++++ b/components/autofill/content/renderer/password_autofill_agent.cc
+@@ -1124,15 +1124,6 @@ bool PasswordAutofillAgent::ShowSuggestions(
+   if (generation_popup_showing)
+     return false;
+ 
+-#if BUILDFLAG(IS_ANDROID)
+-  // Don't call ShowSuggestionPopup if Touch To Fill is currently showing. Since
+-  // Touch To Fill in spirit is very similar to a suggestion pop-up, return true
+-  // so that the AutofillAgent does not try to show other autofill suggestions
+-  // instead.
+-  if (touch_to_fill_state_ == TouchToFillState::kIsShowing)
+-    return true;
+-#endif
+-
+   if (!HasDocumentWithValidFrame(element))
+     return false;
+ 
+diff --git a/components/autofill/core/browser/browser_autofill_manager.cc b/components/autofill/core/browser/browser_autofill_manager.cc
+index 87c2217f42994..a7d249a2c6418 100644
+--- a/components/autofill/core/browser/browser_autofill_manager.cc
++++ b/components/autofill/core/browser/browser_autofill_manager.cc
+@@ -1067,6 +1067,19 @@ void BrowserAutofillManager::OnAskForValuesToFillImpl(
+     return;
+   }
+ 
++  if (AutofillField* _autofill_field = GetAutofillField(form, field)) {
++    switch (_autofill_field->Type().group()) {
++      // Do not override password manager prompt on these fields
++      case FieldTypeGroup::kNoGroup:
++      case FieldTypeGroup::kPasswordField:
++      case FieldTypeGroup::kUsernameField:
++      case FieldTypeGroup::kEmail:
++        return;
++      default:
++        break;
++    }
++  }
++
+   SetDataList(field.datalist_values, field.datalist_labels);
+   external_delegate_->OnQuery(form, field, transformed_box);
+ 

--- a/patches/0095-Support-for-both-browser-and-android-autofill-functi.patch
+++ b/patches/0095-Support-for-both-browser-and-android-autofill-functi.patch
@@ -1,0 +1,264 @@
+From 64c9198da640bff3cf3a2f813dc61214868375b5 Mon Sep 17 00:00:00 2001
+From: fgei <fgei@gmail.com>
+Date: Tue, 21 Feb 2023 01:48:15 +0000
+Subject: [PATCH] Support for both browser and android autofill functionality
+
+---
+ .../browser/android_autofill_manager.cc       | 17 ++++++
+ .../browser/android_autofill_manager.h        | 15 ++++++
+ .../browser/content_autofill_driver.cc        | 53 +++++++++++++++++++
+ .../content/browser/content_autofill_driver.h | 12 +++++
+ 4 files changed, 97 insertions(+)
+
+diff --git a/components/android_autofill/browser/android_autofill_manager.cc b/components/android_autofill/browser/android_autofill_manager.cc
+index b4ce9156aa3e2..87bb06cfd219a 100644
+--- a/components/android_autofill/browser/android_autofill_manager.cc
++++ b/components/android_autofill/browser/android_autofill_manager.cc
+@@ -7,6 +7,7 @@
+ #include "base/memory/ptr_util.h"
+ #include "components/android_autofill/browser/autofill_provider.h"
+ #include "components/autofill/content/browser/content_autofill_driver.h"
++#include "components/autofill/core/browser/browser_autofill_manager.h"
+ #include "content/public/browser/render_frame_host.h"
+ #include "content/public/browser/web_contents.h"
+ 
+@@ -26,6 +27,22 @@ void AndroidDriverInitHook(
+   driver->GetAutofillAgent()->SetQueryPasswordSuggestion(true);
+ }
+ 
++void AndroidAndBrowserDriverInitHook(
++    AutofillClient* client,
++    const std::string& app_locale,
++    ContentAutofillDriver* driver) {
++  driver->set_autofill_manager(std::make_unique<BrowserAutofillManager>(
++      driver, client, app_locale,
++      autofill::AutofillManager::EnableDownloadManager(false)));
++  driver->set_secondary_autofill_manager(base::WrapUnique(
++      new AndroidAutofillManager(driver, client,
++          autofill::AutofillManager::EnableDownloadManager(false))));
++  driver->GetAutofillAgent()->SetUserGestureRequired(false);
++  driver->GetAutofillAgent()->SetSecureContextRequired(true);
++  driver->GetAutofillAgent()->SetFocusRequiresScroll(false);
++  driver->GetAutofillAgent()->SetQueryPasswordSuggestion(true);
++}
++
+ AndroidAutofillManager::AndroidAutofillManager(
+     AutofillDriver* driver,
+     AutofillClient* client,
+diff --git a/components/android_autofill/browser/android_autofill_manager.h b/components/android_autofill/browser/android_autofill_manager.h
+index 1ec42cd458f95..7df9fa0cf01f3 100644
+--- a/components/android_autofill/browser/android_autofill_manager.h
++++ b/components/android_autofill/browser/android_autofill_manager.h
+@@ -15,6 +15,16 @@ namespace autofill {
+ class AutofillProvider;
+ class ContentAutofillDriver;
+ 
++// Creates an AndroidAutofillManager and attaches it to the `driver`.
++//
++// This hook is to be passed to CreateForWebContentsAndDelegate().
++// It is the glue between ContentAutofillDriver[Factory] and
++// AndroidAutofillManager, BrowserAutofillManager.
++void AndroidAndBrowserDriverInitHook(
++    AutofillClient* client,
++    const std::string& app_locale,
++    ContentAutofillDriver* driver);
++
+ // Creates an AndroidAutofillManager and attaches it to the `driver`.
+ //
+ // This hook is to be passed to CreateForWebContentsAndDelegate().
+@@ -82,6 +92,11 @@ class AndroidAutofillManager : public AutofillManager {
+                          const url::Origin& triggered_origin);
+ 
+  protected:
++  friend void AndroidAndBrowserDriverInitHook(
++      AutofillClient* client,
++      const std::string& app_locale,
++      ContentAutofillDriver* driver);
++
+   friend void AndroidDriverInitHook(
+       AutofillClient* client,
+       AutofillManager::EnableDownloadManager enable_download_manager,
+diff --git a/components/autofill/content/browser/content_autofill_driver.cc b/components/autofill/content/browser/content_autofill_driver.cc
+index 8ccb2d564e07d..63d8ea1a8a465 100644
+--- a/components/autofill/content/browser/content_autofill_driver.cc
++++ b/components/autofill/content/browser/content_autofill_driver.cc
+@@ -316,6 +316,10 @@ void ContentAutofillDriver::FormsSeen(
+          const std::vector<FormData>& updated_forms,
+          const std::vector<FormGlobalId>& removed_forms) {
+         target->autofill_manager_->OnFormsSeen(updated_forms, removed_forms);
++        if (target->secondary_autofill_manager_) {
++          target->secondary_autofill_manager_->OnFormsSeen(updated_forms,
++                                                           removed_forms);
++        }
+       });
+ }
+ 
+@@ -342,6 +346,10 @@ void ContentAutofillDriver::FormSubmitted(
+         }
+         target->autofill_manager_->OnFormSubmitted(form, known_success,
+                                                    submission_source);
++        if (target->secondary_autofill_manager_) {
++          target->secondary_autofill_manager_->OnFormSubmitted(
++              form, known_success, submission_source);
++        }
+       });
+ }
+ 
+@@ -362,6 +370,10 @@ void ContentAutofillDriver::TextFieldDidChange(const FormData& raw_form,
+          base::TimeTicks timestamp) {
+         target->autofill_manager_->OnTextFieldDidChange(
+             form, field, bounding_box, timestamp);
++        if (target->secondary_autofill_manager_) {
++          target->secondary_autofill_manager_->OnTextFieldDidChange(
++              form, field, bounding_box, timestamp);
++        }
+       });
+ }
+ 
+@@ -380,6 +392,10 @@ void ContentAutofillDriver::TextFieldDidScroll(const FormData& raw_form,
+          const FormFieldData& field, const gfx::RectF& bounding_box) {
+         target->autofill_manager_->OnTextFieldDidScroll(form, field,
+                                                         bounding_box);
++        if (target->secondary_autofill_manager_) {
++          target->secondary_autofill_manager_->OnTextFieldDidScroll(
++              form, field, bounding_box);
++        }
+       });
+ }
+ 
+@@ -399,6 +415,10 @@ void ContentAutofillDriver::SelectControlDidChange(
+          const FormFieldData& field, const gfx::RectF& bounding_box) {
+         target->autofill_manager_->OnSelectControlDidChange(form, field,
+                                                             bounding_box);
++        if (target->secondary_autofill_manager_) {
++          target->secondary_autofill_manager_->OnSelectControlDidChange(
++              form, field, bounding_box);
++        }
+       });
+ }
+ 
+@@ -424,6 +444,11 @@ void ContentAutofillDriver::AskForValuesToFill(
+         target->autofill_manager_->OnAskForValuesToFill(
+             form, field, bounding_box, autoselect_first_suggestion,
+             form_element_was_clicked);
++        if (target->secondary_autofill_manager_) {
++          target->secondary_autofill_manager_->OnAskForValuesToFill(
++              form, field, bounding_box, autoselect_first_suggestion,
++              form_element_was_clicked);
++        }
+       });
+ }
+ 
+@@ -434,12 +459,19 @@ void ContentAutofillDriver::HidePopup() {
+     DCHECK(!target->IsPrerendering())
+         << "We should never affect UI while prerendering";
+     target->autofill_manager_->OnHidePopup();
++    if (target->secondary_autofill_manager_) {
++      target->secondary_autofill_manager_->OnHidePopup();
++    }
+   });
+ }
+ 
+ void ContentAutofillDriver::FocusNoLongerOnFormCallback(
+     bool had_interacted_form) {
+   autofill_manager_->OnFocusNoLongerOnForm(had_interacted_form);
++  if (secondary_autofill_manager_) {
++    secondary_autofill_manager_->OnFocusNoLongerOnForm(
++        had_interacted_form);
++  }
+ }
+ 
+ void ContentAutofillDriver::FocusNoLongerOnForm(bool had_interacted_form) {
+@@ -467,6 +499,10 @@ void ContentAutofillDriver::FocusOnFormField(const FormData& raw_form,
+          const FormFieldData& field, const gfx::RectF& bounding_box) {
+         target->autofill_manager_->OnFocusOnFormField(form, field,
+                                                       bounding_box);
++        if (target->secondary_autofill_manager_) {
++          target->secondary_autofill_manager_->OnFocusOnFormField(form, field,
++                                                                  bounding_box);
++        }
+       });
+ }
+ 
+@@ -479,6 +515,10 @@ void ContentAutofillDriver::DidFillAutofillFormData(const FormData& raw_form,
+       [](ContentAutofillDriver* target, const FormData& form,
+          base::TimeTicks timestamp) {
+         target->autofill_manager_->OnDidFillAutofillFormData(form, timestamp);
++        if (target->secondary_autofill_manager_) {
++          target->secondary_autofill_manager_->OnDidFillAutofillFormData(
++              form, timestamp);
++        }
+       });
+ }
+ 
+@@ -488,6 +528,9 @@ void ContentAutofillDriver::DidPreviewAutofillFormData() {
+   autofill_router().DidPreviewAutofillFormData(
+       this, [](ContentAutofillDriver* target) {
+         target->autofill_manager_->OnDidPreviewAutofillFormData();
++        if (target->secondary_autofill_manager_) {
++          target->secondary_autofill_manager_->OnDidPreviewAutofillFormData();
++        }
+       });
+ }
+ 
+@@ -497,6 +540,9 @@ void ContentAutofillDriver::DidEndTextFieldEditing() {
+   autofill_router().DidEndTextFieldEditing(
+       this, [](ContentAutofillDriver* target) {
+         target->autofill_manager_->OnDidEndTextFieldEditing();
++        if (target->secondary_autofill_manager_) {
++          target->secondary_autofill_manager_->OnDidEndTextFieldEditing();
++        }
+       });
+ }
+ 
+@@ -508,6 +554,10 @@ void ContentAutofillDriver::SelectFieldOptionsDidChange(
+       this, GetFormWithFrameAndFormMetaData(raw_form),
+       [](ContentAutofillDriver* target, const FormData& form) {
+         target->autofill_manager_->OnSelectFieldOptionsDidChange(form);
++        if (target->secondary_autofill_manager_) {
++          target->secondary_autofill_manager_->OnSelectFieldOptionsDidChange(
++              form);
++        }
+       });
+ }
+ 
+@@ -606,6 +656,9 @@ void ContentAutofillDriver::DidNavigateFrame(
+   if (autofill_router_)  // Can be nullptr only in tests.
+     autofill_router_->UnregisterDriver(this);
+   autofill_manager_->Reset();
++  if (secondary_autofill_manager_) {
++    secondary_autofill_manager_->Reset();
++  }
+ }
+ 
+ const mojo::AssociatedRemote<mojom::AutofillAgent>&
+diff --git a/components/autofill/content/browser/content_autofill_driver.h b/components/autofill/content/browser/content_autofill_driver.h
+index 3a91f9d0771c0..e18bc02c5dca7 100644
+--- a/components/autofill/content/browser/content_autofill_driver.h
++++ b/components/autofill/content/browser/content_autofill_driver.h
+@@ -136,6 +136,14 @@ class ContentAutofillDriver : public AutofillDriver,
+   }
+   AutofillManager* autofill_manager() { return autofill_manager_.get(); }
+ 
++  void set_secondary_autofill_manager(
++      std::unique_ptr<AutofillManager> secondary_autofill_manager) {
++    secondary_autofill_manager_ = std::move(secondary_autofill_manager);
++  }
++  AutofillManager* secondary_autofill_manager() {
++    return secondary_autofill_manager_.get();
++  }
++
+   content::RenderFrameHost* render_frame_host() { return render_frame_host_; }
+ 
+   // Expose the events that originate from the browser and renderer processes,
+@@ -368,6 +376,10 @@ class ContentAutofillDriver : public AutofillDriver,
+   // code.
+   std::unique_ptr<AutofillManager> autofill_manager_ = nullptr;
+ 
++  // adds a reference for AndroidAutofillManager, since native autofill works in
++  // conjunction with browser autofill
++  std::unique_ptr<AutofillManager> secondary_autofill_manager_ = nullptr;
++
+   content::RenderWidgetHost::KeyPressEventCallback key_press_handler_;
+ 
+   mojo::AssociatedReceiver<mojom::AutofillDriver> receiver_{this};

--- a/patches/0096-Support-native-Android-autofill-at-browser.patch
+++ b/patches/0096-Support-native-Android-autofill-at-browser.patch
@@ -1,0 +1,392 @@
+From 270c42ab161c238ed55b939884f91e2a430b582d Mon Sep 17 00:00:00 2001
+From: fgei <fgei@gmail.com>
+Date: Mon, 20 Feb 2023 07:10:55 +0000
+Subject: [PATCH] Support native Android autofill at browser
+
+This enables support for Android Autofil on tabs showing fillable
+entries, reusing the codebase used for webview's android autofill
+support.
+---
+ android_webview/browser/aw_contents.cc        |  2 +-
+ chrome/android/BUILD.gn                       |  1 +
+ .../chromium/chrome/browser/tab/TabImpl.java  | 45 +++++++++++++++++
+ .../browser/tab/TabViewAndroidDelegate.java   | 13 +++++
+ chrome/browser/BUILD.gn                       |  7 +++
+ .../tab_web_contents_delegate_android.cc      |  3 +-
+ chrome/browser/ui/tab_helpers.cc              |  4 +-
+ .../presentation_receiver_window_view.cc      |  4 +-
+ .../embedder_support/view/ContentView.java    | 48 +++++++++++++++++++
+ .../chromium/ui/base/ViewAndroidDelegate.java |  8 ++++
+ 10 files changed, 129 insertions(+), 6 deletions(-)
+
+diff --git a/android_webview/browser/aw_contents.cc b/android_webview/browser/aw_contents.cc
+index dd0f344b42426..d6f4dbad0d42b 100644
+--- a/android_webview/browser/aw_contents.cc
++++ b/android_webview/browser/aw_contents.cc
+@@ -337,7 +337,7 @@ void AwContents::InitAutofillIfNecessary(bool autocomplete_enabled) {
+       autofill_provider
+           ? base::BindRepeating(&autofill::AndroidDriverInitHook,
+                                 AwAutofillClient::FromWebContents(web_contents),
+-                                enable_download_manager)
++                                autofill::AutofillManager::EnableDownloadManager(false))
+           : base::BindRepeating(&autofill::BrowserDriverInitHook,
+                                 AwAutofillClient::FromWebContents(web_contents),
+                                 base::android::GetDefaultLocaleString());
+diff --git a/chrome/android/BUILD.gn b/chrome/android/BUILD.gn
+index bf94b55cd44cb..a422df43fe7c4 100644
+--- a/chrome/android/BUILD.gn
++++ b/chrome/android/BUILD.gn
+@@ -513,6 +513,7 @@ if (current_toolchain == default_toolchain) {
+       "//chrome/browser/webapps/android:java",
+       "//chrome/browser/webauthn/android:java",
+       "//chrome/browser/xsurface:java",
++      "//components/android_autofill/browser:java",
+       "//components/autofill/android:autofill_java",
+       "//components/autofill/android:prefeditor_autofill_java",
+       "//components/background_task_scheduler:background_task_scheduler_java",
+diff --git a/chrome/android/java/src/org/chromium/chrome/browser/tab/TabImpl.java b/chrome/android/java/src/org/chromium/chrome/browser/tab/TabImpl.java
+index 8c7a6ecc664e9..e18da9a61a3f8 100644
+--- a/chrome/android/java/src/org/chromium/chrome/browser/tab/TabImpl.java
++++ b/chrome/android/java/src/org/chromium/chrome/browser/tab/TabImpl.java
+@@ -10,10 +10,14 @@ import android.annotation.SuppressLint;
+ import android.app.Activity;
+ import android.content.Context;
+ import android.graphics.Rect;
++import android.os.Build;
+ import android.text.TextUtils;
++import android.util.SparseArray;
+ import android.view.View;
+ import android.view.View.OnAttachStateChangeListener;
++import android.view.ViewStructure;
+ import android.view.accessibility.AccessibilityEvent;
++import android.view.autofill.AutofillValue;
+ 
+ import androidx.annotation.Nullable;
+ import androidx.annotation.VisibleForTesting;
+@@ -53,6 +57,8 @@ import org.chromium.chrome.browser.tab.state.SerializedCriticalPersistedTabData;
+ import org.chromium.chrome.browser.ui.native_page.FrozenNativePage;
+ import org.chromium.chrome.browser.ui.native_page.NativePage;
+ import org.chromium.chrome.browser.vr.VrModuleProvider;
++import org.chromium.components.autofill.AutofillActionModeCallback;
++import org.chromium.components.autofill.AutofillProvider;
+ import org.chromium.components.dom_distiller.core.DomDistillerUrlUtils;
+ import org.chromium.components.embedder_support.util.UrlConstants;
+ import org.chromium.components.embedder_support.view.ContentView;
+@@ -65,9 +71,11 @@ import org.chromium.components.version_info.VersionInfo;
+ import org.chromium.content_public.browser.ChildProcessImportance;
+ import org.chromium.content_public.browser.ContentFeatureList;
+ import org.chromium.content_public.browser.LoadUrlParams;
++import org.chromium.content_public.browser.SelectionPopupController;
+ import org.chromium.content_public.browser.WebContents;
+ import org.chromium.content_public.browser.WebContentsAccessibility;
+ import org.chromium.content_public.browser.navigation_controller.UserAgentOverrideOption;
++import org.chromium.ui.base.EventOffsetHandler;
+ import org.chromium.ui.base.PageTransition;
+ import org.chromium.ui.base.ViewAndroidDelegate;
+ import org.chromium.ui.base.WindowAndroid;
+@@ -210,6 +218,7 @@ public class TabImpl implements Tab, TabObscuringHandler.Observer {
+     private final TabThemeColorHelper mThemeColorHelper;
+     private int mThemeColor;
+     private boolean mUsedCriticalPersistedTabData;
++    AutofillProvider mAutofillProvider;
+ 
+     /**
+      * Creates an instance of a {@link TabImpl}.
+@@ -253,12 +262,18 @@ public class TabImpl implements Tab, TabObscuringHandler.Observer {
+             public void onViewAttachedToWindow(View view) {
+                 mIsViewAttachedToWindow = true;
+                 updateInteractableState();
++                if (mAutofillProvider != null) {
++                    mAutofillProvider.onContainerViewChanged(mContentView);
++                }
+             }
+ 
+             @Override
+             public void onViewDetachedFromWindow(View view) {
+                 mIsViewAttachedToWindow = false;
+                 updateInteractableState();
++                if (mAutofillProvider != null) {
++                    mAutofillProvider.onContainerViewChanged(mContentView);
++                }
+             }
+         };
+         mTabViewManager = new TabViewManagerImpl(this);
+@@ -775,6 +790,11 @@ public class TabImpl implements Tab, TabObscuringHandler.Observer {
+         for (TabObserver observer : mObservers) observer.onDestroyed(this);
+         mObservers.clear();
+ 
++        if (mAutofillProvider != null) {
++            mAutofillProvider.destroy();
++            mAutofillProvider = null;
++        }
++
+         mUserDataHost.destroy();
+         mTabViewManager.destroy();
+         hideNativePage(false, null);
+@@ -1356,6 +1376,18 @@ public class TabImpl implements Tab, TabObscuringHandler.Observer {
+         return tabsPtrArray;
+     }
+ 
++    public void onProvideAutofillVirtualStructure(ViewStructure structure, int flags) {
++        if (mAutofillProvider != null) {
++            mAutofillProvider.onProvideAutoFillVirtualStructure(structure, flags);
++        }
++    }
++
++    public void autofill(final SparseArray<AutofillValue> values) {
++        if (mAutofillProvider != null) {
++            mAutofillProvider.autofill(values);
++        }
++    }
++
+     /**
+      * Initializes the {@link WebContents}. Completes the browser content components initialization
+      * around a native WebContents pointer.
+@@ -1399,10 +1431,23 @@ public class TabImpl implements Tab, TabObscuringHandler.Observer {
+             mWebContentsDelegate = createWebContentsDelegate();
+ 
+             assert mNativeTabAndroid != 0;
++            SelectionPopupController selectionController = null;
++            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
++                selectionController = SelectionPopupController.fromWebContents(mWebContents);
++                mAutofillProvider = new AutofillProvider(
++                        getContext(), cv, webContents, "NativeAutofillRenderer");
++            }
+             TabImplJni.get().initWebContents(mNativeTabAndroid, mIncognito, isDetached(this),
+                     webContents, mWebContentsDelegate,
+                     new TabContextMenuPopulatorFactory(
+                             mDelegateFactory.createContextMenuPopulatorFactory(this), this));
++            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && selectionController != null) {
++                mAutofillProvider.setWebContents(webContents);
++                cv.setWebContents(webContents);
++                selectionController.setNonSelectionActionModeCallback(
++                        new AutofillActionModeCallback(
++                                mThemedApplicationContext, mAutofillProvider));
++            }
+ 
+             mWebContents.notifyRendererPreferenceUpdate();
+             TabHelpers.initWebContentsHelpers(this);
+diff --git a/chrome/android/java/src/org/chromium/chrome/browser/tab/TabViewAndroidDelegate.java b/chrome/android/java/src/org/chromium/chrome/browser/tab/TabViewAndroidDelegate.java
+index 3f7f930bb8107..56e9dd9f37d36 100644
+--- a/chrome/android/java/src/org/chromium/chrome/browser/tab/TabViewAndroidDelegate.java
++++ b/chrome/android/java/src/org/chromium/chrome/browser/tab/TabViewAndroidDelegate.java
+@@ -4,7 +4,10 @@
+ 
+ package org.chromium.chrome.browser.tab;
+ 
++import android.util.SparseArray;
+ import android.view.ViewGroup;
++import android.view.ViewStructure;
++import android.view.autofill.AutofillValue;
+ 
+ import androidx.annotation.Nullable;
+ import androidx.annotation.VisibleForTesting;
+@@ -85,6 +88,16 @@ public class TabViewAndroidDelegate extends ViewAndroidDelegate {
+         mTab.onBackgroundColorChanged(color);
+     }
+ 
++    @Override
++    public void onProvideAutofillVirtualStructure(ViewStructure structure, int flags) {
++        mTab.onProvideAutofillVirtualStructure(structure, flags);
++    }
++
++    @Override
++    public void autofill(final SparseArray<AutofillValue> values) {
++        mTab.autofill(values);
++    }
++
+     @Override
+     public void onTopControlsChanged(
+             int topControlsOffsetY, int contentOffsetY, int topControlsMinHeightOffsetY) {
+diff --git a/chrome/browser/BUILD.gn b/chrome/browser/BUILD.gn
+index 21547000bf909..d6b935ab46d6e 100644
+--- a/chrome/browser/BUILD.gn
++++ b/chrome/browser/BUILD.gn
+@@ -2500,6 +2500,13 @@ static_library("browser") {
+     deps += [ "//chrome/browser/error_reporting" ]
+   }
+ 
++  if (is_android) {
++    deps += [
++      "//components/android_autofill/browser",
++      "//components/android_autofill/browser:android"
++    ]
++  }
++
+   if (use_ozone) {
+     deps += [
+       "//ui/events/ozone",
+diff --git a/chrome/browser/android/tab_web_contents_delegate_android.cc b/chrome/browser/android/tab_web_contents_delegate_android.cc
+index 67e8a45b6af74..45ecb8ce7271d 100644
+--- a/chrome/browser/android/tab_web_contents_delegate_android.cc
++++ b/chrome/browser/android/tab_web_contents_delegate_android.cc
+@@ -46,6 +46,7 @@
+ #include "chrome/browser/vr/vr_tab_helper.h"
+ #include "chrome/common/chrome_switches.h"
+ #include "chrome/common/url_constants.h"
++#include "components/android_autofill/browser/android_autofill_manager.h"
+ #include "components/autofill/content/browser/content_autofill_driver_factory.h"
+ #include "components/blocked_content/popup_blocker.h"
+ #include "components/blocked_content/popup_tracker.h"
+@@ -160,7 +161,7 @@ void TabWebContentsDelegateAndroid::PortalWebContentsCreated(
+       portal_contents,
+       autofill::ChromeAutofillClient::FromWebContents(portal_contents),
+       base::BindRepeating(
+-          &autofill::BrowserDriverInitHook,
++          &autofill::AndroidAndBrowserDriverInitHook,
+           autofill::ChromeAutofillClient::FromWebContents(portal_contents),
+           g_browser_process->GetApplicationLocale()));
+   ChromePasswordManagerClient::CreateForWebContentsWithAutofillClient(
+diff --git a/chrome/browser/ui/tab_helpers.cc b/chrome/browser/ui/tab_helpers.cc
+index d1f7fc57b3226..2c429d4d23f80 100644
+--- a/chrome/browser/ui/tab_helpers.cc
++++ b/chrome/browser/ui/tab_helpers.cc
+@@ -101,7 +101,7 @@
+ #include "chrome/common/chrome_isolated_world_ids.h"
+ #include "chrome/common/chrome_switches.h"
+ #include "components/autofill/content/browser/content_autofill_driver_factory.h"
+-#include "components/autofill/core/browser/browser_autofill_manager.h"
++#include "components/android_autofill/browser/android_autofill_manager.h"
+ #include "components/blocked_content/popup_blocker_tab_helper.h"
+ #include "components/blocked_content/popup_opener_tab_helper.h"
+ #include "components/breadcrumbs/core/breadcrumbs_status.h"
+@@ -314,7 +314,7 @@ void TabHelpers::AttachTabHelpers(WebContents* web_contents) {
+       web_contents,
+       autofill::ChromeAutofillClient::FromWebContents(web_contents),
+       base::BindRepeating(
+-          &autofill::BrowserDriverInitHook,
++          &autofill::AndroidAndBrowserDriverInitHook,
+           autofill::ChromeAutofillClient::FromWebContents(web_contents),
+           g_browser_process->GetApplicationLocale()));
+   if (breadcrumbs::IsEnabled())
+diff --git a/chrome/browser/ui/views/media_router/presentation_receiver_window_view.cc b/chrome/browser/ui/views/media_router/presentation_receiver_window_view.cc
+index 93cca7d1ea1b7..4077904479767 100644
+--- a/chrome/browser/ui/views/media_router/presentation_receiver_window_view.cc
++++ b/chrome/browser/ui/views/media_router/presentation_receiver_window_view.cc
+@@ -29,7 +29,7 @@
+ #include "chrome/browser/ui/views/exclusive_access_bubble_views.h"
+ #include "chrome/browser/ui/views/media_router/presentation_receiver_window_frame.h"
+ #include "components/autofill/content/browser/content_autofill_driver_factory.h"
+-#include "components/autofill/core/browser/browser_autofill_manager.h"
++#include "components/android_autofill/browser/android_autofill_manager.h"
+ #include "components/blocked_content/popup_blocker_tab_helper.h"
+ #include "components/content_settings/browser/page_specific_content_settings.h"
+ #include "components/infobars/content/content_infobar_manager.h"
+@@ -172,7 +172,7 @@ void PresentationReceiverWindowView::Init() {
+       web_contents,
+       autofill::ChromeAutofillClient::FromWebContents(web_contents),
+       base::BindRepeating(
+-          &autofill::BrowserDriverInitHook,
++          &autofill::AndroidAndBrowserDriverInitHook,
+           autofill::ChromeAutofillClient::FromWebContents(web_contents),
+           g_browser_process->GetApplicationLocale()));
+   ChromePasswordManagerClient::CreateForWebContentsWithAutofillClient(
+diff --git a/components/embedder_support/android/java/src/org/chromium/components/embedder_support/view/ContentView.java b/components/embedder_support/android/java/src/org/chromium/components/embedder_support/view/ContentView.java
+index 0c7749e1b713a..fee09bb5f0c59 100644
+--- a/components/embedder_support/android/java/src/org/chromium/components/embedder_support/view/ContentView.java
++++ b/components/embedder_support/android/java/src/org/chromium/components/embedder_support/view/ContentView.java
+@@ -10,6 +10,7 @@ import android.graphics.Rect;
+ import android.os.Build;
+ import android.os.Bundle;
+ import android.os.Handler;
++import android.util.SparseArray;
+ import android.view.DragEvent;
+ import android.view.KeyEvent;
+ import android.view.MotionEvent;
+@@ -19,6 +20,7 @@ import android.view.View.OnSystemUiVisibilityChangeListener;
+ import android.view.ViewGroup.OnHierarchyChangeListener;
+ import android.view.ViewStructure;
+ import android.view.accessibility.AccessibilityNodeProvider;
++import android.view.autofill.AutofillValue;
+ import android.view.inputmethod.EditorInfo;
+ import android.view.inputmethod.InputConnection;
+ import android.widget.FrameLayout;
+@@ -36,6 +38,7 @@ import org.chromium.content_public.browser.WebContents;
+ import org.chromium.content_public.browser.WebContentsAccessibility;
+ import org.chromium.ui.base.EventForwarder;
+ import org.chromium.ui.base.EventOffsetHandler;
++import org.chromium.ui.base.ViewAndroidDelegate;
+ 
+ /**
+  * The containing view for {@link WebContents} that exists in the Android UI hierarchy and exposes
+@@ -86,6 +89,9 @@ public class ContentView extends FrameLayout
+      */
+     public static ContentView createContentView(Context context,
+             @Nullable EventOffsetHandler eventOffsetHandler, @Nullable WebContents webContents) {
++        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
++            return new ContentViewWithAutofill(context, eventOffsetHandler, webContents);
++        }
+         return new ContentView(context, eventOffsetHandler, webContents);
+     }
+ 
+@@ -597,4 +603,46 @@ public class ContentView extends FrameLayout
+     private boolean webContentsAttached() {
+         return hasValidWebContents() && mWebContents.getTopLevelNativeWindow() != null;
+     }
++
++    /**
++     * API level 26 implementation that includes autofill.
++     */
++    private static class ContentViewWithAutofill extends ContentView {
++        private ViewAndroidDelegate viewAndroidDelegate;
++
++        private ContentViewWithAutofill(
++                Context context, EventOffsetHandler eventOffsetHandler, WebContents webContents) {
++            super(context, eventOffsetHandler, webContents);
++
++            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
++                // The Autofill system-level infrastructure has heuristics for which Views it
++                // considers important for autofill; only these Views will be queried for their
++                // autofill structure on notifications that a new (virtual) View was entered. By
++                // default, FrameLayout is not considered important for autofill. Thus, for
++                // ContentView to be queried for its autofill structure, we must explicitly inform
++                // the autofill system that this View is important for autofill.
++                setImportantForAutofill(View.IMPORTANT_FOR_AUTOFILL_YES);
++            }
++        }
++
++        @Override
++        public void setWebContents(WebContents webContents) {
++            viewAndroidDelegate = webContents.getViewAndroidDelegate();
++            super.setWebContents(webContents);
++        }
++
++        @Override
++        public void onProvideAutofillVirtualStructure(ViewStructure structure, int flags) {
++            if (viewAndroidDelegate != null) {
++                viewAndroidDelegate.onProvideAutofillVirtualStructure(structure, flags);
++            }
++        }
++
++        @Override
++        public void autofill(final SparseArray<AutofillValue> values) {
++            if (viewAndroidDelegate != null) {
++                viewAndroidDelegate.autofill(values);
++            }
++        }
++    }
+ }
+diff --git a/ui/android/java/src/org/chromium/ui/base/ViewAndroidDelegate.java b/ui/android/java/src/org/chromium/ui/base/ViewAndroidDelegate.java
+index c89c7af00a62e..c411316ec03ec 100644
+--- a/ui/android/java/src/org/chromium/ui/base/ViewAndroidDelegate.java
++++ b/ui/android/java/src/org/chromium/ui/base/ViewAndroidDelegate.java
+@@ -29,6 +29,10 @@ import org.chromium.ui.dragdrop.DragStateTracker;
+ import org.chromium.ui.dragdrop.DropDataAndroid;
+ import org.chromium.ui.mojom.CursorType;
+ 
++import android.util.SparseArray;
++import android.view.autofill.AutofillValue;
++import android.view.ViewStructure;
++
+ /**
+  * Class to acquire, position, and remove anchor views from the implementing View.
+  */
+@@ -585,4 +589,8 @@ public class ViewAndroidDelegate {
+     public static void setDragAndDropDelegateForTest(DragAndDropDelegate testDelegate) {
+         sDragAndDropTestDelegate = testDelegate;
+     }
++
++    public void onProvideAutofillVirtualStructure(ViewStructure structure, int flags) {}
++
++    public void autofill(final SparseArray<AutofillValue> values) {}
+ }

--- a/patches/0097-Disable-Play-services-dependent-password-manager-fea.patch
+++ b/patches/0097-Disable-Play-services-dependent-password-manager-fea.patch
@@ -1,0 +1,23 @@
+From 8f73638740ccb4cb1cfc6c814864013cd13b3677 Mon Sep 17 00:00:00 2001
+From: fgei <fgei@gmail.com>
+Date: Tue, 21 Feb 2023 02:02:40 +0000
+Subject: [PATCH] Disable Play services dependent password manager feature by
+ default
+
+---
+ .../password_manager/core/common/password_manager_features.cc   | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/components/password_manager/core/common/password_manager_features.cc b/components/password_manager/core/common/password_manager_features.cc
+index fa9c5abeadff5..d96b469d5bb5e 100644
+--- a/components/password_manager/core/common/password_manager_features.cc
++++ b/components/password_manager/core/common/password_manager_features.cc
+@@ -222,7 +222,7 @@ BASE_FEATURE(kUnifiedCredentialManagerDryRun,
+ // database will be unused but kept in sync for local passwords.
+ BASE_FEATURE(kUnifiedPasswordManagerAndroid,
+              "UnifiedPasswordManagerAndroid",
+-             base::FEATURE_ENABLED_BY_DEFAULT);
++             base::FEATURE_DISABLED_BY_DEFAULT);
+ 
+ // Enables showing contextual error messages when UPM encounters an auth error.
+ BASE_FEATURE(kUnifiedPasswordManagerErrorMessages,

--- a/patches/0098-Disable-Play-services-dependent-password-manager-pre.patch
+++ b/patches/0098-Disable-Play-services-dependent-password-manager-pre.patch
@@ -1,0 +1,26 @@
+From 6034ac171d52eade028c0b7161e2314c6a199818 Mon Sep 17 00:00:00 2001
+From: fgei <fgei@gmail.com>
+Date: Tue, 21 Feb 2023 02:06:16 +0000
+Subject: [PATCH] Disable Play services dependent password manager prefs by
+ default
+
+---
+ components/password_manager/core/browser/password_manager.cc | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/components/password_manager/core/browser/password_manager.cc b/components/password_manager/core/browser/password_manager.cc
+index d67d513536136..f116c83d42d57 100644
+--- a/components/password_manager/core/browser/password_manager.cc
++++ b/components/password_manager/core/browser/password_manager.cc
+@@ -302,9 +302,9 @@ void PasswordManager::RegisterProfilePrefs(
+       prefs::kPasswordDismissCompromisedAlertEnabled, true,
+       user_prefs::PrefRegistrySyncable::SYNCABLE_PREF);
+ #if BUILDFLAG(IS_ANDROID)
+-  registry->RegisterBooleanPref(prefs::kOfferToSavePasswordsEnabledGMS, true);
++  registry->RegisterBooleanPref(prefs::kOfferToSavePasswordsEnabledGMS, false);
+   registry->RegisterBooleanPref(prefs::kSavePasswordsSuspendedByError, false);
+-  registry->RegisterBooleanPref(prefs::kAutoSignInEnabledGMS, true);
++  registry->RegisterBooleanPref(prefs::kAutoSignInEnabledGMS, false);
+   registry->RegisterBooleanPref(prefs::kSettingsMigratedToUPM, false);
+   registry->RegisterIntegerPref(
+       prefs::kCurrentMigrationVersionToGoogleMobileServices, 0);

--- a/patches/0099-Use-local-list-of-supported-languages-for-Language-s.patch
+++ b/patches/0099-Use-local-list-of-supported-languages-for-Language-s.patch
@@ -1,0 +1,34 @@
+From 54ec2ab890f64a1725d0076139af431124fb88be Mon Sep 17 00:00:00 2001
+From: fgei <fgei@gmail.com>
+Date: Sat, 25 Feb 2023 05:11:12 +0100
+Subject: [PATCH] Use local list of supported languages for Language settings
+
+Disable requests or connections to fetch language list from server
+---
+ .../translate/core/browser/translate_language_list.cc       | 6 +++++-
+ 1 file changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/components/translate/core/browser/translate_language_list.cc b/components/translate/core/browser/translate_language_list.cc
+index 1e1753e1b83ae..7525a114d1517 100644
+--- a/components/translate/core/browser/translate_language_list.cc
++++ b/components/translate/core/browser/translate_language_list.cc
+@@ -163,7 +163,7 @@ const char* const kDefaultSupportedLanguages[] = {
+ const char kLanguageListFetchPath[] = "translate_a/l?client=chrome";
+ 
+ // Represent if the language list updater is disabled.
+-bool update_is_disabled = false;
++bool update_is_disabled = true;
+ 
+ // Retry parameter for fetching.
+ const int kMaxRetryOn5xx = 5;
+@@ -229,6 +229,10 @@ GURL TranslateLanguageList::TranslateLanguageUrl() {
+ }
+ 
+ void TranslateLanguageList::RequestLanguageList() {
++  if (update_is_disabled) {
++    return;
++  }
++
+   // If resource requests are not allowed, we'll get a callback when they are.
+   if (!resource_requests_allowed_) {
+     request_pending_ = true;

--- a/patches/0100-Support-for-extended-version-name-and-increments.patch
+++ b/patches/0100-Support-for-extended-version-name-and-increments.patch
@@ -1,0 +1,85 @@
+From 2ff3f024994941abb94b813a872f84a3ad8524a0 Mon Sep 17 00:00:00 2001
+From: fgei <fgei@gmail.com>
+Date: Sun, 26 Feb 2023 10:39:38 +0100
+Subject: [PATCH] Support for extended version name and increments
+
+---
+ build/util/android_chrome_version.py |  2 +-
+ build/util/version.py                |  5 +++++
+ chrome/version.gni                   | 27 +++++++++++++++++++++++++++
+ 3 files changed, 33 insertions(+), 1 deletion(-)
+
+diff --git a/build/util/android_chrome_version.py b/build/util/android_chrome_version.py
+index 910e304bac436..52ebcde02f052 100755
+--- a/build/util/android_chrome_version.py
++++ b/build/util/android_chrome_version.py
+@@ -281,7 +281,7 @@ def GenerateVersionCodes(version_values, arch, is_next_build):
+   """
+ 
+   base_version_code = int(
+-      '%s%03d00' % (version_values['BUILD'], int(version_values['PATCH'])))
++      '%s%03d00' % (version_values['BUILD'], (int(version_values['PATCH']) + int(version_values['INCREMENT']))))
+ 
+   if is_next_build:
+     base_version_code += _NEXT_BUILD_VERSION_CODE_DIFF
+diff --git a/build/util/version.py b/build/util/version.py
+index bf7a59eabf799..40ccb48598804 100755
+--- a/build/util/version.py
++++ b/build/util/version.py
+@@ -128,6 +128,10 @@ def BuildParser():
+                       help='Write substituted strings to FILE.')
+   parser.add_argument('-t', '--template', default=None,
+                       help='Use TEMPLATE as the strings to substitute.')
++  parser.add_argument(
++      '--increment',
++      default='0',
++      help='Version increment to append at version_name, add at version_code.')
+   parser.add_argument(
+       '-e',
+       '--eval',
+@@ -200,6 +204,7 @@ def GenerateValues(options, evals):
+   for key, val in evals.items():
+     values[key] = str(eval(val, globals(), values))
+ 
++  values['INCREMENT'] = options.increment
+   if options.os == 'android':
+     android_chrome_version_codes = android_chrome_version.GenerateVersionCodes(
+         values, options.arch, options.next)
+diff --git a/chrome/version.gni b/chrome/version.gni
+index e197cbe85192b..89d1a4a08e379 100644
+--- a/chrome/version.gni
++++ b/chrome/version.gni
+@@ -39,6 +39,33 @@ if (is_mac) {
+   import("//build/config/android/config.gni")
+   import("//build/config/chrome_build.gni")
+ 
++  declare_args() {
++    # Allows usage for extended versionName increment for android.
++    ext_version_enabled = false
++    # Increment positive integer to append at versionName,
++    # as well as to add on patch section of versionCode.
++    # String is used for utility at build/util/version.py.
++    ext_version_increment = ""
++  }
++
++  # Disallow setting extended version increment when disabled.
++  assert(ext_version_enabled || ext_version_increment == "")
++
++  if (ext_version_enabled) {
++    _version_dictionary_template = "full = \"@MAJOR@.@MINOR@.@BUILD@" +
++                                 ".@PATCH@.@INCREMENT@\" " +
++                                 "major = \"@MAJOR@\" minor = \"@MINOR@\" " +
++                                 "build = \"@BUILD@\" patch = \"@PATCH@\" " +
++                                 "increment = \"@INCREMENT@\" "
++
++    if (ext_version_increment != "") {
++      _script_arguments += [
++        "--increment",
++        ext_version_increment
++      ]
++    }
++  }
++
+   _version_dictionary_template +=
+       "chrome_version_code = " + "\"@CHROME_VERSION_CODE@\" " +
+       "chrome_modern_version_code = \"@CHROME_MODERN_VERSION_CODE@\" " +


### PR DESCRIPTION
This CL adds support for incrementing version code without updating base Chromium code, support for android autofill, with bugfixes such as switching to new keyboard-based browser autofill UI to prevent dropdown menu obstructing other popups, along with always using local list of supported languages for Language settings.