### PR TITLE
Fix NFC/USB FIDO2 security key support when using 3P credential providers

### DIFF
--- a/patches/0162-Enable-CredentialManager-APIs-for-all-apps-supportin.patch
+++ b/patches/0162-Enable-CredentialManager-APIs-for-all-apps-supportin.patch
@@ -6,8 +6,8 @@ Subject: [PATCH] Enable CredentialManager APIs for all apps supporting
 
 ---
  chrome/browser/webauthn/android/BUILD.gn          |  1 +
- .../webauthn/CredManUiRecommenderImpl.java        | 15 +++++++++++++++
- 2 files changed, 16 insertions(+)
+ .../webauthn/CredManUiRecommenderImpl.java        | 25 +++++++++++++++++++++++
+ 2 files changed, 26 insertions(+)
  create mode 100644 chrome/browser/webauthn/android/java/src/org/chromium/chrome/browser/webauthn/CredManUiRecommenderImpl.java
 
 diff --git a/chrome/browser/webauthn/android/BUILD.gn b/chrome/browser/webauthn/android/BUILD.gn
@@ -24,22 +24,32 @@ index 0add49651bc94..b3b1c43bdfdf6 100644
    deps = [
 diff --git a/chrome/browser/webauthn/android/java/src/org/chromium/chrome/browser/webauthn/CredManUiRecommenderImpl.java b/chrome/browser/webauthn/android/java/src/org/chromium/chrome/browser/webauthn/CredManUiRecommenderImpl.java
 new file mode 100644
-index 0000000000000..fcfc935c9218a
+index 0000000000000..0000000000000
 --- /dev/null
 +++ b/chrome/browser/webauthn/android/java/src/org/chromium/chrome/browser/webauthn/CredManUiRecommenderImpl.java
-@@ -0,0 +1,15 @@
+@@ -0,0 +1,25 @@
 +// Copyright 2024 The Chromium Authors
 +// Use of this source code is governed by a BSD-style license that can be
 +// found in the LICENSE file.
 +package org.chromium.chrome.browser.webauthn;
 +
 +import org.chromium.build.annotations.ServiceImpl;
++import org.chromium.components.webauthn.Fido2ApiCallHelper;
 +import org.chromium.components.webauthn.cred_man.CredManUiRecommender;
 +
 +@ServiceImpl(CredManUiRecommender.class)
 +public class CredManUiRecommenderImpl implements CredManUiRecommender {
 +    @Override
 +    public boolean recommendsCustomUi() {
-+        return true; // Use the platform CredMan APIs if available.
++        // Defer to upstream Chrome's PARALLEL_WITH_FIDO_2 mode (Barrier.Mode.BOTH)
++        // when Play Services is available so the FIDO2/hybrid path (incl. NFC/USB
++        // security keys) remains reachable alongside 3P credential providers.
++        // When Play Services is unavailable, recommend the platform CredMan UI so
++        // passkeys still work via 3P providers without any FIDO2 dependency.
++        try {
++            return !Fido2ApiCallHelper.getInstance().arePlayServicesAvailable();
++        } catch (Exception e) {
++            return true;
++        }
 +    }
 +}


### PR DESCRIPTION
When Play Services is present, restore upstream Chrome's PARALLEL_WITH_FIDO_2 mode (Barrier.Mode.BOTH) by deferring to the default recommendsCustomUi() behaviour. This surfaces Chrome's own WebAuthn picker which includes the "Use a security key" entry that dispatches to GMS's NFC/USB FIDO2 modal, fixing hardware security key authentication alongside third-party credential providers such as Proton Pass.

When Play Services is not installed, recommendsCustomUi() returns true as before, keeping ONLY_CRED_MAN mode and preserving full passkey support via 3P CredMan providers without any FIDO2/GMS dependency.

Fixes #1104