### PR TITLE
Improve coverage of opening links in incognito preference in search activity

### DIFF
--- a/patches/0121-Support-for-opening-in-incognito-tabs-for-search-que.patch
+++ b/patches/0121-Support-for-opening-in-incognito-tabs-for-search-que.patch
@@ -1,0 +1,34 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: fgei <fgei@gmail.com>
+Date: Thu, 16 Nov 2023 18:31:07 +0000
+Subject: [PATCH] Support for opening in incognito tabs for search queries from
+ search widgets or intents
+
+---
+ .../chromium/chrome/browser/searchwidget/SearchActivity.java | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/chrome/android/java/src/org/chromium/chrome/browser/searchwidget/SearchActivity.java b/chrome/android/java/src/org/chromium/chrome/browser/searchwidget/SearchActivity.java
+index 8b57b868a1a1a..4e8befc96e018 100644
+--- a/chrome/android/java/src/org/chromium/chrome/browser/searchwidget/SearchActivity.java
++++ b/chrome/android/java/src/org/chromium/chrome/browser/searchwidget/SearchActivity.java
+@@ -300,7 +300,11 @@ public class SearchActivity extends AsyncInitializationActivity
+ 
+     @Override
+     public void finishNativeInitialization() {
++        boolean isIncognitoMode = IntentUtils.safeGetBooleanExtra(getIntent(), IntentHandler.EXTRA_INCOGNITO_MODE, false);
+         Profile profile = Profile.getLastUsedRegularProfile();
++        if (isIncognitoMode) {
++            profile = profile.getPrimaryOTRProfile(true);
++        }
+         mProfileSupplier.set(profile);
+ 
+         super.finishNativeInitialization();
+@@ -365,6 +369,7 @@ public class SearchActivity extends AsyncInitializationActivity
+                        .setLaunchType(TabLaunchType.FROM_EXTERNAL_APP)
+                        .setWebContents(webContents)
+                        .setDelegateFactory(factory)
++                       .setIncognito(isIncognitoMode)
+                        .build();
+         mTab.loadUrl(new LoadUrlParams(ContentUrlConstants.ABOUT_BLANK_DISPLAY_URL));
+ 

--- a/patches/0122-Do-not-query-for-search-suggestions-when-open-links-.patch
+++ b/patches/0122-Do-not-query-for-search-suggestions-when-open-links-.patch
@@ -1,0 +1,24 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: fgei <fgei@gmail.com>
+Date: Thu, 16 Nov 2023 18:34:22 +0000
+Subject: [PATCH] Do not query for search suggestions when open links in
+ incognito is enabled for web search intents
+
+---
+ .../org/chromium/chrome/browser/LaunchIntentDispatcher.java    | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/chrome/android/java/src/org/chromium/chrome/browser/LaunchIntentDispatcher.java b/chrome/android/java/src/org/chromium/chrome/browser/LaunchIntentDispatcher.java
+index dc43814b49142..c93adbc8cd83c 100644
+--- a/chrome/android/java/src/org/chromium/chrome/browser/LaunchIntentDispatcher.java
++++ b/chrome/android/java/src/org/chromium/chrome/browser/LaunchIntentDispatcher.java
+@@ -226,6 +226,9 @@ public class LaunchIntentDispatcher {
+                 searchActivityIntent.setClass(
+                         ContextUtils.getApplicationContext(), SearchActivity.class);
+                 searchActivityIntent.putExtra(SearchManager.QUERY, query);
++                if (TabPreferencesUtils.shouldOpenLinksInIncognito()) {
++                    searchActivityIntent.putExtra(IntentHandler.EXTRA_INCOGNITO_MODE, true);
++                }
+                 mActivity.startActivity(searchActivityIntent);
+             }
+         }


### PR DESCRIPTION
When opening new incognito tabs, and typing URL into the URL bar, there is no search suggestion fetched when enabled. This is not the case when opening URL search bar even when open links in incognito is enabled. Match new incognito tab behavior with web search intents being opened by treating tabs being opened in incognito when "Open external links in incognito" is enabled.