### PR TITLE
Enable WebViewFasterGetDefaultUserAgent by default

### DIFF
--- a/patches/0267-Enable-WebViewFasterGetDefaultUserAgent-by-default.patch
+++ b/patches/0267-Enable-WebViewFasterGetDefaultUserAgent-by-default.patch
@@ -1,0 +1,61 @@
+From 1948eb6ea786ec7e7efb1f8dbc764ee509030b96 Mon Sep 17 00:00:00 2001
+From: inthewaves <inthewaves@pm.me>
+Date: Fri, 22 May 2026 01:35:30 -0700
+Subject: [PATCH 267/267] Enable WebViewFasterGetDefaultUserAgent by default
+
+Apps, in particular ones that use Google Mobile Ads SDK, can dead lock. A worker thread in the
+Mobile Ads SDK holds a singleton lock and calls WebSettings.getDefaultUserAgent() which block until
+a task posted to the main thread to initialize WebView finishes. Meanwhile, the main thread of the
+app enters Mobile Ads SDK. If the Dynamite ads module is not available, the library has a local
+fallback path which attempts to acquires the singleton lock that the worker thread is holding. The
+result is that the main thread gets blocked on a lock held by the worker thread which is waiting for
+main thread to process its task.
+
+Dynamite ads module can be unavailable if Play services + Play Store are not installed (or have some
+other issue). This would block users from using any app with SDK used in this way.
+
+By enabling this feature, the worker thread no longer waits on the initialization task posted to
+main thread to finish and gets a user agent immediately. This works around this deadlock.
+
+Note that Vanadium config doesn't handle WebViewCachedFlags which is meant to be fast and designed
+around SharedPreferences. The feature is only read in the relevant location from WebViewCachedFlags,
+so the native feature change is just for completeness.
+
+Test: Install app like com.faitaujapon.otg which had this issue. With no Play services install, app
+no longer ANRs on start
+Test: tools/autotest.py -C out/Default \
+  android_webview/tools/system_webview_shell/layout_tests/src/org/chromium/webview_shell/test/WebViewThreadTest.java
+---
+ android_webview/common/aw_features.cc                           | 2 +-
+ .../org/chromium/android_webview/common/WebViewCachedFlags.java | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/android_webview/common/aw_features.cc b/android_webview/common/aw_features.cc
+index 337eb3d747457..5b06bf14955c3 100644
+--- a/android_webview/common/aw_features.cc
++++ b/android_webview/common/aw_features.cc
+@@ -306,7 +306,7 @@ BASE_FEATURE(kWebViewUseNonembeddedLowEntropySource,
+ // When enabled, the default user agent string is fetched more quickly without
+ // waiting for chromium startup to complete.
+ BASE_FEATURE(kWebViewFasterGetDefaultUserAgent,
+-             base::FEATURE_DISABLED_BY_DEFAULT);
++             base::FEATURE_ENABLED_BY_DEFAULT);
+ 
+ // When enabled, navigation headers will be saved and restored as part
+ // of saved state for WebView.
+diff --git a/android_webview/java/src/org/chromium/android_webview/common/WebViewCachedFlags.java b/android_webview/java/src/org/chromium/android_webview/common/WebViewCachedFlags.java
+index ebc8767f55788..fda0e693177c8 100644
+--- a/android_webview/java/src/org/chromium/android_webview/common/WebViewCachedFlags.java
++++ b/android_webview/java/src/org/chromium/android_webview/common/WebViewCachedFlags.java
+@@ -180,7 +180,7 @@ public class WebViewCachedFlags {
+                                             DefaultState.DISABLED),
+                                     Map.entry(
+                                             AwFeatures.WEBVIEW_FASTER_GET_DEFAULT_USER_AGENT,
+-                                            DefaultState.DISABLED),
++                                            DefaultState.ENABLED),
+                                     Map.entry(
+                                             BaseFeatures
+                                                     .SHUTDOWN_PRE_NATIVE_THREAD_POOL_AFTER_STARTUP,
+-- 
+2.43.0
+


### PR DESCRIPTION
Closes https://github.com/GrapheneOS/Vanadium/issues/1139
Applies on https://github.com/GrapheneOS/Vanadium/pull/1138

Apps, in particular ones that use Google Mobile Ads SDK, can dead lock. A worker thread in the Mobile Ads SDK holds a singleton lock and calls WebSettings.getDefaultUserAgent() which block until a task posted to the main thread to initialize WebView finishes. Meanwhile, the main thread of the app enters Mobile Ads SDK. If the Dynamite ads module is not available, the library has a local fallback path which attempts to acquires the singleton lock that the worker thread is holding. The result is that the main thread gets blocked on a lock held by the worker thread which is waiting for main thread to process its task.

Dynamite ads module can be unavailable if Play services + Play Store are not installed (or have some other issue). This would block users from using any app with SDK used in this way.

By enabling this feature, the worker thread no longer waits on the initialization task posted to main thread to finish and gets a user agent immediately. This works around this deadlock.

Note that Vanadium config doesn't handle WebViewCachedFlags which is meant to be fast and designed around SharedPreferences. The feature is only read in the relevant location from WebViewCachedFlags, so the native feature change is just for completeness.

Test: Install app like com.faitaujapon.otg which had this issue. With no Play services install, app no longer ANRs on start
Test: `tools/autotest.py -C out/Default android_webview/tools/system_webview_shell/layout_tests/src/org/chromium/webview_shell/test/WebViewThreadTest.java`