### PR TITLE
Fix chrome_public_bundle build by repairing srcjar_deps injection order

### DIFF
--- a/patches/0134-config-Include-the-ConfigInfo-class-for-Monochrome-a.patch
+++ b/patches/0134-config-Include-the-ConfigInfo-class-for-Monochrome-a.patch
@@ -12,16 +12,16 @@ diff --git a/chrome/android/chrome_public_apk_tmpl.gni b/chrome/android/chrome_p
 index 781675358ccef..786d883c5e7ca 100644
 --- a/chrome/android/chrome_public_apk_tmpl.gni
 +++ b/chrome/android/chrome_public_apk_tmpl.gni
-@@ -683,6 +683,12 @@ template("chrome_common_apk_or_module_tmpl") {
- template("chrome_public_apk_or_module_tmpl") {
-   chrome_common_apk_or_module_tmpl(target_name) {
+@@ -685,6 +685,12 @@ template("chrome_public_apk_or_module_tmpl") {
      add_upstream_only_deps = true
+     forward_variables_from(invoker, TESTONLY_AND_VISIBILITY)
+     forward_variables_from(invoker, "*", TESTONLY_AND_VISIBILITY)
 +    if (!defined(srcjar_deps)) {
 +      srcjar_deps = []
 +    }
 +    srcjar_deps += [
 +      "//vanadium/android_config:configinfo_srcjar_apk",
 +    ]
-     forward_variables_from(invoker, TESTONLY_AND_VISIBILITY)
-     forward_variables_from(invoker, "*", TESTONLY_AND_VISIBILITY)
    }
+ }
+


### PR DESCRIPTION
The `configinfo_srcjar_apk` entry of `srcjar_deps` was injected before the two `forward_variables_from()` calls in one of the patches. This is different from the rest of the patches where the `configinfo_srcjar_apk` entry of `srcjar_deps` is injected after. Problem with injecting before is we get a `Missing class app.vanadium.config.ConfigInfo` while doing the `chrome_public_bundle` build, which fails `chrome_public_bundle__dex__r8`.

When building `chrome_public_apk`, the invoker does not actually pass `srcjar_deps` so building apk appears unproblematic. But the problem surfaces when the base module in `chrome_public_bundle` does pass `srcjar_deps` containing module `jni_registration`. With the faulty ordering, the local `srcjar_deps` is set first but immediately overwritten by the `forward_variables_from(invoker, "*", TESTONLY_AND_VISIBILITY)` call and so `configinfo_srcjar_apk` is silently dropped, `ConfigInfo` gets left behind and r8 fails. 

The fix here is a simple reordering to make the order consistent with the rest of the patches.