### PR TITLE
upstream: Fix gl_clear_broken workaround when transform feedback is active

### DIFF
--- a/patches/0240-upstream-Fix-gl_clear_broken-workaround-when-transfo.patch
+++ b/patches/0240-upstream-Fix-gl_clear_broken-workaround-when-transfo.patch
@@ -1,0 +1,518 @@
+From d45d64fb17858fa95b202d84941d05e2ffb63edd Mon Sep 17 00:00:00 2001
+From: inthewaves <inthewaves@pm.me>
+Date: Fri, 13 Mar 2026 05:01:48 -0700
+Subject: [PATCH] upstream: Fix gl_clear_broken workaround when transform
+ feedback is active
+
+The gl_clear_broken workaround uses glUseProgram, but this yields an
+unhandled error when transform feedback is active. A crash can be
+triggered by visiting, e.g.
+https://registry.khronos.org/webgl/sdk/tests/deqp/functional/gles3/shaderpackingfunction.html?webglVersion=2&quiet=0&quick=1
+on a device that has the gl_clear_broken workaround active.
+
+Fix this by pausing transform feedback before the glUseProgram call, and
+then resume it after the original program and buffers have been
+restored. glClear isn't a part of the Vertex Processing steps, so
+pausing transform feedback should be appropriate.
+
+Test: tools/autotest.py -C out/Default/ ES3ClearBufferTest; gl_tests;
+gl_unittests; gpu_unittests; opening the linked page
+---
+ .../service/gles2_cmd_clear_framebuffer.cc    |  25 ++
+ .../service/gles2_cmd_clear_framebuffer.h     |   2 +
+ .../service/gles2_cmd_decoder.cc              |   3 +-
+ .../tests/gl_clear_framebuffer_unittest.cc    | 355 +++++++++++++++++-
+ 4 files changed, 374 insertions(+), 11 deletions(-)
+
+diff --git a/gpu/command_buffer/service/gles2_cmd_clear_framebuffer.cc b/gpu/command_buffer/service/gles2_cmd_clear_framebuffer.cc
+index 843c81c0294da..42772b1e624ec 100644
+--- a/gpu/command_buffer/service/gles2_cmd_clear_framebuffer.cc
++++ b/gpu/command_buffer/service/gles2_cmd_clear_framebuffer.cc
+@@ -4,9 +4,11 @@
+ 
+ #include "gpu/command_buffer/service/gles2_cmd_clear_framebuffer.h"
+ 
++#include "base/functional/callback_helpers.h"
+ #include "gpu/command_buffer/service/gl_utils.h"
+ #include "gpu/command_buffer/service/gles2_cmd_decoder.h"
+ #include "gpu/command_buffer/service/shader_manager.h"
++#include "gpu/command_buffer/service/transform_feedback_manager.h"
+ #include "ui/gfx/geometry/size.h"
+ 
+ namespace {
+@@ -78,6 +80,7 @@ void ClearFramebufferResourceManager::Destroy() {
+ 
+ void ClearFramebufferResourceManager::ClearFramebuffer(
+     const gles2::GLES2Decoder* decoder,
++    TransformFeedback* transform_feedback,
+     const gfx::Size& max_viewport_size,
+     GLbitfield mask,
+     GLfloat clear_color_red,
+@@ -112,6 +115,28 @@ void ClearFramebufferResourceManager::ClearFramebuffer(
+     glDeleteShader(fragment_shader);
+     glDeleteShader(vertex_shader);
+   }
++
++  // Cannot use glUseProgram if transform feedback is active and not paused.
++  // This is a workaround for glClear which isn't part of vertex processing
++  // anyway.
++  base::ScopedClosureRunner resume_transform_feedback;
++  if (transform_feedback && transform_feedback->active() &&
++      !transform_feedback->paused()) {
++    transform_feedback->DoPauseTransformFeedback();
++
++    resume_transform_feedback = base::ScopedClosureRunner(base::BindOnce(
++        [](TransformFeedback* tf) {
++          // To resume, we need to
++          // - bind the paused feedback object (handled in
++          //   RestoreBufferBindings), and
++          // - bind the exact program or pipeline object that was used when
++          //   glBeginTransformFeedback was called (handled in
++          //   RestoreProgramBindings)
++          tf->DoResumeTransformFeedback();
++        },
++        base::Unretained(transform_feedback)));
++  }
++
+   glUseProgram(program_);
+ 
+ #if DCHECK_IS_ON()
+diff --git a/gpu/command_buffer/service/gles2_cmd_clear_framebuffer.h b/gpu/command_buffer/service/gles2_cmd_clear_framebuffer.h
+index 3b2741a37dd9c..6d6076d910e01 100644
+--- a/gpu/command_buffer/service/gles2_cmd_clear_framebuffer.h
++++ b/gpu/command_buffer/service/gles2_cmd_clear_framebuffer.h
+@@ -6,6 +6,7 @@
+ #define GPU_COMMAND_BUFFER_SERVICE_GLES2_CMD_CLEAR_FRAMEBUFFER_H_
+ 
+ #include "gpu/command_buffer/service/gl_utils.h"
++#include "gpu/command_buffer/service/transform_feedback_manager.h"
+ #include "gpu/gpu_gles2_export.h"
+ 
+ namespace gfx {
+@@ -29,6 +30,7 @@ class GPU_GLES2_EXPORT ClearFramebufferResourceManager {
+ 
+   void Destroy();
+   void ClearFramebuffer(const gles2::GLES2Decoder* decoder,
++                        TransformFeedback* transform_feedback,
+                         const gfx::Size& max_viewport_size,
+                         GLbitfield mask,
+                         GLfloat clear_color_red,
+diff --git a/gpu/command_buffer/service/gles2_cmd_decoder.cc b/gpu/command_buffer/service/gles2_cmd_decoder.cc
+index 777c226757334..23aebcd07ccb5 100644
+--- a/gpu/command_buffer/service/gles2_cmd_decoder.cc
++++ b/gpu/command_buffer/service/gles2_cmd_decoder.cc
+@@ -16911,7 +16911,8 @@ void GLES2DecoderImpl::ClearFramebufferForWorkaround(GLbitfield mask) {
+   ScopedGLErrorSuppressor suppressor("GLES2DecoderImpl::ClearWorkaround",
+                                      error_state_.get());
+   clear_framebuffer_blit_->ClearFramebuffer(
+-      this, gfx::Size(viewport_max_width_, viewport_max_height_), mask,
++      this, state_.bound_transform_feedback.get(),
++      gfx::Size(viewport_max_width_, viewport_max_height_), mask,
+       state_.color_clear_red, state_.color_clear_green, state_.color_clear_blue,
+       state_.color_clear_alpha, state_.depth_clear, state_.stencil_clear);
+ }
+diff --git a/gpu/command_buffer/tests/gl_clear_framebuffer_unittest.cc b/gpu/command_buffer/tests/gl_clear_framebuffer_unittest.cc
+index 6ae914e77237b..11ce787c0576f 100644
+--- a/gpu/command_buffer/tests/gl_clear_framebuffer_unittest.cc
++++ b/gpu/command_buffer/tests/gl_clear_framebuffer_unittest.cc
+@@ -31,15 +31,19 @@ class GLClearFramebufferTest : public testing::TestWithParam<bool> {
+   GLClearFramebufferTest() : color_handle_(0u), depth_handle_(0u) {}
+ 
+  protected:
++  virtual GLManager::Options GetGlManagerOptions() {
++    return GLManager::Options();
++  }
++
+   void SetUp() override {
+     if (GetParam()) {
+       // Force the glClear() workaround so we can test it here.
+       GpuDriverBugWorkarounds workarounds;
+       workarounds.gl_clear_broken = true;
+-      gl_.InitializeWithWorkarounds(GLManager::Options(), workarounds);
++      gl_.InitializeWithWorkarounds(GetGlManagerOptions(), workarounds);
+       DCHECK(gl_.workarounds().gl_clear_broken);
+     } else {
+-      gl_.Initialize(GLManager::Options());
++      gl_.Initialize(GetGlManagerOptions());
+       DCHECK(!gl_.workarounds().gl_clear_broken);
+     }
+   }
+@@ -260,16 +264,16 @@ TEST_P(GLClearFramebufferTest, SeparateFramebufferClear) {
+   EXPECT_TRUE(GLTestHelper::CheckPixels(3, 3, 1, 1, 0, kGreen, nullptr));
+ }
+ 
+-class ES3ClearBufferTest : public testing::Test {
++class ES3ClearBufferTest : public GLClearFramebufferTest {
+  protected:
+   static const GLsizei kCanvasSize = 4;
++  static const size_t kTfBufferSizeBytes = 1024;
+ 
+-  void SetUp() override {
++  GLManager::Options GetGlManagerOptions() override {
+     GLManager::Options options;
+     options.size = gfx::Size(kCanvasSize, kCanvasSize);
+     options.context_type = CONTEXT_TYPE_OPENGLES3;
+-
+-    gl_.Initialize(options);
++    return options;
+   }
+ 
+   bool ShouldSkipTest() const {
+@@ -279,14 +283,92 @@ class ES3ClearBufferTest : public testing::Test {
+     return (!gl_.decoder() || !gl_.decoder()->GetContextGroup());
+   }
+ 
+-  void TearDown() override {
+-    gl_.Destroy();
++  bool ShouldSkipTransformFeedbackTest() const {
++    if (!GetParam()) {
++      return false;
++    }
++
++#if defined(ARCH_CPU_X86_FAMILY)
++    std::string renderer =
++        reinterpret_cast<const char*>(glGetString(GL_RENDERER));
++    // android-29;google_apis;x86 does not follow OpenGL ES 3.0+ spec. It
++    // doesn't allow any primitive type to be used in glDrawArrays, etc. while
++    // transform feedback is paused, which will cause an error in the
++    // gl_clear_broken workaround.
++    return renderer ==
++           "Android Emulator OpenGL ES Translator (Google SwiftShader)";
++#else
++    return false;
++#endif
+   }
+ 
+-  GLManager gl_;
++  void InitDrawWithTF();
++
++ protected:
++  GLuint tf_buffer_ = 0;
+ };
+ 
+-TEST_F(ES3ClearBufferTest, ClearBuffersuiv) {
++INSTANTIATE_TEST_SUITE_P(ES3ClearBufferTestWithParam,
++                         ES3ClearBufferTest,
++                         ::testing::Values(true, false));
++
++void ES3ClearBufferTest::InitDrawWithTF() {
++  static const char* vs =
++      "#version 300 es\n"
++      "in vec4 a_Position;\n"
++      "out vec4 v_out;\n"
++      "uniform float u_depth;\n"
++      "void main()\n"
++      "{\n"
++      "   v_out = a_Position;\n"
++      "   gl_Position = a_Position;\n"
++      "   gl_Position.z = u_depth;\n"
++      "}\n";
++  static const char* fs =
++      "#version 300 es\n"
++      "precision mediump float;\n"
++      "uniform vec4 u_draw_color;\n"
++      "out vec4 fragColor;\n"
++      "void main()\n"
++      "{\n"
++      "  fragColor = u_draw_color;\n"
++      "}\n";
++  GLuint vertex_shader = GLTestHelper::CompileShader(GL_VERTEX_SHADER, vs);
++  GLuint fragment_shader = GLTestHelper::CompileShader(GL_FRAGMENT_SHADER, fs);
++  GLuint program = glCreateProgram();
++  glAttachShader(program, vertex_shader);
++  glAttachShader(program, fragment_shader);
++  const char* varyings[] = {"v_out"};
++  glTransformFeedbackVaryings(program, 1, varyings, GL_INTERLEAVED_ATTRIBS);
++  ASSERT_EQ(static_cast<GLenum>(GL_NO_ERROR), glGetError());
++
++  glLinkProgram(program);
++  GLint linked = GL_FALSE;
++  glGetProgramiv(program, GL_LINK_STATUS, &linked);
++  ASSERT_EQ(GL_TRUE, linked);
++
++  DCHECK(program);
++  glUseProgram(program);
++  GLuint position_loc = glGetAttribLocation(program, "a_Position");
++
++  GLTestHelper::SetupUnitQuad(position_loc);
++  color_handle_ = glGetUniformLocation(program, "u_draw_color");
++  DCHECK(color_handle_ != static_cast<GLuint>(-1));
++  depth_handle_ = glGetUniformLocation(program, "u_depth");
++  DCHECK(depth_handle_ != static_cast<GLuint>(-1));
++
++  // Set up transform feedback outputs
++  glGenBuffers(1, &tf_buffer_);
++  glBindBuffer(GL_TRANSFORM_FEEDBACK_BUFFER, tf_buffer_);
++  glBufferData(GL_TRANSFORM_FEEDBACK_BUFFER, kTfBufferSizeBytes, nullptr,
++               GL_DYNAMIC_COPY);
++  GLuint tf;
++  glGenTransformFeedbacks(1, &tf);
++  glBindTransformFeedback(GL_TRANSFORM_FEEDBACK, tf);
++  glBindBufferBase(GL_TRANSFORM_FEEDBACK_BUFFER, 0, tf_buffer_);
++}
++
++TEST_P(ES3ClearBufferTest, ClearBuffersuiv) {
+   if (ShouldSkipTest())
+     return;
+ 
+@@ -298,4 +380,257 @@ TEST_F(ES3ClearBufferTest, ClearBuffersuiv) {
+   GLTestHelper::CheckGLError("no errors", __LINE__);
+ }
+ 
++TEST_P(ES3ClearBufferTest,
++       DrawArraysWithUnclearedAttachmentAndTransformFeedback) {
++  if (ShouldSkipTest()) {
++    GTEST_SKIP() << "ES3 not supported";
++  }
++  if (ShouldSkipTransformFeedbackTest()) {
++    GTEST_SKIP() << "Transform feedback not supported in workaround";
++  }
++
++  InitDrawWithTF();
++
++  glBeginTransformFeedback(GL_TRIANGLES);
++  ASSERT_EQ(static_cast<GLenum>(GL_NO_ERROR), glGetError());
++
++  // Create framebuffer with an uncleared texture attachment and bind it as
++  // the draw framebuffer. This will trigger a clear from HandleDrawArrays ->
++  // DoMultiDrawArrays -> CheckBoundDrawFramebufferValid ->
++  // CheckFramebufferValid -> ClearUnclearedAttachments when drawing quad
++  GLuint fbo, texture;
++  glGenFramebuffers(1, &fbo);
++  glGenTextures(1, &texture);
++  glBindTexture(GL_TEXTURE_2D, texture);
++  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, 2, 2, 0, GL_RGBA, GL_UNSIGNED_BYTE,
++               nullptr /* data, nullptr to make it uncleared */);
++  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
++  glBindFramebuffer(GL_DRAW_FRAMEBUFFER, fbo);
++  glFramebufferTexture2D(GL_DRAW_FRAMEBUFFER, GL_COLOR_ATTACHMENT0,
++                         GL_TEXTURE_2D, texture, 0);
++  EXPECT_EQ(glCheckFramebufferStatus(GL_DRAW_FRAMEBUFFER),
++            static_cast<GLenum>(GL_FRAMEBUFFER_COMPLETE));
++
++  // Draw quad to fbo.
++  SetDrawColor(1.0f, 0.0f, 0.0f, 1.0f);
++  DrawQuad();
++
++  glBindFramebuffer(GL_READ_FRAMEBUFFER, fbo);
++  const uint8_t kRed[] = {255, 0, 0, 255};
++  EXPECT_TRUE(
++      GLTestHelper::CheckPixels(0, 0, 1, 1, 0 /* tolerance */, kRed, nullptr));
++
++  GLint tf_active = 0;
++  GLint tf_paused = 0;
++  glGetIntegerv(GL_TRANSFORM_FEEDBACK_ACTIVE, &tf_active);
++  glGetIntegerv(GL_TRANSFORM_FEEDBACK_PAUSED, &tf_paused);
++  EXPECT_EQ(1, tf_active);
++  EXPECT_EQ(0, tf_paused);
++
++  glEndTransformFeedback();
++  EXPECT_EQ(static_cast<GLenum>(GL_NO_ERROR), glGetError());
++
++  // GLTestHelper::SetupUnitQuad + DrawQuad: 2 triangles (6 vertices) forming a
++  // unit quad
++  constexpr size_t kQuadVertexCount = 6;
++  constexpr size_t kVec4ComponentCount = 4;
++  constexpr size_t kFeedbackSize =
++      kQuadVertexCount * kVec4ComponentCount * sizeof(GLfloat);
++
++  void* mapped = glMapBufferRange(GL_TRANSFORM_FEEDBACK_BUFFER, 0,
++                                  kFeedbackSize, GL_MAP_READ_BIT);
++  ASSERT_NE(nullptr, mapped);
++  ASSERT_EQ(static_cast<GLenum>(GL_NO_ERROR), glGetError());
++  // SAFETY: The transform feedback varying is on v_out which is a vec4 type
++  // (four-component floating-point vector), so a GLfloat is used.
++  // glMapBufferRange (OpenGL API) returns a pointer to the beginning of the
++  // mapped range of size kTfBufferSizeBytes, and kBufferFloats is
++  // kTfBufferSizeBytes / sizeof(GLfloat) is the exact number of GLfloat
++  // elements that fit in that buffer. mapped is not null, so no errors.
++  auto feedback_span =
++      UNSAFE_BUFFERS(base::span(static_cast<const GLfloat*>(mapped),
++                                kQuadVertexCount * kVec4ComponentCount));
++  glUnmapBuffer(GL_TRANSFORM_FEEDBACK_BUFFER);
++  ASSERT_EQ(static_cast<GLenum>(GL_NO_ERROR), glGetError());
++
++  for (size_t vertex_index = 0; vertex_index < kQuadVertexCount;
++       ++vertex_index) {
++    size_t base_index = vertex_index * kVec4ComponentCount;
++    GLfloat w = feedback_span[base_index + 3];
++    GLfloat x = feedback_span[base_index];
++    GLfloat y = feedback_span[base_index + 1];
++    // Unit quad vertex component check
++    EXPECT_FLOAT_EQ(1.0f, std::abs(x))
++        << "x component wrong at vertex " << vertex_index;
++    EXPECT_FLOAT_EQ(1.0f, std::abs(y))
++        << "y component wrong at vertex " << vertex_index;
++    // 1.0f means it was set. SetupUnitQuad vertices are lower dimension than
++    // vec4 (vec2), but 1.0f should be filled in for it.
++    EXPECT_FLOAT_EQ(1.0f, w) << "w component wrong at vertex " << vertex_index;
++  }
++}
++
++TEST_P(ES3ClearBufferTest, ClearDoesNotWriteToTransformFeedbackBuffer) {
++  if (ShouldSkipTest()) {
++    GTEST_SKIP() << "ES3 not supported";
++  }
++  if (ShouldSkipTransformFeedbackTest()) {
++    GTEST_SKIP() << "Transform feedback not supported in workaround";
++  }
++
++  InitDrawWithTF();
++
++  glBeginTransformFeedback(GL_TRIANGLES);
++  ASSERT_EQ(static_cast<GLenum>(GL_NO_ERROR), glGetError());
++
++  // Issue several clears while transform feedback is active. Transform feedback
++  // should only capture Primitives generated by the Vertex Processing step(s).
++  // The workaround should have the effect of glClear which is not part of
++  // Vertex Processing.
++  glClearColor(1.0f, 0.0f, 0.0f, 1.0f);
++  glClear(GL_COLOR_BUFFER_BIT);
++  ASSERT_EQ(static_cast<GLenum>(GL_NO_ERROR), glGetError());
++  const uint8_t kRed[] = {255, 0, 0, 255};
++  EXPECT_TRUE(
++      GLTestHelper::CheckPixels(0, 0, 1, 1, 0 /* tolerance */, kRed, nullptr));
++
++  GLint tf_active = 0;
++  GLint tf_paused = 0;
++  glGetIntegerv(GL_TRANSFORM_FEEDBACK_ACTIVE, &tf_active);
++  glGetIntegerv(GL_TRANSFORM_FEEDBACK_PAUSED, &tf_paused);
++  EXPECT_EQ(1, tf_active);
++  EXPECT_EQ(0, tf_paused);
++
++  glClearColor(0.0f, 1.0f, 0.0f, 1.0f);
++  glClear(GL_COLOR_BUFFER_BIT);
++  ASSERT_EQ(static_cast<GLenum>(GL_NO_ERROR), glGetError());
++  const uint8_t kGreen[] = {0, 255, 0, 255};
++  EXPECT_TRUE(GLTestHelper::CheckPixels(0, 0, 1, 1, 0 /* tolerance */, kGreen,
++                                        nullptr));
++
++  glClearColor(0.0f, 0.0f, 1.0f, 1.0f);
++  glClear(GL_COLOR_BUFFER_BIT);
++  ASSERT_EQ(static_cast<GLenum>(GL_NO_ERROR), glGetError());
++  const uint8_t kBlue[] = {0, 0, 255, 255};
++  EXPECT_TRUE(
++      GLTestHelper::CheckPixels(0, 0, 1, 1, 0 /* tolerance */, kBlue, nullptr));
++
++  glEndTransformFeedback();
++  ASSERT_EQ(static_cast<GLenum>(GL_NO_ERROR), glGetError());
++
++  // The TF buffer was initialized with nullptr (all zeros). If glClear
++  // workaround incorrectly wrote anything to it, we would see non-zero values.
++  constexpr size_t kBufferFloats = kTfBufferSizeBytes / sizeof(GLfloat);
++  void* mapped = glMapBufferRange(GL_TRANSFORM_FEEDBACK_BUFFER, 0,
++                                  kTfBufferSizeBytes, GL_MAP_READ_BIT);
++  ASSERT_NE(nullptr, mapped);
++  ASSERT_EQ(static_cast<GLenum>(GL_NO_ERROR), glGetError());
++  // SAFETY: The transform feedback varying is on v_out which is a vec4 type
++  // (four-component floating-point vector), so a GLfloat is used.
++  // glMapBufferRange (OpenGL API) returns a pointer to the beginning of the
++  // mapped range of size kTfBufferSizeBytes, and kBufferFloats is
++  // kTfBufferSizeBytes / sizeof(GLfloat) is the exact number of GLfloat
++  // elements that fit in that buffer. mapped is not null, so no errors.
++  auto feedback_span = UNSAFE_BUFFERS(
++      base::span(static_cast<const GLfloat*>(mapped), kBufferFloats));
++  glUnmapBuffer(GL_TRANSFORM_FEEDBACK_BUFFER);
++  ASSERT_EQ(static_cast<GLenum>(GL_NO_ERROR), glGetError());
++
++  for (size_t float_index = 0; float_index < kBufferFloats; ++float_index) {
++    EXPECT_EQ(0.0f, feedback_span[float_index])
++        << "TF buffer nonzero at float index " << float_index;
++  }
++}
++
++TEST_P(ES3ClearBufferTest, ClearSucceedsWithDifferentTransformFeedbackTypes) {
++  if (ShouldSkipTest()) {
++    GTEST_SKIP() << "ES3 not supported";
++  }
++  if (ShouldSkipTransformFeedbackTest()) {
++    GTEST_SKIP() << "Transform feedback not supported in workaround";
++  }
++
++  InitDrawWithTF();
++
++  glBeginTransformFeedback(GL_TRIANGLES);
++  ASSERT_EQ(static_cast<GLenum>(GL_NO_ERROR), glGetError());
++
++  glClearColor(1.0f, 0.0f, 0.0f, 1.0f);
++  glClear(GL_COLOR_BUFFER_BIT);
++  ASSERT_EQ(static_cast<GLenum>(GL_NO_ERROR), glGetError());
++  const uint8_t kRed[] = {255, 0, 0, 255};
++  EXPECT_TRUE(
++      GLTestHelper::CheckPixels(0, 0, 1, 1, 0 /* tolerance */, kRed, nullptr));
++
++  glEndTransformFeedback();
++  glBeginTransformFeedback(GL_LINES);
++  ASSERT_EQ(static_cast<GLenum>(GL_NO_ERROR), glGetError());
++
++  glClearColor(0.0f, 1.0f, 0.0f, 1.0f);
++  glClear(GL_COLOR_BUFFER_BIT);
++  ASSERT_EQ(static_cast<GLenum>(GL_NO_ERROR), glGetError());
++  const uint8_t kGreen[] = {0, 255, 0, 255};
++  EXPECT_TRUE(GLTestHelper::CheckPixels(0, 0, 1, 1, 0 /* tolerance */, kGreen,
++                                        nullptr));
++
++  glEndTransformFeedback();
++  glBeginTransformFeedback(GL_POINTS);
++  ASSERT_EQ(static_cast<GLenum>(GL_NO_ERROR), glGetError());
++
++  glClearColor(0.0f, 0.0f, 1.0f, 1.0f);
++  glClear(GL_COLOR_BUFFER_BIT);
++  ASSERT_EQ(static_cast<GLenum>(GL_NO_ERROR), glGetError());
++  const uint8_t kBlue[] = {0, 0, 255, 255};
++  EXPECT_TRUE(
++      GLTestHelper::CheckPixels(0, 0, 1, 1, 0 /* tolerance */, kBlue, nullptr));
++
++  glEndTransformFeedback();
++  ASSERT_EQ(static_cast<GLenum>(GL_NO_ERROR), glGetError());
++}
++
++TEST_P(ES3ClearBufferTest,
++       ClearSucceedsWithPausingAndResumingTransformFeedback) {
++  if (ShouldSkipTest()) {
++    GTEST_SKIP() << "ES3 not supported";
++  }
++  if (ShouldSkipTransformFeedbackTest()) {
++    GTEST_SKIP() << "Transform feedback not supported in workaround";
++  }
++
++  InitDrawWithTF();
++
++  glBeginTransformFeedback(GL_TRIANGLES);
++  ASSERT_EQ(static_cast<GLenum>(GL_NO_ERROR), glGetError());
++
++  glClearColor(1.0f, 0.0f, 0.0f, 1.0f);
++  glClear(GL_COLOR_BUFFER_BIT);
++  ASSERT_EQ(static_cast<GLenum>(GL_NO_ERROR), glGetError());
++  const uint8_t kRed[] = {255, 0, 0, 255};
++  EXPECT_TRUE(
++      GLTestHelper::CheckPixels(0, 0, 1, 1, 0 /* tolerance */, kRed, nullptr));
++
++  glPauseTransformFeedback();
++  ASSERT_EQ(static_cast<GLenum>(GL_NO_ERROR), glGetError());
++
++  glClearColor(0.0f, 1.0f, 0.0f, 1.0f);
++  glClear(GL_COLOR_BUFFER_BIT);
++  ASSERT_EQ(static_cast<GLenum>(GL_NO_ERROR), glGetError());
++  const uint8_t kGreen[] = {0, 255, 0, 255};
++  EXPECT_TRUE(GLTestHelper::CheckPixels(0, 0, 1, 1, 0 /* tolerance */, kGreen,
++                                        nullptr));
++
++  glResumeTransformFeedback();
++  ASSERT_EQ(static_cast<GLenum>(GL_NO_ERROR), glGetError());
++
++  glClearColor(0.0f, 0.0f, 1.0f, 1.0f);
++  glClear(GL_COLOR_BUFFER_BIT);
++  ASSERT_EQ(static_cast<GLenum>(GL_NO_ERROR), glGetError());
++  const uint8_t kBlue[] = {0, 0, 255, 255};
++  EXPECT_TRUE(
++      GLTestHelper::CheckPixels(0, 0, 1, 1, 0 /* tolerance */, kBlue, nullptr));
++
++  glEndTransformFeedback();
++  ASSERT_EQ(static_cast<GLenum>(GL_NO_ERROR), glGetError());
++}
++
+ }  // namespace gpu
+-- 
+2.43.0
+


### PR DESCRIPTION
Note: This is a variant of a patch I submitted upstream. The patch hasn't been merged yet, but it has +2 Code Reviews from Chromium committers, although one +1 was before a CQ Dry Run failure on android-x86-rel emulator image due to SwiftShader not being OpenGL ES spec compliant. The only other failure was with android_optional_gpu_tests_rel which seemed like a flaky test not related to these changes. All other platforms for the CQ Dry Run including android-x64-rel passed.

The gl_clear_broken workaround uses glUseProgram, but this yields an unhandled error when transform feedback is active. A crash can be triggered by visiting, e.g.
https://registry.khronos.org/webgl/sdk/tests/deqp/functional/gles3/shaderpackingfunction.html?webglVersion=2&quiet=0&quick=1 on a device that has the gl_clear_broken workaround active.

Fix this by pausing transform feedback before the glUseProgram call, and then resume it after the original program and buffers have been restored. glClear isn't a part of the Vertex Processing steps, so pausing transform feedback should be appropriate.

Test: tools/autotest.py -C out/Default/ ES3ClearBufferTest; gl_tests; gl_unittests; gpu_unittests; opening the linked page