### PR TITLE
Add clear browsing data on exit

### DIFF
--- a/patches/0292-Add-clear-browsing-data-on-exit.patch
+++ b/patches/0292-Add-clear-browsing-data-on-exit.patch
@@ -1,0 +1,1331 @@
+From 92b25fc63213e7dac78dc61fc66e2bb83cd78f1a Mon Sep 17 00:00:00 2001
+From: aaravrav <37036762+aaravrav@users.noreply.github.com>
+Date: Tue, 14 Jul 2026 11:49:03 +0530
+Subject: [PATCH] Add clear browsing data on exit
+
+Add independent options for clearing history, site data, cache,
+passwords, form data and site settings. Clear selected data when the
+last browser activity finishes and before browsing can begin the next
+time Vanadium opens.
+---
+ .../chrome/browser/app/ChromeActivity.java    |  22 ++
+ .../customtabs/CustomTabsConnection.java      |  39 ++
+ .../browser/customtabs/HiddenTabHolder.java   |   7 +
+ .../chrome/browser/init/BrowserParts.java     |  10 +
+ .../init/ChromeBrowserInitializer.java        |  13 +-
+ chrome/android/junit/BUILD.gn                 |   1 +
+ .../CustomTabsConnectionUnitTest.java         |  43 +++
+ .../shared_preferences/SharedPrefsUtils.java  |  18 +
+ .../chrome_app_java_resources_ext_sources.gni |   1 +
+ .../android/chrome_java_ext_sources.gni       |   2 +
+ ...lear_browsing_data_on_exit_preferences.xml |  34 ++
+ .../java/res/xml/privacy_preferences_ext.xml  |   6 +-
+ .../ClearBrowsingDataOnExitManager.java       | 304 ++++++++++++++++
+ .../ClearBrowsingDataOnExitSettings.java      |  65 ++++
+ .../privacy/settings/PrivacySettingsExt.java  |   8 +
+ .../ClearBrowsingDataOnExitManagerTest.java   | 343 ++++++++++++++++++
+ .../strings/android_chrome_ext_strings.grdp   |   6 +
+ 17 files changed, 918 insertions(+), 4 deletions(-)
+ create mode 100644 vanadium/chromium_src/chrome/android/java/res/xml/clear_browsing_data_on_exit_preferences.xml
+ create mode 100644 vanadium/chromium_src/chrome/android/java/src/org/chromium/chrome/browser/ClearBrowsingDataOnExitManager.java
+ create mode 100644 vanadium/chromium_src/chrome/android/java/src/org/chromium/chrome/browser/privacy/settings/ClearBrowsingDataOnExitSettings.java
+ create mode 100644 vanadium/chromium_src/chrome/android/junit/src/org/chromium/chrome/browser/ClearBrowsingDataOnExitManagerTest.java
+
+diff --git a/chrome/android/java/src/org/chromium/chrome/browser/app/ChromeActivity.java b/chrome/android/java/src/org/chromium/chrome/browser/app/ChromeActivity.java
+index df1e608403265..417135f1aca41 100644
+--- a/chrome/android/java/src/org/chromium/chrome/browser/app/ChromeActivity.java
++++ b/chrome/android/java/src/org/chromium/chrome/browser/app/ChromeActivity.java
+@@ -77,6 +77,7 @@ import org.chromium.chrome.browser.ChromeActivitySessionTracker;
+ import org.chromium.chrome.browser.ChromeApplicationImpl;
+ import org.chromium.chrome.browser.ChromeKeyboardVisibilityDelegate;
+ import org.chromium.chrome.browser.ChromeWindow;
++import org.chromium.chrome.browser.ClearBrowsingDataOnExitManager;
+ import org.chromium.chrome.browser.DeferredStartupHandler;
+ import org.chromium.chrome.browser.IntentHandler;
+ import org.chromium.chrome.browser.PlayServicesVersionInfo;
+@@ -452,6 +453,7 @@ public abstract class ChromeActivity extends AsyncInitializationActivity
+     private CloseListenerManager mCloseListenerManager;
+     private StylusWritingCoordinator mStylusWritingCoordinator;
+     private boolean mBlockingDrawForAppRestart;
++    private boolean mIsRegisteredForBrowsingDataOnExit;
+     private Runnable mShowContentRunnable;
+     private boolean mIsRecreatingForTabletModeChange;
+     // This is only used on automotive.
+@@ -511,6 +513,9 @@ public abstract class ChromeActivity extends AsyncInitializationActivity
+     protected void onPostCreate() {
+         incrementCounter(ChromePreferenceKeys.UMA_ON_POSTCREATE_COUNTER);
+         super.onPostCreate();
++        assert !mIsRegisteredForBrowsingDataOnExit;
++        mIsRegisteredForBrowsingDataOnExit = true;
++        ClearBrowsingDataOnExitManager.onBrowsingActivityCreated();
+     }
+ 
+     @Override
+@@ -1052,6 +1057,18 @@ public abstract class ChromeActivity extends AsyncInitializationActivity
+         return mLaunchCause;
+     }
+ 
++    @Override
++    public void prepareForInitialNavigation(Runnable onComplete) {
++        getProfileProviderSupplier().runSyncOrOnAvailable((profileProvider) -> {
++            if (isActivityFinishingOrDestroyed()) {
++                onComplete.run();
++                return;
++            }
++            ClearBrowsingDataOnExitManager.prepareForBrowsingSession(
++                    profileProvider.getOriginalProfile(), onComplete);
++        });
++    }
++
+     @Override
+     public void initializeState() {
+         super.initializeState();
+@@ -2079,6 +2096,11 @@ public abstract class ChromeActivity extends AsyncInitializationActivity
+ 
+         mActivityTabProvider.destroy();
+ 
++        if (mIsRegisteredForBrowsingDataOnExit) {
++            ClearBrowsingDataOnExitManager.onBrowsingActivityDestroyed(isFinishing());
++            mIsRegisteredForBrowsingDataOnExit = false;
++        }
++
+         super.onDestroy();
+     }
+ 
+diff --git a/chrome/android/java/src/org/chromium/chrome/browser/customtabs/CustomTabsConnection.java b/chrome/android/java/src/org/chromium/chrome/browser/customtabs/CustomTabsConnection.java
+index 6e3ecf9d905d6..e2ccc30a9a893 100644
+--- a/chrome/android/java/src/org/chromium/chrome/browser/customtabs/CustomTabsConnection.java
++++ b/chrome/android/java/src/org/chromium/chrome/browser/customtabs/CustomTabsConnection.java
+@@ -60,6 +60,7 @@ import org.chromium.build.annotations.NullMarked;
+ import org.chromium.build.annotations.Nullable;
+ import org.chromium.chrome.R;
+ import org.chromium.chrome.browser.ChromeApplicationImpl;
++import org.chromium.chrome.browser.ClearBrowsingDataOnExitManager;
+ import org.chromium.chrome.browser.IntentHandler;
+ import org.chromium.chrome.browser.WarmupManager;
+ import org.chromium.chrome.browser.browserservices.PostMessageHandler;
+@@ -461,6 +462,7 @@ public class CustomTabsConnection {
+      * @return true for success.
+      */
+     private boolean warmupInternal(@Nullable Runnable completionCallback) {
++        if (ClearBrowsingDataOnExitManager.shouldBlockCustomTabPreloading()) return false;
+         // Here and in mayLaunchUrl(), don't do expensive work for background applications.
+         if (!isCallerForegroundOrSelf()) return false;
+         int uid = Binder.getCallingUid();
+@@ -500,6 +502,7 @@ public class CustomTabsConnection {
+             tasks.add(
+                     TaskTraits.UI_DEFAULT,
+                     () -> {
++                        if (ClearBrowsingDataOnExitManager.shouldBlockCustomTabPreloading()) return;
+                         if (mHiddenTabHolder.hasHiddenTab()) return;
+ 
+                         try (TraceEvent e = TraceEvent.scoped("CreateSpareTab")) {
+@@ -658,6 +661,7 @@ public class CustomTabsConnection {
+             final @Nullable Uri url,
+             final @Nullable Bundle extras,
+             final @Nullable List<Bundle> otherLikelyBundles) {
++        if (ClearBrowsingDataOnExitManager.isEnabled()) return false;
+         // mayLaunchUrl should not be executed for Incognito CCT since all setup is created with
+         // regular profile. If we need to enable mayLaunchUrl for off-the-record profiles, we need
+         // to update the profile used. Please see crbug.com/40706528.
+@@ -706,6 +710,7 @@ public class CustomTabsConnection {
+     @ExperimentalPrefetch
+     private void prefetchInternal(
+             SessionHolder<?> session, List<Uri> urls, PrefetchOptions options) {
++        if (ClearBrowsingDataOnExitManager.isEnabled()) return;
+         boolean usePrefetchProxy = options.requiresAnonymousIpWhenCrossOrigin;
+         Origin sourceOrigin =
+                 options.sourceOrigin != null
+@@ -722,6 +727,9 @@ public class CustomTabsConnection {
+         // (3)
+         Runnable startPrefetch =
+                 () -> {
++                    if (ClearBrowsingDataOnExitManager.shouldBlockCustomTabPreloading()) {
++                        return;
++                    }
+                     String verifiedSourceOrigin =
+                             isValidForPrefetchSourceOrigin(session, sourceOrigin)
+                                     ? sourceOrigin.toString()
+@@ -732,6 +740,10 @@ public class CustomTabsConnection {
+                         PostTask.postTask(
+                                 TaskTraits.UI_DEFAULT,
+                                 () -> {
++                                    if (ClearBrowsingDataOnExitManager
++                                            .shouldBlockCustomTabPreloading()) {
++                                        return;
++                                    }
+                                     WarmupManager.getInstance()
+                                             .startPrefetchFromCct(
+                                                     urlString,
+@@ -782,6 +794,7 @@ public class CustomTabsConnection {
+             final @Nullable List<Bundle> otherLikelyBundles) {
+         ThreadUtils.assertOnUiThread();
+         try (TraceEvent e = TraceEvent.scoped("CustomTabsConnection.mayLaunchUrlOnUiThread")) {
++            if (ClearBrowsingDataOnExitManager.shouldBlockCustomTabPreloading()) return;
+             enableExperimentIdsIfNecessary(extras);
+ 
+             if (lowConfidence) {
+@@ -1085,6 +1098,7 @@ public class CustomTabsConnection {
+      * @param intent incoming intent.
+      */
+     public void onHandledIntent(@Nullable SessionHolder<?> session, Intent intent) {
++        if (ClearBrowsingDataOnExitManager.shouldBlockCustomTabPreloading()) return;
+         String url = IntentHandler.getUrlFromIntent(intent);
+         if (TextUtils.isEmpty(url)) {
+             return;
+@@ -1127,6 +1141,7 @@ public class CustomTabsConnection {
+ 
+     private void maybePreconnectToRedirectEndpoint(
+             @Nullable SessionHolder<?> session, String url, Intent intent) {
++        if (ClearBrowsingDataOnExitManager.shouldBlockCustomTabPreloading()) return;
+         // For the preconnection to not be a no-op, we need more than just the native library.
+         if (!ChromeBrowserInitializer.getInstance().isFullBrowserInitialized()) {
+             return;
+@@ -1203,6 +1218,10 @@ public class CustomTabsConnection {
+             @Nullable SessionHolder<?> session, Intent intent) {
+         ThreadUtils.assertOnUiThread();
+ 
++        if (ClearBrowsingDataOnExitManager.shouldBlockCustomTabPreloading()) {
++            return ParallelRequestStatus.NO_REQUEST;
++        }
++
+         if (!intent.hasExtra(PARALLEL_REQUEST_URL_KEY)
+                 && !intent.hasExtra(PARALLEL_REQUEST_URL_LIST_KEY)) {
+             return ParallelRequestStatus.NO_REQUEST;
+@@ -1287,6 +1306,8 @@ public class CustomTabsConnection {
+     int maybePrefetchResources(@Nullable SessionHolder<?> session, Intent intent) {
+         ThreadUtils.assertOnUiThread();
+ 
++        if (ClearBrowsingDataOnExitManager.shouldBlockCustomTabPreloading()) return 0;
++
+         if (!mClientManager.getAllowResourcePrefetchForSession(session)) return 0;
+ 
+         if (IntentHandler.hasAnyIncognitoExtra(intent.getExtras())) {
+@@ -1986,6 +2007,9 @@ public class CustomTabsConnection {
+     }
+ 
+     boolean maySpeculate(SessionHolder<?> session) {
++        if (ClearBrowsingDataOnExitManager.shouldBlockCustomTabPreloading()) {
++            return false;
++        }
+         if (!DeviceClassManager.enablePrerendering()) {
+             return false;
+         }
+@@ -2006,6 +2030,20 @@ public class CustomTabsConnection {
+         mHiddenTabHolder.destroyHiddenTab(session);
+     }
+ 
++    /** Cancels pending warmup tasks and destroys spare and hidden tabs. */
++    public static void destroyPreloadedTabs() {
++        ThreadUtils.assertOnUiThread();
++        CustomTabsConnection connection = sInstance;
++        if (connection != null) {
++            @Nullable ChainedTasks warmupTasks = connection.mWarmupTasks;
++            if (warmupTasks != null) warmupTasks.cancel();
++        }
++        WarmupManager.getInstance().destroySpareTab();
++        if (connection != null) {
++            connection.mHiddenTabHolder.destroyHiddenTabUnconditionally();
++        }
++    }
++
+     /*
+      * This function will do as much as it can to have a subsequent navigation
+      * to the specified url sped up, including speculatively loading a url, preconnecting,
+@@ -2259,6 +2297,7 @@ public class CustomTabsConnection {
+ 
+     /** Kicks off a navigation in the background before the CustomTabActivity is started. */
+     public boolean startEarlyNavigationInHiddenTab(Profile profile, Intent intent) {
++        if (ClearBrowsingDataOnExitManager.shouldBlockCustomTabPreloading()) return false;
+         return mHiddenTabHolder.startEarlynavigation(profile, intent);
+     }
+ 
+diff --git a/chrome/android/java/src/org/chromium/chrome/browser/customtabs/HiddenTabHolder.java b/chrome/android/java/src/org/chromium/chrome/browser/customtabs/HiddenTabHolder.java
+index 405efead2011e..47429b1a2a51f 100644
+--- a/chrome/android/java/src/org/chromium/chrome/browser/customtabs/HiddenTabHolder.java
++++ b/chrome/android/java/src/org/chromium/chrome/browser/customtabs/HiddenTabHolder.java
+@@ -273,6 +273,13 @@ public class HiddenTabHolder {
+         mSpeculation = null;
+     }
+ 
++    /** Destroys the hidden tab regardless of its session or navigation state. */
++    void destroyHiddenTabUnconditionally() {
++        if (mSpeculation == null) return;
++        mSpeculation.hiddenTab.tab.destroy();
++        mSpeculation = null;
++    }
++
+     /** Returns whether there currently is a hidden tab. */
+     boolean hasHiddenTab() {
+         return mSpeculation != null;
+diff --git a/chrome/android/java/src/org/chromium/chrome/browser/init/BrowserParts.java b/chrome/android/java/src/org/chromium/chrome/browser/init/BrowserParts.java
+index e351342039631..48a6ae9208612 100644
+--- a/chrome/android/java/src/org/chromium/chrome/browser/init/BrowserParts.java
++++ b/chrome/android/java/src/org/chromium/chrome/browser/init/BrowserParts.java
+@@ -40,6 +40,16 @@ public interface BrowserParts {
+      */
+     void postInflationStartup();
+ 
++    /**
++     * Called after the browser process starts but before activity startup tasks that may navigate.
++     * Implementations must invoke {@code onComplete} before initial navigation continues.
++     *
++     * @param onComplete Callback to invoke when initial navigation may proceed.
++     */
++    default void prepareForInitialNavigation(Runnable onComplete) {
++        onComplete.run();
++    }
++
+     /**
+      * Called during {@link ChromeBrowserInitializer#handlePostNativeStartup(BrowserParts)}.
+      * Optionaly preconnect to the URL specified in the launch intent, if any. The
+diff --git a/chrome/android/java/src/org/chromium/chrome/browser/init/ChromeBrowserInitializer.java b/chrome/android/java/src/org/chromium/chrome/browser/init/ChromeBrowserInitializer.java
+index ec9adf97fdedc..99bbd7efdfaca 100644
+--- a/chrome/android/java/src/org/chromium/chrome/browser/init/ChromeBrowserInitializer.java
++++ b/chrome/android/java/src/org/chromium/chrome/browser/init/ChromeBrowserInitializer.java
+@@ -168,15 +168,18 @@ public class ChromeBrowserInitializer {
+ 
+         ProcessInitializationHandler.getInstance().onPostNativeStartup();
+ 
+-        final ChainedTasks tasks = new ChainedTasks();
++        final ChainedTasks beforeActivityNativeInitTasks = new ChainedTasks();
+         ProcessInitializationHandler.getInstance()
+                 .enqueuePostNativeTasksToRunBeforeActivityNativeInit(
+-                        tasks, delegate.startMinimalBrowser());
++                        beforeActivityNativeInitTasks, delegate.startMinimalBrowser());
++
++        final ChainedTasks tasks = new ChainedTasks();
+ 
+         tasks.add(
+                 TaskTraits.UI_DEFAULT,
+                 () -> {
+                     try (TraceEvent te = TraceEvent.scoped("Activity.maybePreconnect")) {
++                        if (delegate.isActivityFinishingOrDestroyed()) return;
+                         // Run as early as possible. It should also be in a separate task (and
+                         // after) initNetworkChangeNotifier, as this posts a task to the UI thread
+                         // that would interfere with preconneciton otherwise. By preconnecting
+@@ -229,6 +232,9 @@ public class ChromeBrowserInitializer {
+                 });
+ 
+         if (isAsync) {
++            beforeActivityNativeInitTasks.add(
++                    TaskTraits.UI_DEFAULT,
++                    () -> delegate.prepareForInitialNavigation(() -> tasks.start(false)));
+             // We want to start this queue once the C++ startup tasks have run; allow the
+             // C++ startup to run asynchronously, and set it up to start the Java queue once
+             // it has finished.
+@@ -243,11 +249,12 @@ public class ChromeBrowserInitializer {
+ 
+                         @Override
+                         public void onSuccess(@Nullable StartupMetrics metrics) {
+-                            tasks.start(false);
++                            beforeActivityNativeInitTasks.start(false);
+                         }
+                     });
+         } else {
+             startChromeBrowserProcessesSync(delegate.shouldStartGpuProcess());
++            beforeActivityNativeInitTasks.start(true);
+             tasks.start(true);
+         }
+     }
+diff --git a/chrome/android/junit/BUILD.gn b/chrome/android/junit/BUILD.gn
+index 997eeb22b7b8c..9a5adc1fc8648 100644
+--- a/chrome/android/junit/BUILD.gn
++++ b/chrome/android/junit/BUILD.gn
+@@ -428,6 +428,7 @@ if (is_android) {
+     sources = [
+       "//chrome/android/java/src/org/chromium/chrome/browser/bottombar/BottomBarAppMenuUpdateBadgeControllerUnitTest.java",
+       "//chrome/android/java/src/org/chromium/chrome/browser/bottombar/BottomBarContainerCoordinatorUnitTest.java",
++      "//vanadium/chromium_src/chrome/android/junit/src/org/chromium/chrome/browser/ClearBrowsingDataOnExitManagerTest.java",
+       "src/org/chromium/chrome/browser/BrowserExitReasonTrackerUnitTest.java",
+       "src/org/chromium/chrome/browser/ChromeActionModeHandlerUnitTest.java",
+       "src/org/chromium/chrome/browser/ChromeActivityUnitTest.java",
+diff --git a/chrome/android/junit/src/org/chromium/chrome/browser/customtabs/CustomTabsConnectionUnitTest.java b/chrome/android/junit/src/org/chromium/chrome/browser/customtabs/CustomTabsConnectionUnitTest.java
+index 94d45825b5aa1..83899ca10b8f2 100644
+--- a/chrome/android/junit/src/org/chromium/chrome/browser/customtabs/CustomTabsConnectionUnitTest.java
++++ b/chrome/android/junit/src/org/chromium/chrome/browser/customtabs/CustomTabsConnectionUnitTest.java
+@@ -30,6 +30,7 @@ import static org.chromium.chrome.browser.customtabs.CustomTabsConnection.ON_ACT
+ import android.app.PendingIntent;
+ import android.content.Intent;
+ import android.net.Network;
++import android.net.Uri;
+ import android.os.Bundle;
+ import android.os.Process;
+ 
+@@ -51,6 +52,7 @@ import org.robolectric.RuntimeEnvironment;
+ import org.robolectric.annotation.Config;
+ import org.robolectric.shadows.ShadowProcess;
+ 
++import org.chromium.base.shared_preferences.SharedPrefsUtils.SharedPrefsExt;
+ import org.chromium.base.test.BaseRobolectricTestRunner;
+ import org.chromium.base.test.util.Batch;
+ import org.chromium.base.test.util.Features.DisableFeatures;
+@@ -62,6 +64,7 @@ import org.chromium.chrome.browser.browserservices.intents.SessionHolder;
+ import org.chromium.chrome.browser.customtabs.content.EngagementSignalsHandler;
+ import org.chromium.chrome.browser.flags.ChromeFeatureList;
+ import org.chromium.chrome.browser.privacy.settings.PrivacyPreferencesManagerImpl;
++import org.chromium.chrome.browser.profiles.Profile;
+ import org.chromium.chrome.browser.tab.Tab;
+ 
+ /** Tests for some parts of {@link CustomTabsConnection}. */
+@@ -86,6 +89,7 @@ public class CustomTabsConnectionUnitTest {
+ 
+     @Before
+     public void setup() {
++        resetClearBrowsingDataOnExitPreferences();
+         CustomTabsConnection.setInstanceForTesting(null);
+         mConnection = CustomTabsConnection.getInstance();
+         mSession = spy(CustomTabsSessionToken.createMockSessionTokenForTesting());
+@@ -101,6 +105,36 @@ public class CustomTabsConnectionUnitTest {
+     @After
+     public void tearDown() {
+         SessionDataHolder.getInstance().removeActiveHandler(mSessionHandler);
++        resetClearBrowsingDataOnExitPreferences();
++    }
++
++    @Test
++    public void clearBrowsingDataOnExitDisablesSpeculation() {
++        SharedPrefsExt.CLEAR_BROWSING_DATA_ON_EXIT_HISTORY.putSync(true);
++
++        assertFalse(mConnection.maySpeculate(mSessionHolder));
++    }
++
++    @Test
++    public void clearBrowsingDataOnExitDisablesEarlyNavigation() {
++        SharedPrefsExt.CLEAR_BROWSING_DATA_ON_EXIT_HISTORY.putSync(true);
++
++        assertFalse(mConnection.startEarlyNavigationInHiddenTab(mock(Profile.class), new Intent()));
++    }
++
++    @Test
++    public void clearBrowsingDataOnExitDisablesServicePreloading() {
++        SharedPrefsExt.CLEAR_BROWSING_DATA_ON_EXIT_HISTORY.putSync(true);
++        Uri url = Uri.parse("https://example.test/");
++
++        assertFalse(mConnection.warmup());
++        assertFalse(mConnection.mayLaunchUrl(mSession, url, null, null));
++
++        Intent intent = new Intent();
++        intent.putExtra(CustomTabsConnection.PARALLEL_REQUEST_URL_KEY, url);
++        assertEquals(
++                CustomTabsConnection.ParallelRequestStatus.NO_REQUEST,
++                mConnection.handleParallelRequest(mSessionHolder, intent));
+     }
+ 
+     @Test
+@@ -207,6 +241,15 @@ public class CustomTabsConnectionUnitTest {
+                 handler);
+     }
+ 
++    private static void resetClearBrowsingDataOnExitPreferences() {
++        SharedPrefsExt.CLEAR_BROWSING_DATA_ON_EXIT_HISTORY.putSync(false);
++        SharedPrefsExt.CLEAR_BROWSING_DATA_ON_EXIT_COOKIES.putSync(false);
++        SharedPrefsExt.CLEAR_BROWSING_DATA_ON_EXIT_CACHE.putSync(false);
++        SharedPrefsExt.CLEAR_BROWSING_DATA_ON_EXIT_PASSWORDS.putSync(false);
++        SharedPrefsExt.CLEAR_BROWSING_DATA_ON_EXIT_FORM_DATA.putSync(false);
++        SharedPrefsExt.CLEAR_BROWSING_DATA_ON_EXIT_SITE_SETTINGS.putSync(false);
++    }
++
+     @Test
+     @DisableFeatures(ChromeFeatureList.SEARCH_IN_CCT)
+     public void shouldEnableOmniboxForIntent_featureDisabled() {
+diff --git a/vanadium/chromium_src/base/android/java/src/org/chromium/base/shared_preferences/SharedPrefsUtils.java b/vanadium/chromium_src/base/android/java/src/org/chromium/base/shared_preferences/SharedPrefsUtils.java
+index e9f9abe73111d..e98079a47d580 100644
+--- a/vanadium/chromium_src/base/android/java/src/org/chromium/base/shared_preferences/SharedPrefsUtils.java
++++ b/vanadium/chromium_src/base/android/java/src/org/chromium/base/shared_preferences/SharedPrefsUtils.java
+@@ -119,6 +119,18 @@ public final class SharedPrefsUtils {
+ 
+     // Stores SharedPreferences keys and its default value
+     public static class SharedPrefsExt {
++        public static final BoolSharedPref CLEAR_BROWSING_DATA_ON_EXIT_CACHE =
++                new BoolSharedPref("clear_browsing_data_on_exit_cache", false);
++        public static final BoolSharedPref CLEAR_BROWSING_DATA_ON_EXIT_COOKIES =
++                new BoolSharedPref("clear_browsing_data_on_exit_cookies", false);
++        public static final BoolSharedPref CLEAR_BROWSING_DATA_ON_EXIT_FORM_DATA =
++                new BoolSharedPref("clear_browsing_data_on_exit_form_data", false);
++        public static final BoolSharedPref CLEAR_BROWSING_DATA_ON_EXIT_HISTORY =
++                new BoolSharedPref("clear_browsing_data_on_exit_history", false);
++        public static final BoolSharedPref CLEAR_BROWSING_DATA_ON_EXIT_PASSWORDS =
++                new BoolSharedPref("clear_browsing_data_on_exit_passwords", false);
++        public static final BoolSharedPref CLEAR_BROWSING_DATA_ON_EXIT_SITE_SETTINGS =
++                new BoolSharedPref("clear_browsing_data_on_exit_site_settings", false);
+         public static final BoolSharedPref CLOSE_TABS_ON_EXIT =
+                 new BoolSharedPref("close_tabs_on_exit", false);
+         public static final BoolSharedPref OPEN_LINKS_IN_INCOGNITO =
+@@ -133,6 +145,12 @@ public final class SharedPrefsUtils {
+     static boolean isKeyInUse(String key) {
+         // clang-format off
+         return Arrays.asList(
++            SharedPrefsExt.CLEAR_BROWSING_DATA_ON_EXIT_CACHE.getKey(),
++            SharedPrefsExt.CLEAR_BROWSING_DATA_ON_EXIT_COOKIES.getKey(),
++            SharedPrefsExt.CLEAR_BROWSING_DATA_ON_EXIT_FORM_DATA.getKey(),
++            SharedPrefsExt.CLEAR_BROWSING_DATA_ON_EXIT_HISTORY.getKey(),
++            SharedPrefsExt.CLEAR_BROWSING_DATA_ON_EXIT_PASSWORDS.getKey(),
++            SharedPrefsExt.CLEAR_BROWSING_DATA_ON_EXIT_SITE_SETTINGS.getKey(),
+             SharedPrefsExt.CLOSE_TABS_ON_EXIT.getKey(),
+             SharedPrefsExt.OPEN_LINKS_IN_INCOGNITO.getKey()
+         ).contains(key);
+diff --git a/vanadium/chromium_src/chrome/android/chrome_app_java_resources_ext_sources.gni b/vanadium/chromium_src/chrome/android/chrome_app_java_resources_ext_sources.gni
+index 77db9242631bb..004177626a488 100644
+--- a/vanadium/chromium_src/chrome/android/chrome_app_java_resources_ext_sources.gni
++++ b/vanadium/chromium_src/chrome/android/chrome_app_java_resources_ext_sources.gni
+@@ -11,6 +11,7 @@ chrome_app_java_resources_ext_full_path_sources = [
+ # Three lines of code for minimizing conflicts in rebasing changes
+ # Three lines of code for minimizing conflicts in rebasing changes
+ chrome_app_java_resources_ext_rel_path_sources = [
++  "java/res/xml/clear_browsing_data_on_exit_preferences.xml",
+   "java/res/xml/privacy_preferences_ext.xml",
+ ]
+ # Three lines of code for minimizing conflicts in rebasing changes
+diff --git a/vanadium/chromium_src/chrome/android/chrome_java_ext_sources.gni b/vanadium/chromium_src/chrome/android/chrome_java_ext_sources.gni
+index 62b91c8e5cfda..25d7027ca54c6 100644
+--- a/vanadium/chromium_src/chrome/android/chrome_java_ext_sources.gni
++++ b/vanadium/chromium_src/chrome/android/chrome_java_ext_sources.gni
+@@ -12,8 +12,10 @@ chrome_java_ext_full_path_sources = [
+ # Three lines of code for minimizing conflicts in rebasing changes
+ chrome_java_ext_rel_path_sources = [
+   "java/src/org/chromium/chrome/browser/ChromeApplicationImplHooks.java",
++  "java/src/org/chromium/chrome/browser/ClearBrowsingDataOnExitManager.java",
+   "java/src/org/chromium/chrome/browser/LaunchIntentDispatcherHooks.java",
+   "java/src/org/chromium/chrome/browser/TabPreferencesUtils.java",
++  "java/src/org/chromium/chrome/browser/privacy/settings/ClearBrowsingDataOnExitSettings.java",
+   "java/src/org/chromium/chrome/browser/privacy/settings/PrivacySettingsExt.java",
+   "java/src/org/chromium/chrome/browser/searchwidget/SearchActivityHooks.java",
+   "java/src/org/chromium/chrome/browser/settings/search/SearchIndexProviderHooks.java",
+diff --git a/vanadium/chromium_src/chrome/android/java/res/xml/clear_browsing_data_on_exit_preferences.xml b/vanadium/chromium_src/chrome/android/java/res/xml/clear_browsing_data_on_exit_preferences.xml
+new file mode 100644
+index 0000000000000..0b308ed5b50a6
+--- /dev/null
++++ b/vanadium/chromium_src/chrome/android/java/res/xml/clear_browsing_data_on_exit_preferences.xml
+@@ -0,0 +1,34 @@
++<?xml version="1.0" encoding="utf-8"?>
++<!--
++Copyright 2026 GrapheneOS
++Use of this source code is governed by a GPL-2.0-only style license
++that can be found in the LICENSE file.
++-->
++<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
++    <org.chromium.components.browser_ui.settings.ChromeSwitchPreference
++        android:key="clear_browsing_data_on_exit_history"
++        android:title="@string/clear_history_title"
++        android:summary="@string/clear_browsing_history_summary"
++        android:persistent="false"/>
++    <org.chromium.components.browser_ui.settings.ChromeSwitchPreference
++        android:key="clear_browsing_data_on_exit_cookies"
++        android:title="@string/clear_cookies_and_site_data_title"
++        android:summary="@string/clear_cookies_and_site_data_summary_basic"
++        android:persistent="false"/>
++    <org.chromium.components.browser_ui.settings.ChromeSwitchPreference
++        android:key="clear_browsing_data_on_exit_cache"
++        android:title="@string/clear_cache_title"
++        android:persistent="false"/>
++    <org.chromium.components.browser_ui.settings.ChromeSwitchPreference
++        android:key="clear_browsing_data_on_exit_passwords"
++        android:title="@string/clear_passwords_title"
++        android:persistent="false"/>
++    <org.chromium.components.browser_ui.settings.ChromeSwitchPreference
++        android:key="clear_browsing_data_on_exit_form_data"
++        android:title="@string/clear_form_data_title"
++        android:persistent="false"/>
++    <org.chromium.components.browser_ui.settings.ChromeSwitchPreference
++        android:key="clear_browsing_data_on_exit_site_settings"
++        android:title="@string/prefs_site_settings"
++        android:persistent="false"/>
++</PreferenceScreen>
+diff --git a/vanadium/chromium_src/chrome/android/java/res/xml/privacy_preferences_ext.xml b/vanadium/chromium_src/chrome/android/java/res/xml/privacy_preferences_ext.xml
+index f1d44d6b4b764..5c091109d20b4 100644
+--- a/vanadium/chromium_src/chrome/android/java/res/xml/privacy_preferences_ext.xml
++++ b/vanadium/chromium_src/chrome/android/java/res/xml/privacy_preferences_ext.xml
+@@ -15,6 +15,11 @@ that can be found in the LICENSE file.
+         android:title="@string/close_tabs_on_exit_title"
+         android:summary="@string/close_tabs_on_exit_summary"
+         android:persistent="false"/>
++    <org.chromium.components.browser_ui.settings.ChromeBasePreference
++        android:key="clear_browsing_data_on_exit"
++        android:title="@string/clear_browsing_data_on_exit_title"
++        android:summary="@string/clear_browsing_data_on_exit_summary"
++        android:fragment="org.chromium.chrome.browser.privacy.settings.ClearBrowsingDataOnExitSettings"/>
+     <org.chromium.components.browser_ui.settings.ChromeSwitchPreference
+         android:key="open_links_in_incognito"
+         android:title="@string/open_links_in_incognito_title"
+@@ -29,4 +34,3 @@ that can be found in the LICENSE file.
+         android:title="@string/cross_origin_referrer_policy_title"
+         android:fragment="org.chromium.chrome.browser.referrer.settings.CrossOriginReferrerPolicySettings"/>
+ </PreferenceScreen>
+-
+diff --git a/vanadium/chromium_src/chrome/android/java/src/org/chromium/chrome/browser/ClearBrowsingDataOnExitManager.java b/vanadium/chromium_src/chrome/android/java/src/org/chromium/chrome/browser/ClearBrowsingDataOnExitManager.java
+new file mode 100644
+index 0000000000000..0494b5e9cb543
+--- /dev/null
++++ b/vanadium/chromium_src/chrome/android/java/src/org/chromium/chrome/browser/ClearBrowsingDataOnExitManager.java
+@@ -0,0 +1,304 @@
++// Copyright 2026 GrapheneOS
++// Use of this source code is governed by a GPL-2.0-only style license that can be
++// found in the LICENSE file.
++
++package org.chromium.chrome.browser;
++
++import androidx.annotation.VisibleForTesting;
++
++import org.chromium.base.ResettersForTesting;
++import org.chromium.base.ThreadUtils;
++import org.chromium.base.shared_preferences.SharedPrefsUtils.SharedPrefsExt;
++import org.chromium.build.annotations.NullMarked;
++import org.chromium.build.annotations.Nullable;
++import org.chromium.chrome.browser.browsing_data.BrowsingDataBridge;
++import org.chromium.chrome.browser.browsing_data.BrowsingDataBridge.OnClearBrowsingDataListener;
++import org.chromium.chrome.browser.browsing_data.BrowsingDataType;
++import org.chromium.chrome.browser.browsing_data.TimePeriod;
++import org.chromium.chrome.browser.customtabs.CustomTabsConnection;
++import org.chromium.chrome.browser.profiles.Profile;
++
++import java.util.ArrayList;
++import java.util.Arrays;
++import java.util.List;
++
++/** Clears user-selected browsing data between browser activity sessions. */
++@NullMarked
++public final class ClearBrowsingDataOnExitManager {
++    private static final int DATA_TYPE_COUNT = 6;
++    private static final int NO_SESSION_ID = -1;
++
++    @VisibleForTesting
++    interface BrowsingDataClearer {
++        void clear(Profile profile, Runnable onComplete, int[] dataTypes);
++    }
++
++    private static final BrowsingDataClearer DEFAULT_BROWSING_DATA_CLEARER =
++            ClearBrowsingDataOnExitManager::clearBrowsingData;
++    private static final List<Runnable> sSessionReadyCallbacks = new ArrayList<>();
++
++    private static BrowsingDataClearer sBrowsingDataClearer = DEFAULT_BROWSING_DATA_CLEARER;
++    private static @Nullable Profile sSessionProfile;
++    private static int sRegisteredActivityCount;
++    private static int sPendingActivityRecreationCount;
++    private static int sSessionId;
++    // Custom Tab service callbacks can query this before posting work to the UI thread.
++    private static volatile boolean sCleanupInProgress;
++    private static boolean sSessionReady;
++    private static boolean sSessionStarted;
++    private static boolean sStartupCleanupRequired;
++
++    private ClearBrowsingDataOnExitManager() {}
++
++    /** Registers a browser activity before its native initialization starts. */
++    public static void onBrowsingActivityCreated() {
++        ThreadUtils.checkUiThread();
++        if (sPendingActivityRecreationCount != 0) {
++            // Keep the activity counted while Android recreates it.
++            sPendingActivityRecreationCount--;
++            return;
++        }
++        sRegisteredActivityCount++;
++    }
++
++    /**
++     * Starts a browsing session and invokes {@code onReady} after selected data has been cleared.
++     * Callers must wait for this before preconnecting, restoring tabs, or navigating. Cleanup also
++     * runs at startup because Android can kill the process without finishing the last activity. If
++     * a Custom Tab service keeps the process alive after the last activity closes, the next
++     * activity waits for the previous cleanup to finish.
++     *
++     * @param profile Regular profile whose browsing data may be cleared.
++     * @param onReady Callback to invoke when browser session startup may proceed.
++     */
++    public static void prepareForBrowsingSession(Profile profile, Runnable onReady) {
++        ThreadUtils.checkUiThread();
++        assert sRegisteredActivityCount != 0 : "Browsing session started without an activity";
++        if (sSessionStarted) {
++            assert sSessionProfile == profile : "A browsing session cannot span original profiles";
++            runWhenSessionReady(onReady);
++            return;
++        }
++
++        sSessionStarted = true;
++        sSessionReady = false;
++        sSessionProfile = profile;
++        sSessionId++;
++        sStartupCleanupRequired = isEnabled();
++
++        if (!sCleanupInProgress && !sStartupCleanupRequired) {
++            sSessionReady = true;
++            onReady.run();
++            return;
++        }
++
++        sSessionReadyCallbacks.add(onReady);
++        continueSessionStartup();
++    }
++
++    /**
++     * Unregisters a browser activity and clears data after the last registered activity finishes.
++     * An activity being recreated remains counted until Android creates its replacement. This
++     * prevents cleanup from starting if another activity closes before the replacement is created.
++     *
++     * @param activityFinishing Whether the activity is finishing rather than being recreated.
++     */
++    public static void onBrowsingActivityDestroyed(boolean activityFinishing) {
++        ThreadUtils.checkUiThread();
++        if (sRegisteredActivityCount == 0) {
++            assert false : "Browsing activity destroyed without a matching creation";
++            return;
++        }
++
++        if (!activityFinishing) {
++            sPendingActivityRecreationCount++;
++            return;
++        }
++
++        sRegisteredActivityCount--;
++        if (sRegisteredActivityCount != 0 || !sSessionStarted) {
++            return;
++        }
++
++        sSessionStarted = false;
++        sSessionReady = false;
++        sStartupCleanupRequired = false;
++        Profile profile = sSessionProfile;
++        sSessionProfile = null;
++        if (profile == null) {
++            assert false : "Browsing session ended without an original profile";
++            return;
++        }
++
++        int[] dataTypes = getSelectedDataTypes();
++        if (dataTypes.length == 0) return;
++
++        if (!sCleanupInProgress) {
++            startBrowsingDataCleanup(profile, dataTypes, NO_SESSION_ID);
++        }
++    }
++
++    /** Updates cleanup state after the selected data types change. */
++    public static void onDataTypePreferenceChanged() {
++        ThreadUtils.checkUiThread();
++        if (sSessionStarted && !sSessionReady) {
++            // If the selected data types change while startup cleanup is running, clean again
++            // using the updated selection before startup continues.
++            sStartupCleanupRequired = isEnabled();
++        }
++        if (isEnabled()) {
++            CustomTabsConnection.destroyPreloadedTabs();
++        }
++    }
++
++    /** Returns whether at least one data type is selected for automatic cleanup. */
++    public static boolean isEnabled() {
++        return SharedPrefsExt.CLEAR_BROWSING_DATA_ON_EXIT_HISTORY.get()
++                || SharedPrefsExt.CLEAR_BROWSING_DATA_ON_EXIT_COOKIES.get()
++                || SharedPrefsExt.CLEAR_BROWSING_DATA_ON_EXIT_CACHE.get()
++                || SharedPrefsExt.CLEAR_BROWSING_DATA_ON_EXIT_PASSWORDS.get()
++                || SharedPrefsExt.CLEAR_BROWSING_DATA_ON_EXIT_FORM_DATA.get()
++                || SharedPrefsExt.CLEAR_BROWSING_DATA_ON_EXIT_SITE_SETTINGS.get();
++    }
++
++    /** Returns whether automatic cleanup requires Custom Tab preloading to remain disabled. */
++    public static boolean shouldBlockCustomTabPreloading() {
++        return sCleanupInProgress || isEnabled();
++    }
++
++    private static void runWhenSessionReady(Runnable onReady) {
++        if (!sSessionReady) {
++            sSessionReadyCallbacks.add(onReady);
++        } else {
++            onReady.run();
++        }
++    }
++
++    private static void continueSessionStartup() {
++        if (!sSessionStarted || sSessionReady || sCleanupInProgress) return;
++        if (!sStartupCleanupRequired) {
++            finishSessionStartup();
++            return;
++        }
++
++        int[] dataTypes = getSelectedDataTypes();
++        sStartupCleanupRequired = false;
++        if (dataTypes.length == 0) {
++            finishSessionStartup();
++            return;
++        }
++
++        Profile profile = sSessionProfile;
++        if (profile == null) {
++            assert false : "Browsing session started without an original profile";
++            finishSessionStartup();
++            return;
++        }
++        startBrowsingDataCleanup(profile, dataTypes, sSessionId);
++    }
++
++    private static void finishSessionStartup() {
++        assert sSessionStarted;
++        assert !sCleanupInProgress;
++        sSessionReady = true;
++        runSessionReadyCallbacks();
++    }
++
++    private static void runSessionReadyCallbacks() {
++        List<Runnable> readyCallbacks = new ArrayList<>(sSessionReadyCallbacks);
++        sSessionReadyCallbacks.clear();
++        for (Runnable callback : readyCallbacks) {
++            callback.run();
++        }
++    }
++
++    private static void startBrowsingDataCleanup(
++            Profile profile, int[] dataTypes, int cleanupSessionId) {
++        assert !sCleanupInProgress;
++        sCleanupInProgress = true;
++        // Custom Tab preloading is not associated with an activity and could otherwise run while
++        // data is being cleared. Enabling automatic cleanup also prevents new preload requests.
++        CustomTabsConnection.destroyPreloadedTabs();
++        sBrowsingDataClearer.clear(
++                profile,
++                () -> {
++                    ThreadUtils.checkUiThread();
++                    assert sCleanupInProgress;
++                    sCleanupInProgress = false;
++
++                    if (sSessionStarted && !sSessionReady) {
++                        // If cleanup started for the previous session, run cleanup again with the
++                        // new session's selections before startup continues.
++                        if (cleanupSessionId != sSessionId) {
++                            sStartupCleanupRequired = isEnabled();
++                        }
++                        if (cleanupSessionId == sSessionId && !sStartupCleanupRequired) {
++                            finishSessionStartup();
++                        } else {
++                            continueSessionStartup();
++                        }
++                        return;
++                    }
++
++                    // If the activity is destroyed while waiting for cleanup, invoke its pending
++                    // callbacks so browser initialization can finish.
++                    runSessionReadyCallbacks();
++                },
++                dataTypes);
++    }
++
++    @VisibleForTesting
++    static int[] getSelectedDataTypesForTesting() {
++        return getSelectedDataTypes();
++    }
++
++    private static int[] getSelectedDataTypes() {
++        int[] dataTypes = new int[DATA_TYPE_COUNT];
++        int count = 0;
++        if (SharedPrefsExt.CLEAR_BROWSING_DATA_ON_EXIT_HISTORY.get()) {
++            dataTypes[count++] = BrowsingDataType.HISTORY;
++        }
++        if (SharedPrefsExt.CLEAR_BROWSING_DATA_ON_EXIT_COOKIES.get()) {
++            dataTypes[count++] = BrowsingDataType.SITE_DATA;
++        }
++        if (SharedPrefsExt.CLEAR_BROWSING_DATA_ON_EXIT_CACHE.get()) {
++            dataTypes[count++] = BrowsingDataType.CACHE;
++        }
++        if (SharedPrefsExt.CLEAR_BROWSING_DATA_ON_EXIT_PASSWORDS.get()) {
++            dataTypes[count++] = BrowsingDataType.PASSWORDS;
++        }
++        if (SharedPrefsExt.CLEAR_BROWSING_DATA_ON_EXIT_FORM_DATA.get()) {
++            dataTypes[count++] = BrowsingDataType.FORM_DATA;
++        }
++        if (SharedPrefsExt.CLEAR_BROWSING_DATA_ON_EXIT_SITE_SETTINGS.get()) {
++            dataTypes[count++] = BrowsingDataType.SITE_SETTINGS;
++        }
++        return Arrays.copyOf(dataTypes, count);
++    }
++
++    private static void clearBrowsingData(Profile profile, Runnable onComplete, int[] dataTypes) {
++        OnClearBrowsingDataListener listener = onComplete::run;
++        BrowsingDataBridge.getForProfile(profile).clearBrowsingData(
++                listener, dataTypes, TimePeriod.ALL_TIME);
++    }
++
++    @VisibleForTesting
++    static void setBrowsingDataClearerForTesting(BrowsingDataClearer browsingDataClearer) {
++        sBrowsingDataClearer = browsingDataClearer;
++        ResettersForTesting.register(ClearBrowsingDataOnExitManager::resetForTesting);
++    }
++
++    @VisibleForTesting
++    static void resetForTesting() {
++        sBrowsingDataClearer = DEFAULT_BROWSING_DATA_CLEARER;
++        sSessionReadyCallbacks.clear();
++        sSessionProfile = null;
++        sRegisteredActivityCount = 0;
++        sPendingActivityRecreationCount = 0;
++        sSessionId = 0;
++        sCleanupInProgress = false;
++        sSessionReady = false;
++        sSessionStarted = false;
++        sStartupCleanupRequired = false;
++    }
++}
+diff --git a/vanadium/chromium_src/chrome/android/java/src/org/chromium/chrome/browser/privacy/settings/ClearBrowsingDataOnExitSettings.java b/vanadium/chromium_src/chrome/android/java/src/org/chromium/chrome/browser/privacy/settings/ClearBrowsingDataOnExitSettings.java
+new file mode 100644
+index 0000000000000..7f01e356dca3b
+--- /dev/null
++++ b/vanadium/chromium_src/chrome/android/java/src/org/chromium/chrome/browser/privacy/settings/ClearBrowsingDataOnExitSettings.java
+@@ -0,0 +1,65 @@
++// Copyright 2026 GrapheneOS
++// Use of this source code is governed by a GPL-2.0-only style license that can be
++// found in the LICENSE file.
++
++package org.chromium.chrome.browser.privacy.settings;
++
++import android.os.Bundle;
++
++import org.chromium.base.shared_preferences.SharedPrefsUtils.BoolSharedPref;
++import org.chromium.base.shared_preferences.SharedPrefsUtils.SharedPrefsExt;
++import org.chromium.base.supplier.MonotonicObservableSupplier;
++import org.chromium.base.supplier.ObservableSuppliers;
++import org.chromium.base.supplier.SettableMonotonicObservableSupplier;
++import org.chromium.build.annotations.NullMarked;
++import org.chromium.build.annotations.Nullable;
++import org.chromium.chrome.R;
++import org.chromium.chrome.browser.ClearBrowsingDataOnExitManager;
++import org.chromium.chrome.browser.settings.ChromeBaseSettingsFragment;
++import org.chromium.components.browser_ui.settings.ChromeSwitchPreference;
++import org.chromium.components.browser_ui.settings.SettingsUtils;
++
++@NullMarked
++public final class ClearBrowsingDataOnExitSettings extends ChromeBaseSettingsFragment {
++    private final SettableMonotonicObservableSupplier<String> mPageTitle =
++            ObservableSuppliers.createMonotonic();
++
++    @Override
++    public void onCreatePreferences(@Nullable Bundle savedInstanceState, @Nullable String rootKey) {
++        SettingsUtils.addPreferencesFromResource(
++                this, R.xml.clear_browsing_data_on_exit_preferences);
++        mPageTitle.set(getString(R.string.clear_browsing_data_on_exit_title));
++
++        bindPreference(SharedPrefsExt.CLEAR_BROWSING_DATA_ON_EXIT_HISTORY);
++        bindPreference(SharedPrefsExt.CLEAR_BROWSING_DATA_ON_EXIT_COOKIES);
++        bindPreference(SharedPrefsExt.CLEAR_BROWSING_DATA_ON_EXIT_CACHE);
++        bindPreference(SharedPrefsExt.CLEAR_BROWSING_DATA_ON_EXIT_PASSWORDS);
++        bindPreference(SharedPrefsExt.CLEAR_BROWSING_DATA_ON_EXIT_FORM_DATA);
++        bindPreference(SharedPrefsExt.CLEAR_BROWSING_DATA_ON_EXIT_SITE_SETTINGS);
++    }
++
++    private void bindPreference(BoolSharedPref sharedPref) {
++        ChromeSwitchPreference preference = findPreference(sharedPref.getKey());
++        if (preference == null) {
++            return;
++        }
++
++        preference.setChecked(sharedPref.get());
++        preference.setOnPreferenceChangeListener(
++                (ignoredPreference, newValue) -> {
++                    sharedPref.put((boolean) newValue);
++                    ClearBrowsingDataOnExitManager.onDataTypePreferenceChanged();
++                    return true;
++                });
++    }
++
++    @Override
++    public MonotonicObservableSupplier<String> getPageTitle() {
++        return mPageTitle;
++    }
++
++    @Override
++    public int getAnimationType() {
++        return AnimationType.PROPERTY;
++    }
++}
+diff --git a/vanadium/chromium_src/chrome/android/java/src/org/chromium/chrome/browser/privacy/settings/PrivacySettingsExt.java b/vanadium/chromium_src/chrome/android/java/src/org/chromium/chrome/browser/privacy/settings/PrivacySettingsExt.java
+index d0711e695b226..8967b9ad96815 100644
+--- a/vanadium/chromium_src/chrome/android/java/src/org/chromium/chrome/browser/privacy/settings/PrivacySettingsExt.java
++++ b/vanadium/chromium_src/chrome/android/java/src/org/chromium/chrome/browser/privacy/settings/PrivacySettingsExt.java
+@@ -30,6 +30,8 @@ import org.chromium.components.user_prefs.UserPrefs;
+ final class PrivacySettingsExt {
+ 
+     private static final String PREF_SEARCH_SUGGESTIONS = "search_suggestions";
++    private static final String PREF_CLEAR_BROWSING_DATA_ON_EXIT =
++            "clear_browsing_data_on_exit";
+     private static final String PREF_CLOSE_TABS_ON_EXIT = SharedPrefsExt.CLOSE_TABS_ON_EXIT.getKey();
+     private static final String PREF_OPEN_LINKS_IN_INCOGNITO =
+             SharedPrefsExt.OPEN_LINKS_IN_INCOGNITO.getKey();
+@@ -100,6 +102,12 @@ final class PrivacySettingsExt {
+             closeTabsOnExitPref.setOnPreferenceChangeListener(getListener(profile));
+         }
+ 
++        Preference clearBrowsingDataOnExitPref =
++                prefFragment.findPreference(PREF_CLEAR_BROWSING_DATA_ON_EXIT);
++        if (clearBrowsingDataOnExitPref != null) {
++            clearBrowsingDataOnExitPref.setOrder(PRIVACY_PREFERENCES_ORDER);
++        }
++
+         ChromeSwitchPreference openLinksInIncognitoPref =
+                 (ChromeSwitchPreference) prefFragment.findPreference(PREF_OPEN_LINKS_IN_INCOGNITO);
+         if (openLinksInIncognitoPref != null) {
+diff --git a/vanadium/chromium_src/chrome/android/junit/src/org/chromium/chrome/browser/ClearBrowsingDataOnExitManagerTest.java b/vanadium/chromium_src/chrome/android/junit/src/org/chromium/chrome/browser/ClearBrowsingDataOnExitManagerTest.java
+new file mode 100644
+index 0000000000000..0e0ad35420b20
+--- /dev/null
++++ b/vanadium/chromium_src/chrome/android/junit/src/org/chromium/chrome/browser/ClearBrowsingDataOnExitManagerTest.java
+@@ -0,0 +1,343 @@
++// Copyright 2026 GrapheneOS
++// Use of this source code is governed by a GPL-2.0-only style license that can be
++// found in the LICENSE file.
++
++package org.chromium.chrome.browser;
++
++import static org.junit.Assert.assertArrayEquals;
++import static org.junit.Assert.assertEquals;
++import static org.junit.Assert.assertFalse;
++import static org.junit.Assert.assertTrue;
++import static org.mockito.Mockito.mock;
++
++import org.junit.After;
++import org.junit.Before;
++import org.junit.Test;
++import org.junit.runner.RunWith;
++import org.robolectric.RobolectricTestRunner;
++import org.robolectric.RuntimeEnvironment;
++import org.robolectric.annotation.Config;
++
++import org.chromium.base.ContextUtils;
++import org.chromium.base.shared_preferences.SharedPrefsUtils.SharedPrefsExt;
++import org.chromium.chrome.browser.browsing_data.BrowsingDataType;
++import org.chromium.chrome.browser.profiles.Profile;
++
++import java.util.ArrayList;
++import java.util.Arrays;
++import java.util.List;
++
++/** Unit tests for {@link ClearBrowsingDataOnExitManager}. */
++@RunWith(RobolectricTestRunner.class)
++@Config(manifest = Config.NONE)
++public final class ClearBrowsingDataOnExitManagerTest {
++    private static final class PendingClearRequest {
++        final int[] dataTypes;
++        final Runnable completionCallback;
++
++        PendingClearRequest(int[] dataTypes, Runnable completionCallback) {
++            this.dataTypes = Arrays.copyOf(dataTypes, dataTypes.length);
++            this.completionCallback = completionCallback;
++        }
++
++        void complete() {
++            completionCallback.run();
++        }
++    }
++
++    private final List<PendingClearRequest> mClearRequests = new ArrayList<>();
++    private Profile mProfile;
++
++    @Before
++    public void setUp() {
++        ContextUtils.initApplicationContextForTests(RuntimeEnvironment.getApplication());
++        resetPreferences();
++        mProfile = mock(Profile.class);
++        ClearBrowsingDataOnExitManager.setBrowsingDataClearerForTesting(this::recordClearRequest);
++    }
++
++    @After
++    public void tearDown() {
++        ClearBrowsingDataOnExitManager.resetForTesting();
++        resetPreferences();
++    }
++
++    @Test
++    public void testDefaultDoesNotClear() {
++        boolean[] ready = {false};
++        ClearBrowsingDataOnExitManager.onBrowsingActivityCreated();
++        ClearBrowsingDataOnExitManager.prepareForBrowsingSession(mProfile, () -> ready[0] = true);
++
++        assertTrue(ready[0]);
++        ClearBrowsingDataOnExitManager.onBrowsingActivityDestroyed(
++                /* activityFinishing= */ true);
++        assertTrue(mClearRequests.isEmpty());
++    }
++
++    @Test
++    public void testSelectedDataTypes() {
++        SharedPrefsExt.CLEAR_BROWSING_DATA_ON_EXIT_HISTORY.put(true);
++        SharedPrefsExt.CLEAR_BROWSING_DATA_ON_EXIT_COOKIES.put(true);
++        SharedPrefsExt.CLEAR_BROWSING_DATA_ON_EXIT_CACHE.put(true);
++        SharedPrefsExt.CLEAR_BROWSING_DATA_ON_EXIT_PASSWORDS.put(true);
++        SharedPrefsExt.CLEAR_BROWSING_DATA_ON_EXIT_FORM_DATA.put(true);
++        SharedPrefsExt.CLEAR_BROWSING_DATA_ON_EXIT_SITE_SETTINGS.put(true);
++
++        int[] expected = {BrowsingDataType.HISTORY, BrowsingDataType.SITE_DATA,
++                BrowsingDataType.CACHE, BrowsingDataType.PASSWORDS, BrowsingDataType.FORM_DATA,
++                BrowsingDataType.SITE_SETTINGS};
++        assertArrayEquals(
++                expected, ClearBrowsingDataOnExitManager.getSelectedDataTypesForTesting());
++    }
++
++    @Test
++    public void testEnabledReflectsSelections() {
++        assertFalse(ClearBrowsingDataOnExitManager.isEnabled());
++        SharedPrefsExt.CLEAR_BROWSING_DATA_ON_EXIT_HISTORY.put(true);
++        assertTrue(ClearBrowsingDataOnExitManager.isEnabled());
++        SharedPrefsExt.CLEAR_BROWSING_DATA_ON_EXIT_HISTORY.put(false);
++        assertFalse(ClearBrowsingDataOnExitManager.isEnabled());
++    }
++
++    @Test
++    public void testStartupCleanupBlocksUntilCompletion() {
++        SharedPrefsExt.CLEAR_BROWSING_DATA_ON_EXIT_HISTORY.put(true);
++        boolean[] ready = {false};
++
++        ClearBrowsingDataOnExitManager.onBrowsingActivityCreated();
++        ClearBrowsingDataOnExitManager.prepareForBrowsingSession(mProfile, () -> ready[0] = true);
++
++        assertEquals(1, mClearRequests.size());
++        assertFalse(ready[0]);
++        assertArrayEquals(new int[] {BrowsingDataType.HISTORY}, mClearRequests.get(0).dataTypes);
++        mClearRequests.get(0).complete();
++        assertTrue(ready[0]);
++
++        ClearBrowsingDataOnExitManager.onBrowsingActivityDestroyed(
++                /* activityFinishing= */ true);
++        assertEquals(2, mClearRequests.size());
++    }
++
++    @Test
++    public void testEachSessionClearsAtStartupWhenEnabled() {
++        SharedPrefsExt.CLEAR_BROWSING_DATA_ON_EXIT_CACHE.put(true);
++        startSessionAndCompleteStartupCleanup();
++
++        ClearBrowsingDataOnExitManager.onBrowsingActivityDestroyed(
++                /* activityFinishing= */ true);
++        assertEquals(2, mClearRequests.size());
++        mClearRequests.get(1).complete();
++
++        boolean[] ready = {false};
++        ClearBrowsingDataOnExitManager.onBrowsingActivityCreated();
++        ClearBrowsingDataOnExitManager.prepareForBrowsingSession(mProfile, () -> ready[0] = true);
++        assertEquals(3, mClearRequests.size());
++        assertFalse(ready[0]);
++    }
++
++    @Test
++    public void testActivityRecreationDoesNotClear() {
++        SharedPrefsExt.CLEAR_BROWSING_DATA_ON_EXIT_CACHE.put(true);
++        startSessionAndCompleteStartupCleanup();
++
++        ClearBrowsingDataOnExitManager.onBrowsingActivityDestroyed(
++                /* activityFinishing= */ false);
++        assertEquals(1, mClearRequests.size());
++
++        boolean[] replacementReady = {false};
++        ClearBrowsingDataOnExitManager.onBrowsingActivityCreated();
++        ClearBrowsingDataOnExitManager.prepareForBrowsingSession(
++                mProfile, () -> replacementReady[0] = true);
++        assertTrue(replacementReady[0]);
++        ClearBrowsingDataOnExitManager.onBrowsingActivityDestroyed(
++                /* activityFinishing= */ true);
++        assertEquals(2, mClearRequests.size());
++    }
++
++    @Test
++    public void testOtherBrowsingActivityDelaysCleanup() {
++        SharedPrefsExt.CLEAR_BROWSING_DATA_ON_EXIT_COOKIES.put(true);
++        boolean[] ready = {false, false};
++
++        ClearBrowsingDataOnExitManager.onBrowsingActivityCreated();
++        ClearBrowsingDataOnExitManager.onBrowsingActivityCreated();
++        ClearBrowsingDataOnExitManager.prepareForBrowsingSession(mProfile, () -> ready[0] = true);
++        ClearBrowsingDataOnExitManager.prepareForBrowsingSession(mProfile, () -> ready[1] = true);
++        assertEquals(1, mClearRequests.size());
++        assertFalse(ready[0]);
++        assertFalse(ready[1]);
++
++        mClearRequests.get(0).complete();
++        assertTrue(ready[0]);
++        assertTrue(ready[1]);
++        ClearBrowsingDataOnExitManager.onBrowsingActivityDestroyed(
++                /* activityFinishing= */ true);
++        assertEquals(1, mClearRequests.size());
++
++        ClearBrowsingDataOnExitManager.onBrowsingActivityDestroyed(
++                /* activityFinishing= */ true);
++        assertEquals(2, mClearRequests.size());
++    }
++
++    @Test
++    public void testActivityIsCountedBeforeNativeInitialization() {
++        SharedPrefsExt.CLEAR_BROWSING_DATA_ON_EXIT_CACHE.put(true);
++        startSessionAndCompleteStartupCleanup();
++        ClearBrowsingDataOnExitManager.onBrowsingActivityCreated();
++
++        ClearBrowsingDataOnExitManager.onBrowsingActivityDestroyed(
++                /* activityFinishing= */ true);
++        assertEquals(1, mClearRequests.size());
++
++        boolean[] ready = {false};
++        ClearBrowsingDataOnExitManager.prepareForBrowsingSession(mProfile, () -> ready[0] = true);
++        assertTrue(ready[0]);
++        ClearBrowsingDataOnExitManager.onBrowsingActivityDestroyed(
++                /* activityFinishing= */ true);
++        assertEquals(2, mClearRequests.size());
++    }
++
++    @Test
++    public void testPendingRecreationPreventsCleanupBetweenActivities() {
++        SharedPrefsExt.CLEAR_BROWSING_DATA_ON_EXIT_HISTORY.put(true);
++        boolean[] ready = {false, false};
++
++        ClearBrowsingDataOnExitManager.onBrowsingActivityCreated();
++        ClearBrowsingDataOnExitManager.onBrowsingActivityCreated();
++        ClearBrowsingDataOnExitManager.prepareForBrowsingSession(mProfile, () -> ready[0] = true);
++        ClearBrowsingDataOnExitManager.prepareForBrowsingSession(mProfile, () -> ready[1] = true);
++        mClearRequests.get(0).complete();
++        assertTrue(ready[0]);
++        assertTrue(ready[1]);
++
++        ClearBrowsingDataOnExitManager.onBrowsingActivityDestroyed(
++                /* activityFinishing= */ false);
++        ClearBrowsingDataOnExitManager.onBrowsingActivityDestroyed(
++                /* activityFinishing= */ true);
++        assertEquals(1, mClearRequests.size());
++
++        boolean[] replacementReady = {false};
++        ClearBrowsingDataOnExitManager.onBrowsingActivityCreated();
++        ClearBrowsingDataOnExitManager.prepareForBrowsingSession(
++                mProfile, () -> replacementReady[0] = true);
++        assertTrue(replacementReady[0]);
++        ClearBrowsingDataOnExitManager.onBrowsingActivityDestroyed(
++                /* activityFinishing= */ true);
++        assertEquals(2, mClearRequests.size());
++    }
++
++    @Test
++    public void testNewSessionRunsFreshCleanupAfterInFlightExitCleanup() {
++        SharedPrefsExt.CLEAR_BROWSING_DATA_ON_EXIT_PASSWORDS.put(true);
++        startSessionAndCompleteStartupCleanup();
++        ClearBrowsingDataOnExitManager.onBrowsingActivityDestroyed(
++                /* activityFinishing= */ true);
++        assertEquals(2, mClearRequests.size());
++
++        boolean[] ready = {false};
++        ClearBrowsingDataOnExitManager.onBrowsingActivityCreated();
++        ClearBrowsingDataOnExitManager.prepareForBrowsingSession(mProfile, () -> ready[0] = true);
++        assertEquals(2, mClearRequests.size());
++        assertFalse(ready[0]);
++
++        mClearRequests.get(1).complete();
++        assertEquals(3, mClearRequests.size());
++        assertFalse(ready[0]);
++        assertArrayEquals(new int[] {BrowsingDataType.PASSWORDS}, mClearRequests.get(2).dataTypes);
++        mClearRequests.get(2).complete();
++        assertTrue(ready[0]);
++    }
++
++    @Test
++    public void testSelectionChangeDuringStartupRunsFreshCleanup() {
++        SharedPrefsExt.CLEAR_BROWSING_DATA_ON_EXIT_HISTORY.put(true);
++        boolean[] ready = {false};
++
++        ClearBrowsingDataOnExitManager.onBrowsingActivityCreated();
++        ClearBrowsingDataOnExitManager.prepareForBrowsingSession(mProfile, () -> ready[0] = true);
++        assertArrayEquals(new int[] {BrowsingDataType.HISTORY}, mClearRequests.get(0).dataTypes);
++
++        SharedPrefsExt.CLEAR_BROWSING_DATA_ON_EXIT_CACHE.put(true);
++        ClearBrowsingDataOnExitManager.onDataTypePreferenceChanged();
++        SharedPrefsExt.CLEAR_BROWSING_DATA_ON_EXIT_HISTORY.put(false);
++        ClearBrowsingDataOnExitManager.onDataTypePreferenceChanged();
++        mClearRequests.get(0).complete();
++
++        assertEquals(2, mClearRequests.size());
++        assertFalse(ready[0]);
++        assertArrayEquals(new int[] {BrowsingDataType.CACHE}, mClearRequests.get(1).dataTypes);
++        mClearRequests.get(1).complete();
++        assertTrue(ready[0]);
++    }
++
++    @Test
++    public void testDestroyedActivityStillRunsQueuedStartupCallback() {
++        SharedPrefsExt.CLEAR_BROWSING_DATA_ON_EXIT_SITE_SETTINGS.put(true);
++        boolean[] ready = {false};
++
++        ClearBrowsingDataOnExitManager.onBrowsingActivityCreated();
++        ClearBrowsingDataOnExitManager.prepareForBrowsingSession(mProfile, () -> ready[0] = true);
++        ClearBrowsingDataOnExitManager.onBrowsingActivityDestroyed(
++                /* activityFinishing= */ true);
++        assertFalse(ready[0]);
++
++        mClearRequests.get(0).complete();
++        assertTrue(ready[0]);
++
++        boolean[] nextReady = {false};
++        ClearBrowsingDataOnExitManager.onBrowsingActivityCreated();
++        ClearBrowsingDataOnExitManager.prepareForBrowsingSession(
++                mProfile, () -> nextReady[0] = true);
++        assertEquals(2, mClearRequests.size());
++        assertFalse(nextReady[0]);
++    }
++
++    @Test
++    public void testDisablingSelectionWaitsForInFlightCleanup() {
++        SharedPrefsExt.CLEAR_BROWSING_DATA_ON_EXIT_FORM_DATA.put(true);
++        startSessionAndCompleteStartupCleanup();
++        ClearBrowsingDataOnExitManager.onBrowsingActivityDestroyed(
++                /* activityFinishing= */ true);
++
++        SharedPrefsExt.CLEAR_BROWSING_DATA_ON_EXIT_FORM_DATA.put(false);
++        ClearBrowsingDataOnExitManager.onDataTypePreferenceChanged();
++        assertTrue(ClearBrowsingDataOnExitManager.shouldBlockCustomTabPreloading());
++        boolean[] ready = {false};
++        ClearBrowsingDataOnExitManager.onBrowsingActivityCreated();
++        ClearBrowsingDataOnExitManager.prepareForBrowsingSession(mProfile, () -> ready[0] = true);
++        assertFalse(ready[0]);
++
++        mClearRequests.get(1).complete();
++        assertTrue(ready[0]);
++        assertEquals(2, mClearRequests.size());
++        assertFalse(ClearBrowsingDataOnExitManager.shouldBlockCustomTabPreloading());
++        ClearBrowsingDataOnExitManager.onBrowsingActivityDestroyed(
++                /* activityFinishing= */ true);
++        assertEquals(2, mClearRequests.size());
++    }
++
++    private void startSessionAndCompleteStartupCleanup() {
++        int requestIndex = mClearRequests.size();
++        boolean[] ready = {false};
++        ClearBrowsingDataOnExitManager.onBrowsingActivityCreated();
++        ClearBrowsingDataOnExitManager.prepareForBrowsingSession(mProfile, () -> ready[0] = true);
++        assertEquals(requestIndex + 1, mClearRequests.size());
++        assertFalse(ready[0]);
++        mClearRequests.get(requestIndex).complete();
++        assertTrue(ready[0]);
++    }
++
++    private void recordClearRequest(Profile profile, Runnable onComplete, int[] dataTypes) {
++        assertEquals(mProfile, profile);
++        mClearRequests.add(new PendingClearRequest(dataTypes, onComplete));
++    }
++
++    private static void resetPreferences() {
++        SharedPrefsExt.CLEAR_BROWSING_DATA_ON_EXIT_HISTORY.putSync(false);
++        SharedPrefsExt.CLEAR_BROWSING_DATA_ON_EXIT_COOKIES.putSync(false);
++        SharedPrefsExt.CLEAR_BROWSING_DATA_ON_EXIT_CACHE.putSync(false);
++        SharedPrefsExt.CLEAR_BROWSING_DATA_ON_EXIT_PASSWORDS.putSync(false);
++        SharedPrefsExt.CLEAR_BROWSING_DATA_ON_EXIT_FORM_DATA.putSync(false);
++        SharedPrefsExt.CLEAR_BROWSING_DATA_ON_EXIT_SITE_SETTINGS.putSync(false);
++    }
++}
+diff --git a/vanadium/chromium_src/chrome/browser/ui/android/strings/android_chrome_ext_strings.grdp b/vanadium/chromium_src/chrome/browser/ui/android/strings/android_chrome_ext_strings.grdp
+index 3dc9d0438ec7d..bd18dfb1c220d 100644
+--- a/vanadium/chromium_src/chrome/browser/ui/android/strings/android_chrome_ext_strings.grdp
++++ b/vanadium/chromium_src/chrome/browser/ui/android/strings/android_chrome_ext_strings.grdp
+@@ -3,6 +3,12 @@
+  Use of this source code is governed by a GPLv2 only-style license that can be
+  found in the LICENSE file. -->
+ <grit-part>
++  <message name="IDS_CLEAR_BROWSING_DATA_ON_EXIT_TITLE" desc="Title of the clear browsing data on exit settings page">
++    Clear browsing data on exit
++  </message>
++  <message name="IDS_CLEAR_BROWSING_DATA_ON_EXIT_SUMMARY" desc="Summary of the clear browsing data on exit settings page">
++    Choose data to delete when Vanadium closes
++  </message>
+   <message name="IDS_CLOSE_TABS_ON_EXIT_TITLE" desc="Title of closing tabs on exit menu item">
+     Close tabs on exit
+   </message>
+-- 
+2.55.0
+

--- a/patches/0292-Add-clear-browsing-data-on-exit.patch
+++ b/patches/0292-Add-clear-browsing-data-on-exit.patch
@@ -1,4 +1,4 @@
-From 92b25fc63213e7dac78dc61fc66e2bb83cd78f1a Mon Sep 17 00:00:00 2001
+From b746bde4455254c20fc0fe68ace00e345fcb59eb Mon Sep 17 00:00:00 2001
 From: aaravrav <37036762+aaravrav@users.noreply.github.com>
 Date: Tue, 14 Jul 2026 11:49:03 +0530
 Subject: [PATCH] Add clear browsing data on exit
@@ -8,28 +8,39 @@ passwords, form data and site settings. Clear selected data when the
 last browser activity finishes and before browsing can begin the next
 time Vanadium opens.
 ---
- .../chrome/browser/app/ChromeActivity.java    |  22 ++
+ .../chrome/browser/app/ChromeActivity.java    |  22 +
  .../customtabs/CustomTabsConnection.java      |  39 ++
  .../browser/customtabs/HiddenTabHolder.java   |   7 +
  .../chrome/browser/init/BrowserParts.java     |  10 +
  .../init/ChromeBrowserInitializer.java        |  13 +-
- chrome/android/junit/BUILD.gn                 |   1 +
- .../CustomTabsConnectionUnitTest.java         |  43 +++
+ .../search/SearchIndexProviderRegistry.java   |   2 +
+ .../customtabs/CustomTabsConnectionTest.java  |  39 ++
+ .../init/ChromeBrowserInitializerTest.java    |  34 ++
+ chrome/android/junit/BUILD.gn                 |   6 +
+ .../CustomTabsConnectionUnitTest.java         |  43 ++
  .../shared_preferences/SharedPrefsUtils.java  |  18 +
  .../chrome_app_java_resources_ext_sources.gni |   1 +
  .../android/chrome_java_ext_sources.gni       |   2 +
  ...lear_browsing_data_on_exit_preferences.xml |  34 ++
  .../java/res/xml/privacy_preferences_ext.xml  |   6 +-
- .../ClearBrowsingDataOnExitManager.java       | 304 ++++++++++++++++
- .../ClearBrowsingDataOnExitSettings.java      |  65 ++++
+ .../ClearBrowsingDataOnExitManager.java       | 334 ++++++++++++
+ .../ClearBrowsingDataOnExitSettings.java      |  72 +++
  .../privacy/settings/PrivacySettingsExt.java  |   8 +
- .../ClearBrowsingDataOnExitManagerTest.java   | 343 ++++++++++++++++++
+ ...igningCertificatePackageManagerShadow.java |  19 +
+ ...ClearBrowsingDataOnExitCustomTabsTest.java | 176 +++++++
+ .../ClearBrowsingDataOnExitManagerTest.java   | 482 ++++++++++++++++++
+ .../ClearBrowsingDataOnExitBridgeTest.java    | 110 ++++
+ .../ClearBrowsingDataOnExitSettingsTest.java  | 149 ++++++
  .../strings/android_chrome_ext_strings.grdp   |   6 +
- 17 files changed, 918 insertions(+), 4 deletions(-)
+ 24 files changed, 1628 insertions(+), 4 deletions(-)
  create mode 100644 vanadium/chromium_src/chrome/android/java/res/xml/clear_browsing_data_on_exit_preferences.xml
  create mode 100644 vanadium/chromium_src/chrome/android/java/src/org/chromium/chrome/browser/ClearBrowsingDataOnExitManager.java
  create mode 100644 vanadium/chromium_src/chrome/android/java/src/org/chromium/chrome/browser/privacy/settings/ClearBrowsingDataOnExitSettings.java
+ create mode 100644 vanadium/chromium_src/chrome/android/junit/src/app/vanadium/test/NoSigningCertificatePackageManagerShadow.java
+ create mode 100644 vanadium/chromium_src/chrome/android/junit/src/org/chromium/chrome/browser/ClearBrowsingDataOnExitCustomTabsTest.java
  create mode 100644 vanadium/chromium_src/chrome/android/junit/src/org/chromium/chrome/browser/ClearBrowsingDataOnExitManagerTest.java
+ create mode 100644 vanadium/chromium_src/chrome/android/junit/src/org/chromium/chrome/browser/browsing_data/ClearBrowsingDataOnExitBridgeTest.java
+ create mode 100644 vanadium/chromium_src/chrome/android/junit/src/org/chromium/chrome/browser/privacy/settings/ClearBrowsingDataOnExitSettingsTest.java
 
 diff --git a/chrome/android/java/src/org/chromium/chrome/browser/app/ChromeActivity.java b/chrome/android/java/src/org/chromium/chrome/browser/app/ChromeActivity.java
 index df1e608403265..417135f1aca41 100644
@@ -93,7 +104,7 @@ index df1e608403265..417135f1aca41 100644
      }
  
 diff --git a/chrome/android/java/src/org/chromium/chrome/browser/customtabs/CustomTabsConnection.java b/chrome/android/java/src/org/chromium/chrome/browser/customtabs/CustomTabsConnection.java
-index 6e3ecf9d905d6..e2ccc30a9a893 100644
+index 6e3ecf9d905d6..550f91da56764 100644
 --- a/chrome/android/java/src/org/chromium/chrome/browser/customtabs/CustomTabsConnection.java
 +++ b/chrome/android/java/src/org/chromium/chrome/browser/customtabs/CustomTabsConnection.java
 @@ -60,6 +60,7 @@ import org.chromium.build.annotations.NullMarked;
@@ -124,7 +135,7 @@ index 6e3ecf9d905d6..e2ccc30a9a893 100644
              final @Nullable Uri url,
              final @Nullable Bundle extras,
              final @Nullable List<Bundle> otherLikelyBundles) {
-+        if (ClearBrowsingDataOnExitManager.isEnabled()) return false;
++        if (ClearBrowsingDataOnExitManager.shouldBlockCustomTabPreloading()) return false;
          // mayLaunchUrl should not be executed for Incognito CCT since all setup is created with
          // regular profile. If we need to enable mayLaunchUrl for off-the-record profiles, we need
          // to update the profile used. Please see crbug.com/40706528.
@@ -132,7 +143,7 @@ index 6e3ecf9d905d6..e2ccc30a9a893 100644
      @ExperimentalPrefetch
      private void prefetchInternal(
              SessionHolder<?> session, List<Uri> urls, PrefetchOptions options) {
-+        if (ClearBrowsingDataOnExitManager.isEnabled()) return;
++        if (ClearBrowsingDataOnExitManager.shouldBlockCustomTabPreloading()) return;
          boolean usePrefetchProxy = options.requiresAnonymousIpWhenCrossOrigin;
          Origin sourceOrigin =
                  options.sourceOrigin != null
@@ -328,18 +339,166 @@ index ec9adf97fdedc..99bbd7efdfaca 100644
              tasks.start(true);
          }
      }
+diff --git a/chrome/android/java/src/org/chromium/chrome/browser/settings/search/SearchIndexProviderRegistry.java b/chrome/android/java/src/org/chromium/chrome/browser/settings/search/SearchIndexProviderRegistry.java
+index 61e32e4c1c135..0e63640dc6822 100644
+--- a/chrome/android/java/src/org/chromium/chrome/browser/settings/search/SearchIndexProviderRegistry.java
++++ b/chrome/android/java/src/org/chromium/chrome/browser/settings/search/SearchIndexProviderRegistry.java
+@@ -31,6 +31,7 @@ import org.chromium.chrome.browser.language.settings.LanguageSettings;
+ import org.chromium.chrome.browser.night_mode.settings.ThemeSettingsFragment;
+ import org.chromium.chrome.browser.prefetch.settings.PreloadPagesSettingsFragment;
+ import org.chromium.chrome.browser.privacy.secure_dns.SecureDnsSettings;
++import org.chromium.chrome.browser.privacy.settings.ClearBrowsingDataOnExitSettings;
+ import org.chromium.chrome.browser.privacy.settings.DoNotTrackSettings;
+ import org.chromium.chrome.browser.privacy.settings.PrivacySettings;
+ import org.chromium.chrome.browser.privacy_sandbox.AdMeasurementFragment;
+@@ -97,6 +98,7 @@ public final class SearchIndexProviderRegistry {
+                     AutofillOptionsFragment.SEARCH_INDEX_DATA_PROVIDER,
+                     ContextualSearchSettingsFragment.SEARCH_INDEX_DATA_PROVIDER,
+                     GlicSettings.SEARCH_INDEX_DATA_PROVIDER,
++                    ClearBrowsingDataOnExitSettings.SEARCH_INDEX_DATA_PROVIDER,
+                     DoNotTrackSettings.SEARCH_INDEX_DATA_PROVIDER,
+                     HomepageSettings.SEARCH_INDEX_DATA_PROVIDER,
+                     LegalInformationSettings.SEARCH_INDEX_DATA_PROVIDER,
+diff --git a/chrome/android/javatests/src/org/chromium/chrome/browser/customtabs/CustomTabsConnectionTest.java b/chrome/android/javatests/src/org/chromium/chrome/browser/customtabs/CustomTabsConnectionTest.java
+index 7d8d6142b9fdb..6281c8e1da470 100644
+--- a/chrome/android/javatests/src/org/chromium/chrome/browser/customtabs/CustomTabsConnectionTest.java
++++ b/chrome/android/javatests/src/org/chromium/chrome/browser/customtabs/CustomTabsConnectionTest.java
+@@ -275,6 +275,45 @@ public class CustomTabsConnectionTest {
+                 mCustomTabsConnection.mayLaunchUrl(token, null, null, null));
+     }
+ 
++    @Test
++    @SmallTest
++    @CommandLineFlags.Add(ChromeSwitches.DISABLE_FIRST_RUN_EXPERIENCE)
++    public void testDestroyPreloadedTabsDestroysSpareAndHiddenTabs() throws Exception {
++        CustomTabsTestUtils.warmUpAndWait();
++        CustomTabsSessionToken token = CustomTabsSessionToken.createMockSessionTokenForTesting();
++        var sessionHolder = new SessionHolder<>(token);
++        Assert.assertTrue(mCustomTabsConnection.newSession(token));
++        mCustomTabsConnection.setCanUseHiddenTabForSession(sessionHolder, true);
++        mCustomTabsConnection.setShouldSpeculateLoadOnCellularForSession(sessionHolder, true);
++        Assert.assertTrue(mCustomTabsConnection.mayLaunchUrl(token, Uri.parse(URL), null, null));
++
++        CallbackHelper tabDestroyedHelper = new CallbackHelper();
++        ThreadUtils.runOnUiThreadBlocking(
++                () -> {
++                    HiddenTabHolder.SpeculationParams speculation =
++                            mCustomTabsConnection.getSpeculationParamsForTesting();
++                    Assert.assertNotNull(speculation);
++                    Tab hiddenTab = speculation.hiddenTab.tab;
++                    hiddenTab.addObserver(
++                            new EmptyTabObserver() {
++                                @Override
++                                public void onDestroyed(Tab tab) {
++                                    tabDestroyedHelper.notifyCalled();
++                                }
++                            });
++
++                    Profile profile = ProfileManager.getLastUsedRegularProfile();
++                    WarmupManager.getInstance().createRegularSpareTab(profile);
++                    Assert.assertTrue(WarmupManager.getInstance().hasSpareTab(profile, false));
++
++                    CustomTabsConnection.destroyPreloadedTabs();
++
++                    Assert.assertFalse(WarmupManager.getInstance().hasSpareTab(profile, false));
++                    Assert.assertNull(mCustomTabsConnection.getSpeculationParamsForTesting());
++                });
++        tabDestroyedHelper.waitForCallback(0);
++    }
++
+     /** Tests that if the renderer backing a hidden tab is killed, the speculation is canceled. */
+     @Test
+     @SmallTest
+diff --git a/chrome/android/javatests/src/org/chromium/chrome/browser/init/ChromeBrowserInitializerTest.java b/chrome/android/javatests/src/org/chromium/chrome/browser/init/ChromeBrowserInitializerTest.java
+index 3f127f5738d8c..06149849c3f27 100644
+--- a/chrome/android/javatests/src/org/chromium/chrome/browser/init/ChromeBrowserInitializerTest.java
++++ b/chrome/android/javatests/src/org/chromium/chrome/browser/init/ChromeBrowserInitializerTest.java
+@@ -16,6 +16,7 @@ import org.chromium.chrome.test.ChromeJUnit4ClassRunner;
+ 
+ import java.util.concurrent.Semaphore;
+ import java.util.concurrent.TimeUnit;
++import java.util.concurrent.atomic.AtomicReference;
+ 
+ /** Tests for ChromeBrowserInitializer. */
+ @RunWith(ChromeJUnit4ClassRunner.class)
+@@ -70,6 +71,39 @@ public class ChromeBrowserInitializerTest {
+         Assert.assertTrue(done.tryAcquire(10, TimeUnit.SECONDS));
+     }
+ 
++    @Test
++    @SmallTest
++    public void testAsynchronousStartupWaitsForInitialNavigationPreparation() throws Exception {
++        Semaphore preparationRequested = new Semaphore(0);
++        Semaphore initializationFinished = new Semaphore(0);
++        AtomicReference<Runnable> continueStartup = new AtomicReference<>();
++        BrowserParts parts =
++                new EmptyBrowserParts() {
++                    @Override
++                    public void prepareForInitialNavigation(Runnable onComplete) {
++                        continueStartup.set(onComplete);
++                        preparationRequested.release();
++                    }
++
++                    @Override
++                    public void finishNativeInitialization() {
++                        initializationFinished.release();
++                    }
++                };
++
++        ThreadUtils.runOnUiThreadBlocking(
++                () -> {
++                    mInstance.handlePreNativeStartupAndLoadLibraries(parts);
++                    mInstance.handlePostNativeStartup(true, parts);
++                });
++
++        Assert.assertTrue(preparationRequested.tryAcquire(10, TimeUnit.SECONDS));
++        Assert.assertFalse(initializationFinished.tryAcquire(200, TimeUnit.MILLISECONDS));
++
++        ThreadUtils.runOnUiThreadBlocking(continueStartup.get());
++        Assert.assertTrue(initializationFinished.tryAcquire(10, TimeUnit.SECONDS));
++    }
++
+     @Test
+     @SmallTest
+     public void testDelayedTasks() throws Exception {
 diff --git a/chrome/android/junit/BUILD.gn b/chrome/android/junit/BUILD.gn
-index 997eeb22b7b8c..9a5adc1fc8648 100644
+index 997eeb22b7b8c..40d6b4ad0e04e 100644
 --- a/chrome/android/junit/BUILD.gn
 +++ b/chrome/android/junit/BUILD.gn
-@@ -428,6 +428,7 @@ if (is_android) {
+@@ -41,6 +41,7 @@ if (is_android) {
+   robolectric_library("chrome_junit_tests_helper") {
+     sources = [
+       "//chrome/browser/bookmarks/android/junit/src/org/chromium/chrome/browser/bookmarks/FakeBookmarkModel.java",
++      "//vanadium/chromium_src/chrome/android/junit/src/app/vanadium/test/NoSigningCertificatePackageManagerShadow.java",
+       "src/org/chromium/chrome/browser/ChromeRobolectricTestRunner.java",
+       "src/org/chromium/chrome/browser/compositor/overlays/strip/TestTabModel.java",
+       "src/org/chromium/chrome/browser/multiwindow/MultiWindowTestUtils.java",
+@@ -428,6 +429,8 @@ if (is_android) {
      sources = [
        "//chrome/android/java/src/org/chromium/chrome/browser/bottombar/BottomBarAppMenuUpdateBadgeControllerUnitTest.java",
        "//chrome/android/java/src/org/chromium/chrome/browser/bottombar/BottomBarContainerCoordinatorUnitTest.java",
++      "//vanadium/chromium_src/chrome/android/junit/src/org/chromium/chrome/browser/ClearBrowsingDataOnExitCustomTabsTest.java",
 +      "//vanadium/chromium_src/chrome/android/junit/src/org/chromium/chrome/browser/ClearBrowsingDataOnExitManagerTest.java",
        "src/org/chromium/chrome/browser/BrowserExitReasonTrackerUnitTest.java",
        "src/org/chromium/chrome/browser/ChromeActionModeHandlerUnitTest.java",
        "src/org/chromium/chrome/browser/ChromeActivityUnitTest.java",
+@@ -1512,6 +1515,8 @@ if (is_android) {
+       "//chrome/browser/collaboration/android/java/src/org/chromium/chrome/browser/collaboration/CollaborationControllerDelegateImplUnitTest.java",
+       "//chrome/browser/commerce/subscriptions/test/android/java/src/org/chromium/chrome/browser/subscriptions/CommerceSubscriptionsServiceFactoryUnitTest.java",
+       "//chrome/browser/commerce/subscriptions/test/android/java/src/org/chromium/chrome/browser/subscriptions/CommerceSubscriptionsServiceUnitTest.java",
++      "//vanadium/chromium_src/chrome/android/junit/src/org/chromium/chrome/browser/browsing_data/ClearBrowsingDataOnExitBridgeTest.java",
++      "//vanadium/chromium_src/chrome/android/junit/src/org/chromium/chrome/browser/privacy/settings/ClearBrowsingDataOnExitSettingsTest.java",
+       "src/org/chromium/chrome/browser/about_settings/AboutSettingsBridgeTest.java",
+       "src/org/chromium/chrome/browser/accessibility/AccessibilityTabHelperTest.java",
+       "src/org/chromium/chrome/browser/accessibility/PageZoomIphControllerTest.java",
+@@ -1604,6 +1609,7 @@ if (is_android) {
+       ":chrome_junit_tests_helper",
+       "//base:holder_java",
+       "//chrome/browser/actor/android:java",
++      "//chrome/browser/browsing_data/android:java",
+       "//chrome/browser/notifications:java",
+       "//chrome/browser/privacy:privacy_preference_manager_java",
+       "//chrome/browser/ui/android/multiwindow:multi_instance_data_proto_java",
 diff --git a/chrome/android/junit/src/org/chromium/chrome/browser/customtabs/CustomTabsConnectionUnitTest.java b/chrome/android/junit/src/org/chromium/chrome/browser/customtabs/CustomTabsConnectionUnitTest.java
 index 94d45825b5aa1..83899ca10b8f2 100644
 --- a/chrome/android/junit/src/org/chromium/chrome/browser/customtabs/CustomTabsConnectionUnitTest.java
@@ -555,10 +714,10 @@ index f1d44d6b4b764..5c091109d20b4 100644
 -
 diff --git a/vanadium/chromium_src/chrome/android/java/src/org/chromium/chrome/browser/ClearBrowsingDataOnExitManager.java b/vanadium/chromium_src/chrome/android/java/src/org/chromium/chrome/browser/ClearBrowsingDataOnExitManager.java
 new file mode 100644
-index 0000000000000..0494b5e9cb543
+index 0000000000000..69ed19f686e4e
 --- /dev/null
 +++ b/vanadium/chromium_src/chrome/android/java/src/org/chromium/chrome/browser/ClearBrowsingDataOnExitManager.java
-@@ -0,0 +1,304 @@
+@@ -0,0 +1,334 @@
 +// Copyright 2026 GrapheneOS
 +// Use of this source code is governed by a GPL-2.0-only style license that can be
 +// found in the LICENSE file.
@@ -569,6 +728,7 @@ index 0000000000000..0494b5e9cb543
 +
 +import org.chromium.base.ResettersForTesting;
 +import org.chromium.base.ThreadUtils;
++import org.chromium.base.shared_preferences.SharedPrefsUtils.BoolSharedPref;
 +import org.chromium.base.shared_preferences.SharedPrefsUtils.SharedPrefsExt;
 +import org.chromium.build.annotations.NullMarked;
 +import org.chromium.build.annotations.Nullable;
@@ -586,8 +746,33 @@ index 0000000000000..0494b5e9cb543
 +/** Clears user-selected browsing data between browser activity sessions. */
 +@NullMarked
 +public final class ClearBrowsingDataOnExitManager {
-+    private static final int DATA_TYPE_COUNT = 6;
 +    private static final int NO_SESSION_ID = -1;
++
++    private static final class DataTypeSelection {
++        final BoolSharedPref mPref;
++        final int mDataType;
++
++        DataTypeSelection(BoolSharedPref pref, int dataType) {
++            mPref = pref;
++            mDataType = dataType;
++        }
++    }
++
++    private static final DataTypeSelection[] DATA_TYPE_SELECTIONS = {
++        new DataTypeSelection(
++                SharedPrefsExt.CLEAR_BROWSING_DATA_ON_EXIT_HISTORY, BrowsingDataType.HISTORY),
++        new DataTypeSelection(
++                SharedPrefsExt.CLEAR_BROWSING_DATA_ON_EXIT_COOKIES, BrowsingDataType.SITE_DATA),
++        new DataTypeSelection(
++                SharedPrefsExt.CLEAR_BROWSING_DATA_ON_EXIT_CACHE, BrowsingDataType.CACHE),
++        new DataTypeSelection(
++                SharedPrefsExt.CLEAR_BROWSING_DATA_ON_EXIT_PASSWORDS, BrowsingDataType.PASSWORDS),
++        new DataTypeSelection(
++                SharedPrefsExt.CLEAR_BROWSING_DATA_ON_EXIT_FORM_DATA, BrowsingDataType.FORM_DATA),
++        new DataTypeSelection(
++                SharedPrefsExt.CLEAR_BROWSING_DATA_ON_EXIT_SITE_SETTINGS,
++                BrowsingDataType.SITE_SETTINGS),
++    };
 +
 +    @VisibleForTesting
 +    interface BrowsingDataClearer {
@@ -600,6 +785,7 @@ index 0000000000000..0494b5e9cb543
 +
 +    private static BrowsingDataClearer sBrowsingDataClearer = DEFAULT_BROWSING_DATA_CLEARER;
 +    private static @Nullable Profile sSessionProfile;
++    private static @Nullable Profile sPendingExitCleanupProfile;
 +    private static int sRegisteredActivityCount;
 +    private static int sPendingActivityRecreationCount;
 +    private static int sSessionId;
@@ -691,35 +877,39 @@ index 0000000000000..0494b5e9cb543
 +            return;
 +        }
 +
++        if (sCleanupInProgress) {
++            // Defer this exit cleanup until the current cleanup finishes. Before starting the
++            // deferred cleanup, check the selected cleanup options again.
++            sPendingExitCleanupProfile = profile;
++            return;
++        }
++
 +        int[] dataTypes = getSelectedDataTypes();
 +        if (dataTypes.length == 0) return;
 +
-+        if (!sCleanupInProgress) {
-+            startBrowsingDataCleanup(profile, dataTypes, NO_SESSION_ID);
-+        }
++        startBrowsingDataCleanup(profile, dataTypes, NO_SESSION_ID);
 +    }
 +
 +    /** Updates cleanup state after the selected data types change. */
 +    public static void onDataTypePreferenceChanged() {
 +        ThreadUtils.checkUiThread();
++        boolean enabled = isEnabled();
 +        if (sSessionStarted && !sSessionReady) {
 +            // If the selected data types change while startup cleanup is running, clean again
 +            // using the updated selection before startup continues.
-+            sStartupCleanupRequired = isEnabled();
++            sStartupCleanupRequired = enabled;
 +        }
-+        if (isEnabled()) {
++        if (enabled) {
 +            CustomTabsConnection.destroyPreloadedTabs();
 +        }
 +    }
 +
 +    /** Returns whether at least one data type is selected for automatic cleanup. */
 +    public static boolean isEnabled() {
-+        return SharedPrefsExt.CLEAR_BROWSING_DATA_ON_EXIT_HISTORY.get()
-+                || SharedPrefsExt.CLEAR_BROWSING_DATA_ON_EXIT_COOKIES.get()
-+                || SharedPrefsExt.CLEAR_BROWSING_DATA_ON_EXIT_CACHE.get()
-+                || SharedPrefsExt.CLEAR_BROWSING_DATA_ON_EXIT_PASSWORDS.get()
-+                || SharedPrefsExt.CLEAR_BROWSING_DATA_ON_EXIT_FORM_DATA.get()
-+                || SharedPrefsExt.CLEAR_BROWSING_DATA_ON_EXIT_SITE_SETTINGS.get();
++        for (DataTypeSelection selection : DATA_TYPE_SELECTIONS) {
++            if (selection.mPref.get()) return true;
++        }
++        return false;
 +    }
 +
 +    /** Returns whether automatic cleanup requires Custom Tab preloading to remain disabled. */
@@ -788,6 +978,9 @@ index 0000000000000..0494b5e9cb543
 +                    sCleanupInProgress = false;
 +
 +                    if (sSessionStarted && !sSessionReady) {
++                        // A new session started while this cleanup ran. Its startup cleanup
++                        // replaces any pending exit cleanup before the new session can continue.
++                        sPendingExitCleanupProfile = null;
 +                        // If cleanup started for the previous session, run cleanup again with the
 +                        // new session's selections before startup continues.
 +                        if (cleanupSessionId != sSessionId) {
@@ -801,6 +994,17 @@ index 0000000000000..0494b5e9cb543
 +                        return;
 +                    }
 +
++                    // Finish a pending exit cleanup before allowing browser startup to continue.
++                    Profile pendingProfile = sPendingExitCleanupProfile;
++                    sPendingExitCleanupProfile = null;
++                    if (pendingProfile != null) {
++                        int[] exitDataTypes = getSelectedDataTypes();
++                        if (exitDataTypes.length != 0) {
++                            startBrowsingDataCleanup(pendingProfile, exitDataTypes, NO_SESSION_ID);
++                            return;
++                        }
++                    }
++
 +                    // If the activity is destroyed while waiting for cleanup, invoke its pending
 +                    // callbacks so browser initialization can finish.
 +                    runSessionReadyCallbacks();
@@ -808,52 +1012,37 @@ index 0000000000000..0494b5e9cb543
 +                dataTypes);
 +    }
 +
-+    @VisibleForTesting
 +    static int[] getSelectedDataTypesForTesting() {
 +        return getSelectedDataTypes();
 +    }
 +
 +    private static int[] getSelectedDataTypes() {
-+        int[] dataTypes = new int[DATA_TYPE_COUNT];
++        int[] dataTypes = new int[DATA_TYPE_SELECTIONS.length];
 +        int count = 0;
-+        if (SharedPrefsExt.CLEAR_BROWSING_DATA_ON_EXIT_HISTORY.get()) {
-+            dataTypes[count++] = BrowsingDataType.HISTORY;
-+        }
-+        if (SharedPrefsExt.CLEAR_BROWSING_DATA_ON_EXIT_COOKIES.get()) {
-+            dataTypes[count++] = BrowsingDataType.SITE_DATA;
-+        }
-+        if (SharedPrefsExt.CLEAR_BROWSING_DATA_ON_EXIT_CACHE.get()) {
-+            dataTypes[count++] = BrowsingDataType.CACHE;
-+        }
-+        if (SharedPrefsExt.CLEAR_BROWSING_DATA_ON_EXIT_PASSWORDS.get()) {
-+            dataTypes[count++] = BrowsingDataType.PASSWORDS;
-+        }
-+        if (SharedPrefsExt.CLEAR_BROWSING_DATA_ON_EXIT_FORM_DATA.get()) {
-+            dataTypes[count++] = BrowsingDataType.FORM_DATA;
-+        }
-+        if (SharedPrefsExt.CLEAR_BROWSING_DATA_ON_EXIT_SITE_SETTINGS.get()) {
-+            dataTypes[count++] = BrowsingDataType.SITE_SETTINGS;
++        for (DataTypeSelection selection : DATA_TYPE_SELECTIONS) {
++            if (selection.mPref.get()) {
++                dataTypes[count++] = selection.mDataType;
++            }
 +        }
 +        return Arrays.copyOf(dataTypes, count);
 +    }
 +
 +    private static void clearBrowsingData(Profile profile, Runnable onComplete, int[] dataTypes) {
 +        OnClearBrowsingDataListener listener = onComplete::run;
-+        BrowsingDataBridge.getForProfile(profile).clearBrowsingData(
-+                listener, dataTypes, TimePeriod.ALL_TIME);
++        BrowsingDataBridge.getForProfile(profile)
++                .clearBrowsingData(listener, dataTypes, TimePeriod.ALL_TIME);
 +    }
 +
-+    @VisibleForTesting
 +    static void setBrowsingDataClearerForTesting(BrowsingDataClearer browsingDataClearer) {
 +        sBrowsingDataClearer = browsingDataClearer;
 +        ResettersForTesting.register(ClearBrowsingDataOnExitManager::resetForTesting);
 +    }
 +
-+    @VisibleForTesting
 +    static void resetForTesting() {
 +        sBrowsingDataClearer = DEFAULT_BROWSING_DATA_CLEARER;
 +        sSessionReadyCallbacks.clear();
 +        sSessionProfile = null;
++        sPendingExitCleanupProfile = null;
 +        sRegisteredActivityCount = 0;
 +        sPendingActivityRecreationCount = 0;
 +        sSessionId = 0;
@@ -865,10 +1054,10 @@ index 0000000000000..0494b5e9cb543
 +}
 diff --git a/vanadium/chromium_src/chrome/android/java/src/org/chromium/chrome/browser/privacy/settings/ClearBrowsingDataOnExitSettings.java b/vanadium/chromium_src/chrome/android/java/src/org/chromium/chrome/browser/privacy/settings/ClearBrowsingDataOnExitSettings.java
 new file mode 100644
-index 0000000000000..7f01e356dca3b
+index 0000000000000..a204956adbc39
 --- /dev/null
 +++ b/vanadium/chromium_src/chrome/android/java/src/org/chromium/chrome/browser/privacy/settings/ClearBrowsingDataOnExitSettings.java
-@@ -0,0 +1,65 @@
+@@ -0,0 +1,72 @@
 +// Copyright 2026 GrapheneOS
 +// Use of this source code is governed by a GPL-2.0-only style license that can be
 +// found in the LICENSE file.
@@ -887,6 +1076,7 @@ index 0000000000000..7f01e356dca3b
 +import org.chromium.chrome.R;
 +import org.chromium.chrome.browser.ClearBrowsingDataOnExitManager;
 +import org.chromium.chrome.browser.settings.ChromeBaseSettingsFragment;
++import org.chromium.chrome.browser.settings.search.ChromeBaseSearchIndexProvider;
 +import org.chromium.components.browser_ui.settings.ChromeSwitchPreference;
 +import org.chromium.components.browser_ui.settings.SettingsUtils;
 +
@@ -911,6 +1101,7 @@ index 0000000000000..7f01e356dca3b
 +
 +    private void bindPreference(BoolSharedPref sharedPref) {
 +        ChromeSwitchPreference preference = findPreference(sharedPref.getKey());
++        assert preference != null : "No preference in XML for key " + sharedPref.getKey();
 +        if (preference == null) {
 +            return;
 +        }
@@ -933,6 +1124,11 @@ index 0000000000000..7f01e356dca3b
 +    public int getAnimationType() {
 +        return AnimationType.PROPERTY;
 +    }
++
++    public static final ChromeBaseSearchIndexProvider SEARCH_INDEX_DATA_PROVIDER =
++            new ChromeBaseSearchIndexProvider(
++                    ClearBrowsingDataOnExitSettings.class.getName(),
++                    R.xml.clear_browsing_data_on_exit_preferences);
 +}
 diff --git a/vanadium/chromium_src/chrome/android/java/src/org/chromium/chrome/browser/privacy/settings/PrivacySettingsExt.java b/vanadium/chromium_src/chrome/android/java/src/org/chromium/chrome/browser/privacy/settings/PrivacySettingsExt.java
 index d0711e695b226..8967b9ad96815 100644
@@ -960,12 +1156,219 @@ index d0711e695b226..8967b9ad96815 100644
          ChromeSwitchPreference openLinksInIncognitoPref =
                  (ChromeSwitchPreference) prefFragment.findPreference(PREF_OPEN_LINKS_IN_INCOGNITO);
          if (openLinksInIncognitoPref != null) {
+diff --git a/vanadium/chromium_src/chrome/android/junit/src/app/vanadium/test/NoSigningCertificatePackageManagerShadow.java b/vanadium/chromium_src/chrome/android/junit/src/app/vanadium/test/NoSigningCertificatePackageManagerShadow.java
+new file mode 100644
+index 0000000000000..87641ee602378
+--- /dev/null
++++ b/vanadium/chromium_src/chrome/android/junit/src/app/vanadium/test/NoSigningCertificatePackageManagerShadow.java
+@@ -0,0 +1,19 @@
++// Copyright 2026 GrapheneOS
++// Use of this source code is governed by a GPL-2.0-only style license that can be
++// found in the LICENSE file.
++
++package app.vanadium.test;
++
++import org.robolectric.annotation.Implementation;
++import org.robolectric.annotation.Implements;
++import org.robolectric.shadows.ShadowApplicationPackageManager;
++
++@Implements(className = "android.app.ApplicationPackageManager")
++public final class NoSigningCertificatePackageManagerShadow
++        extends ShadowApplicationPackageManager {
++    @Implementation
++    protected boolean hasSigningCertificate(
++            String packageName, byte[] certificate, int certificateType) {
++        return false;
++    }
++}
+diff --git a/vanadium/chromium_src/chrome/android/junit/src/org/chromium/chrome/browser/ClearBrowsingDataOnExitCustomTabsTest.java b/vanadium/chromium_src/chrome/android/junit/src/org/chromium/chrome/browser/ClearBrowsingDataOnExitCustomTabsTest.java
+new file mode 100644
+index 0000000000000..ecff0296fc86a
+--- /dev/null
++++ b/vanadium/chromium_src/chrome/android/junit/src/org/chromium/chrome/browser/ClearBrowsingDataOnExitCustomTabsTest.java
+@@ -0,0 +1,176 @@
++// Copyright 2026 GrapheneOS
++// Use of this source code is governed by a GPL-2.0-only style license that can be
++// found in the LICENSE file.
++
++package org.chromium.chrome.browser;
++
++import static org.junit.Assert.assertFalse;
++import static org.junit.Assert.assertTrue;
++import static org.mockito.ArgumentMatchers.any;
++import static org.mockito.ArgumentMatchers.anyBoolean;
++import static org.mockito.ArgumentMatchers.anyInt;
++import static org.mockito.ArgumentMatchers.anyString;
++import static org.mockito.Mockito.mock;
++import static org.mockito.Mockito.never;
++import static org.mockito.Mockito.verify;
++import static org.mockito.Mockito.when;
++import static org.robolectric.Shadows.shadowOf;
++
++import android.net.Uri;
++import android.os.Bundle;
++import android.os.Looper;
++
++import androidx.browser.customtabs.CustomTabsService;
++import androidx.browser.customtabs.CustomTabsSessionToken;
++import androidx.browser.customtabs.PrefetchOptions;
++
++import org.junit.After;
++import org.junit.Before;
++import org.junit.Test;
++import org.junit.runner.RunWith;
++import org.robolectric.annotation.Config;
++
++import org.chromium.base.shared_preferences.SharedPrefsUtils.SharedPrefsExt;
++import org.chromium.base.test.BaseRobolectricTestRunner;
++import org.chromium.base.test.util.Features.EnableFeatures;
++import org.chromium.chrome.browser.customtabs.CustomTabsConnection;
++import org.chromium.chrome.browser.flags.ChromeFeatureList;
++import org.chromium.chrome.browser.init.ChromeBrowserInitializer;
++import org.chromium.chrome.browser.profiles.Profile;
++import org.chromium.chrome.browser.profiles.ProfileManager;
++
++import app.vanadium.test.NoSigningCertificatePackageManagerShadow;
++
++import java.util.List;
++
++/** Tests Custom Tab preloading with clear-browsing-data-on-exit enabled. */
++@RunWith(BaseRobolectricTestRunner.class)
++@Config(shadows = NoSigningCertificatePackageManagerShadow.class)
++public final class ClearBrowsingDataOnExitCustomTabsTest {
++    private CustomTabsConnection mConnection;
++    private CustomTabsSessionToken mSession;
++    private WarmupManager mWarmupManager;
++
++    @Before
++    public void setUp() {
++        resetPreferences();
++        ClearBrowsingDataOnExitManager.resetForTesting();
++
++        Profile profile = mock(Profile.class);
++        ProfileManager.setLastUsedProfileForTesting(profile);
++
++        ChromeBrowserInitializer initializer = mock(ChromeBrowserInitializer.class);
++        when(initializer.isFullBrowserInitialized()).thenReturn(true);
++        ChromeBrowserInitializer.setForTesting(initializer);
++
++        mWarmupManager = mock(WarmupManager.class);
++        WarmupManager.setInstanceForTesting(mWarmupManager);
++        WarmupManagerJni.setInstanceForTesting(mock(WarmupManager.Natives.class));
++
++        CustomTabsConnection.setInstanceForTesting(null);
++        CustomTabsConnection.sSkipTabPrewarmingForTesting = true;
++        mConnection = CustomTabsConnection.getInstance();
++        mSession = CustomTabsSessionToken.createMockSessionTokenForTesting();
++        assertTrue(mConnection.newSession(mSession));
++    }
++
++    @After
++    public void tearDown() {
++        CustomTabsConnection.sSkipTabPrewarmingForTesting = false;
++        ClearBrowsingDataOnExitManager.resetForTesting();
++        resetPreferences();
++    }
++
++    @Test
++    public void testCleanupInProgressBlocksPreloadingAfterSelectionIsDisabled() {
++        SharedPrefsExt.CLEAR_BROWSING_DATA_ON_EXIT_HISTORY.putSync(true);
++        ClearBrowsingDataOnExitManager.setBrowsingDataClearerForTesting(
++                (profile, onComplete, dataTypes) -> {});
++        ClearBrowsingDataOnExitManager.onBrowsingActivityCreated();
++        ClearBrowsingDataOnExitManager.prepareForBrowsingSession(mock(Profile.class), () -> {});
++
++        SharedPrefsExt.CLEAR_BROWSING_DATA_ON_EXIT_HISTORY.putSync(false);
++        ClearBrowsingDataOnExitManager.onDataTypePreferenceChanged();
++
++        assertFalse(ClearBrowsingDataOnExitManager.isEnabled());
++        assertTrue(ClearBrowsingDataOnExitManager.shouldBlockCustomTabPreloading());
++        assertFalse(mConnection.warmup());
++        assertFalse(
++                mConnection.mayLaunchUrl(mSession, Uri.parse("https://example.test"), null, null));
++    }
++
++    @Test
++    public void testQueuedMayLaunchUrlRunsWhenCleanupRemainsDisabled() {
++        assertTrue(mConnection.mayLaunchUrl(mSession, null, null, createLikelyUrls()));
++
++        shadowOf(Looper.getMainLooper()).idle();
++
++        verify(mWarmupManager).maybePreconnectUrlAndSubResources(any(Profile.class), anyString());
++    }
++
++    @Test
++    public void testQueuedMayLaunchUrlStopsWhenCleanupIsEnabled() {
++        assertTrue(mConnection.mayLaunchUrl(mSession, null, null, createLikelyUrls()));
++
++        SharedPrefsExt.CLEAR_BROWSING_DATA_ON_EXIT_HISTORY.putSync(true);
++        ClearBrowsingDataOnExitManager.onDataTypePreferenceChanged();
++        shadowOf(Looper.getMainLooper()).idle();
++
++        verify(mWarmupManager, never())
++                .maybePreconnectUrlAndSubResources(any(Profile.class), anyString());
++    }
++
++    @Test
++    @EnableFeatures(ChromeFeatureList.CCT_NAVIGATIONAL_PREFETCH)
++    public void testQueuedPrefetchRunsWhenCleanupRemainsDisabled() {
++        mConnection.prefetch(
++                mSession,
++                List.of(Uri.parse("https://example.test")),
++                new PrefetchOptions.Builder().build());
++
++        shadowOf(Looper.getMainLooper()).idle();
++
++        verify(mWarmupManager).startPrefetchFromCct(anyString(), anyBoolean(), any());
++    }
++
++    @Test
++    @EnableFeatures(ChromeFeatureList.CCT_NAVIGATIONAL_PREFETCH)
++    public void testQueuedPrefetchStopsWhenCleanupIsEnabled() {
++        mConnection.prefetch(
++                mSession,
++                List.of(Uri.parse("https://example.test")),
++                new PrefetchOptions.Builder().build());
++
++        SharedPrefsExt.CLEAR_BROWSING_DATA_ON_EXIT_HISTORY.putSync(true);
++        ClearBrowsingDataOnExitManager.onDataTypePreferenceChanged();
++        shadowOf(Looper.getMainLooper()).idle();
++
++        verify(mWarmupManager, never()).startPrefetchFromCct(anyString(), anyBoolean(), any());
++    }
++
++    @Test
++    public void testDestroyPreloadedTabsCancelsWarmupAndDestroysSpareTab() {
++        assertTrue(mConnection.warmup());
++
++        CustomTabsConnection.destroyPreloadedTabs();
++        shadowOf(Looper.getMainLooper()).idle();
++
++        verify(mWarmupManager).destroySpareTab();
++        verify(mWarmupManager, never()).initializeViewHierarchy(any(), anyInt(), anyInt());
++    }
++
++    private static List<Bundle> createLikelyUrls() {
++        Bundle url = new Bundle();
++        url.putParcelable(CustomTabsService.KEY_URL, Uri.parse("https://example.test"));
++        return List.of(url);
++    }
++
++    private static void resetPreferences() {
++        SharedPrefsExt.CLEAR_BROWSING_DATA_ON_EXIT_HISTORY.putSync(false);
++        SharedPrefsExt.CLEAR_BROWSING_DATA_ON_EXIT_COOKIES.putSync(false);
++        SharedPrefsExt.CLEAR_BROWSING_DATA_ON_EXIT_CACHE.putSync(false);
++        SharedPrefsExt.CLEAR_BROWSING_DATA_ON_EXIT_PASSWORDS.putSync(false);
++        SharedPrefsExt.CLEAR_BROWSING_DATA_ON_EXIT_FORM_DATA.putSync(false);
++        SharedPrefsExt.CLEAR_BROWSING_DATA_ON_EXIT_SITE_SETTINGS.putSync(false);
++    }
++}
 diff --git a/vanadium/chromium_src/chrome/android/junit/src/org/chromium/chrome/browser/ClearBrowsingDataOnExitManagerTest.java b/vanadium/chromium_src/chrome/android/junit/src/org/chromium/chrome/browser/ClearBrowsingDataOnExitManagerTest.java
 new file mode 100644
-index 0000000000000..0e0ad35420b20
+index 0000000000000..ebc7d7e64863e
 --- /dev/null
 +++ b/vanadium/chromium_src/chrome/android/junit/src/org/chromium/chrome/browser/ClearBrowsingDataOnExitManagerTest.java
-@@ -0,0 +1,343 @@
+@@ -0,0 +1,482 @@
 +// Copyright 2026 GrapheneOS
 +// Use of this source code is governed by a GPL-2.0-only style license that can be
 +// found in the LICENSE file.
@@ -987,6 +1390,7 @@ index 0000000000000..0e0ad35420b20
 +import org.robolectric.annotation.Config;
 +
 +import org.chromium.base.ContextUtils;
++import org.chromium.base.shared_preferences.SharedPrefsUtils.BoolSharedPref;
 +import org.chromium.base.shared_preferences.SharedPrefsUtils.SharedPrefsExt;
 +import org.chromium.chrome.browser.browsing_data.BrowsingDataType;
 +import org.chromium.chrome.browser.profiles.Profile;
@@ -1000,16 +1404,16 @@ index 0000000000000..0e0ad35420b20
 +@Config(manifest = Config.NONE)
 +public final class ClearBrowsingDataOnExitManagerTest {
 +    private static final class PendingClearRequest {
-+        final int[] dataTypes;
-+        final Runnable completionCallback;
++        final int[] mDataTypes;
++        final Runnable mCompletionCallback;
 +
 +        PendingClearRequest(int[] dataTypes, Runnable completionCallback) {
-+            this.dataTypes = Arrays.copyOf(dataTypes, dataTypes.length);
-+            this.completionCallback = completionCallback;
++            mDataTypes = Arrays.copyOf(dataTypes, dataTypes.length);
++            mCompletionCallback = completionCallback;
 +        }
 +
 +        void complete() {
-+            completionCallback.run();
++            mCompletionCallback.run();
 +        }
 +    }
 +
@@ -1037,8 +1441,7 @@ index 0000000000000..0e0ad35420b20
 +        ClearBrowsingDataOnExitManager.prepareForBrowsingSession(mProfile, () -> ready[0] = true);
 +
 +        assertTrue(ready[0]);
-+        ClearBrowsingDataOnExitManager.onBrowsingActivityDestroyed(
-+                /* activityFinishing= */ true);
++        ClearBrowsingDataOnExitManager.onBrowsingActivityDestroyed(/* activityFinishing= */ true);
 +        assertTrue(mClearRequests.isEmpty());
 +    }
 +
@@ -1051,9 +1454,14 @@ index 0000000000000..0e0ad35420b20
 +        SharedPrefsExt.CLEAR_BROWSING_DATA_ON_EXIT_FORM_DATA.put(true);
 +        SharedPrefsExt.CLEAR_BROWSING_DATA_ON_EXIT_SITE_SETTINGS.put(true);
 +
-+        int[] expected = {BrowsingDataType.HISTORY, BrowsingDataType.SITE_DATA,
-+                BrowsingDataType.CACHE, BrowsingDataType.PASSWORDS, BrowsingDataType.FORM_DATA,
-+                BrowsingDataType.SITE_SETTINGS};
++        int[] expected = {
++            BrowsingDataType.HISTORY,
++            BrowsingDataType.SITE_DATA,
++            BrowsingDataType.CACHE,
++            BrowsingDataType.PASSWORDS,
++            BrowsingDataType.FORM_DATA,
++            BrowsingDataType.SITE_SETTINGS
++        };
 +        assertArrayEquals(
 +                expected, ClearBrowsingDataOnExitManager.getSelectedDataTypesForTesting());
 +    }
@@ -1068,6 +1476,23 @@ index 0000000000000..0e0ad35420b20
 +    }
 +
 +    @Test
++    public void testEachSelectionIndependentlySelectsItsDataType() {
++        assertSingleSelection(
++                SharedPrefsExt.CLEAR_BROWSING_DATA_ON_EXIT_HISTORY, BrowsingDataType.HISTORY);
++        assertSingleSelection(
++                SharedPrefsExt.CLEAR_BROWSING_DATA_ON_EXIT_COOKIES, BrowsingDataType.SITE_DATA);
++        assertSingleSelection(
++                SharedPrefsExt.CLEAR_BROWSING_DATA_ON_EXIT_CACHE, BrowsingDataType.CACHE);
++        assertSingleSelection(
++                SharedPrefsExt.CLEAR_BROWSING_DATA_ON_EXIT_PASSWORDS, BrowsingDataType.PASSWORDS);
++        assertSingleSelection(
++                SharedPrefsExt.CLEAR_BROWSING_DATA_ON_EXIT_FORM_DATA, BrowsingDataType.FORM_DATA);
++        assertSingleSelection(
++                SharedPrefsExt.CLEAR_BROWSING_DATA_ON_EXIT_SITE_SETTINGS,
++                BrowsingDataType.SITE_SETTINGS);
++    }
++
++    @Test
 +    public void testStartupCleanupBlocksUntilCompletion() {
 +        SharedPrefsExt.CLEAR_BROWSING_DATA_ON_EXIT_HISTORY.put(true);
 +        boolean[] ready = {false};
@@ -1077,12 +1502,11 @@ index 0000000000000..0e0ad35420b20
 +
 +        assertEquals(1, mClearRequests.size());
 +        assertFalse(ready[0]);
-+        assertArrayEquals(new int[] {BrowsingDataType.HISTORY}, mClearRequests.get(0).dataTypes);
++        assertArrayEquals(new int[] {BrowsingDataType.HISTORY}, mClearRequests.get(0).mDataTypes);
 +        mClearRequests.get(0).complete();
 +        assertTrue(ready[0]);
 +
-+        ClearBrowsingDataOnExitManager.onBrowsingActivityDestroyed(
-+                /* activityFinishing= */ true);
++        ClearBrowsingDataOnExitManager.onBrowsingActivityDestroyed(/* activityFinishing= */ true);
 +        assertEquals(2, mClearRequests.size());
 +    }
 +
@@ -1091,8 +1515,7 @@ index 0000000000000..0e0ad35420b20
 +        SharedPrefsExt.CLEAR_BROWSING_DATA_ON_EXIT_CACHE.put(true);
 +        startSessionAndCompleteStartupCleanup();
 +
-+        ClearBrowsingDataOnExitManager.onBrowsingActivityDestroyed(
-+                /* activityFinishing= */ true);
++        ClearBrowsingDataOnExitManager.onBrowsingActivityDestroyed(/* activityFinishing= */ true);
 +        assertEquals(2, mClearRequests.size());
 +        mClearRequests.get(1).complete();
 +
@@ -1108,8 +1531,7 @@ index 0000000000000..0e0ad35420b20
 +        SharedPrefsExt.CLEAR_BROWSING_DATA_ON_EXIT_CACHE.put(true);
 +        startSessionAndCompleteStartupCleanup();
 +
-+        ClearBrowsingDataOnExitManager.onBrowsingActivityDestroyed(
-+                /* activityFinishing= */ false);
++        ClearBrowsingDataOnExitManager.onBrowsingActivityDestroyed(/* activityFinishing= */ false);
 +        assertEquals(1, mClearRequests.size());
 +
 +        boolean[] replacementReady = {false};
@@ -1117,8 +1539,7 @@ index 0000000000000..0e0ad35420b20
 +        ClearBrowsingDataOnExitManager.prepareForBrowsingSession(
 +                mProfile, () -> replacementReady[0] = true);
 +        assertTrue(replacementReady[0]);
-+        ClearBrowsingDataOnExitManager.onBrowsingActivityDestroyed(
-+                /* activityFinishing= */ true);
++        ClearBrowsingDataOnExitManager.onBrowsingActivityDestroyed(/* activityFinishing= */ true);
 +        assertEquals(2, mClearRequests.size());
 +    }
 +
@@ -1138,12 +1559,10 @@ index 0000000000000..0e0ad35420b20
 +        mClearRequests.get(0).complete();
 +        assertTrue(ready[0]);
 +        assertTrue(ready[1]);
-+        ClearBrowsingDataOnExitManager.onBrowsingActivityDestroyed(
-+                /* activityFinishing= */ true);
++        ClearBrowsingDataOnExitManager.onBrowsingActivityDestroyed(/* activityFinishing= */ true);
 +        assertEquals(1, mClearRequests.size());
 +
-+        ClearBrowsingDataOnExitManager.onBrowsingActivityDestroyed(
-+                /* activityFinishing= */ true);
++        ClearBrowsingDataOnExitManager.onBrowsingActivityDestroyed(/* activityFinishing= */ true);
 +        assertEquals(2, mClearRequests.size());
 +    }
 +
@@ -1153,15 +1572,13 @@ index 0000000000000..0e0ad35420b20
 +        startSessionAndCompleteStartupCleanup();
 +        ClearBrowsingDataOnExitManager.onBrowsingActivityCreated();
 +
-+        ClearBrowsingDataOnExitManager.onBrowsingActivityDestroyed(
-+                /* activityFinishing= */ true);
++        ClearBrowsingDataOnExitManager.onBrowsingActivityDestroyed(/* activityFinishing= */ true);
 +        assertEquals(1, mClearRequests.size());
 +
 +        boolean[] ready = {false};
 +        ClearBrowsingDataOnExitManager.prepareForBrowsingSession(mProfile, () -> ready[0] = true);
 +        assertTrue(ready[0]);
-+        ClearBrowsingDataOnExitManager.onBrowsingActivityDestroyed(
-+                /* activityFinishing= */ true);
++        ClearBrowsingDataOnExitManager.onBrowsingActivityDestroyed(/* activityFinishing= */ true);
 +        assertEquals(2, mClearRequests.size());
 +    }
 +
@@ -1178,10 +1595,8 @@ index 0000000000000..0e0ad35420b20
 +        assertTrue(ready[0]);
 +        assertTrue(ready[1]);
 +
-+        ClearBrowsingDataOnExitManager.onBrowsingActivityDestroyed(
-+                /* activityFinishing= */ false);
-+        ClearBrowsingDataOnExitManager.onBrowsingActivityDestroyed(
-+                /* activityFinishing= */ true);
++        ClearBrowsingDataOnExitManager.onBrowsingActivityDestroyed(/* activityFinishing= */ false);
++        ClearBrowsingDataOnExitManager.onBrowsingActivityDestroyed(/* activityFinishing= */ true);
 +        assertEquals(1, mClearRequests.size());
 +
 +        boolean[] replacementReady = {false};
@@ -1189,8 +1604,7 @@ index 0000000000000..0e0ad35420b20
 +        ClearBrowsingDataOnExitManager.prepareForBrowsingSession(
 +                mProfile, () -> replacementReady[0] = true);
 +        assertTrue(replacementReady[0]);
-+        ClearBrowsingDataOnExitManager.onBrowsingActivityDestroyed(
-+                /* activityFinishing= */ true);
++        ClearBrowsingDataOnExitManager.onBrowsingActivityDestroyed(/* activityFinishing= */ true);
 +        assertEquals(2, mClearRequests.size());
 +    }
 +
@@ -1198,8 +1612,7 @@ index 0000000000000..0e0ad35420b20
 +    public void testNewSessionRunsFreshCleanupAfterInFlightExitCleanup() {
 +        SharedPrefsExt.CLEAR_BROWSING_DATA_ON_EXIT_PASSWORDS.put(true);
 +        startSessionAndCompleteStartupCleanup();
-+        ClearBrowsingDataOnExitManager.onBrowsingActivityDestroyed(
-+                /* activityFinishing= */ true);
++        ClearBrowsingDataOnExitManager.onBrowsingActivityDestroyed(/* activityFinishing= */ true);
 +        assertEquals(2, mClearRequests.size());
 +
 +        boolean[] ready = {false};
@@ -1211,7 +1624,7 @@ index 0000000000000..0e0ad35420b20
 +        mClearRequests.get(1).complete();
 +        assertEquals(3, mClearRequests.size());
 +        assertFalse(ready[0]);
-+        assertArrayEquals(new int[] {BrowsingDataType.PASSWORDS}, mClearRequests.get(2).dataTypes);
++        assertArrayEquals(new int[] {BrowsingDataType.PASSWORDS}, mClearRequests.get(2).mDataTypes);
 +        mClearRequests.get(2).complete();
 +        assertTrue(ready[0]);
 +    }
@@ -1223,7 +1636,7 @@ index 0000000000000..0e0ad35420b20
 +
 +        ClearBrowsingDataOnExitManager.onBrowsingActivityCreated();
 +        ClearBrowsingDataOnExitManager.prepareForBrowsingSession(mProfile, () -> ready[0] = true);
-+        assertArrayEquals(new int[] {BrowsingDataType.HISTORY}, mClearRequests.get(0).dataTypes);
++        assertArrayEquals(new int[] {BrowsingDataType.HISTORY}, mClearRequests.get(0).mDataTypes);
 +
 +        SharedPrefsExt.CLEAR_BROWSING_DATA_ON_EXIT_CACHE.put(true);
 +        ClearBrowsingDataOnExitManager.onDataTypePreferenceChanged();
@@ -1233,30 +1646,32 @@ index 0000000000000..0e0ad35420b20
 +
 +        assertEquals(2, mClearRequests.size());
 +        assertFalse(ready[0]);
-+        assertArrayEquals(new int[] {BrowsingDataType.CACHE}, mClearRequests.get(1).dataTypes);
++        assertArrayEquals(new int[] {BrowsingDataType.CACHE}, mClearRequests.get(1).mDataTypes);
 +        mClearRequests.get(1).complete();
 +        assertTrue(ready[0]);
 +    }
 +
 +    @Test
-+    public void testDestroyedActivityStillRunsQueuedStartupCallback() {
++    public void testDestroyedActivityRunsQueuedStartupCallbackAfterExitCleanup() {
 +        SharedPrefsExt.CLEAR_BROWSING_DATA_ON_EXIT_SITE_SETTINGS.put(true);
 +        boolean[] ready = {false};
 +
 +        ClearBrowsingDataOnExitManager.onBrowsingActivityCreated();
 +        ClearBrowsingDataOnExitManager.prepareForBrowsingSession(mProfile, () -> ready[0] = true);
-+        ClearBrowsingDataOnExitManager.onBrowsingActivityDestroyed(
-+                /* activityFinishing= */ true);
++        ClearBrowsingDataOnExitManager.onBrowsingActivityDestroyed(/* activityFinishing= */ true);
 +        assertFalse(ready[0]);
 +
 +        mClearRequests.get(0).complete();
++        assertFalse(ready[0]);
++        assertEquals(2, mClearRequests.size());
++        mClearRequests.get(1).complete();
 +        assertTrue(ready[0]);
 +
 +        boolean[] nextReady = {false};
 +        ClearBrowsingDataOnExitManager.onBrowsingActivityCreated();
 +        ClearBrowsingDataOnExitManager.prepareForBrowsingSession(
 +                mProfile, () -> nextReady[0] = true);
-+        assertEquals(2, mClearRequests.size());
++        assertEquals(3, mClearRequests.size());
 +        assertFalse(nextReady[0]);
 +    }
 +
@@ -1264,8 +1679,7 @@ index 0000000000000..0e0ad35420b20
 +    public void testDisablingSelectionWaitsForInFlightCleanup() {
 +        SharedPrefsExt.CLEAR_BROWSING_DATA_ON_EXIT_FORM_DATA.put(true);
 +        startSessionAndCompleteStartupCleanup();
-+        ClearBrowsingDataOnExitManager.onBrowsingActivityDestroyed(
-+                /* activityFinishing= */ true);
++        ClearBrowsingDataOnExitManager.onBrowsingActivityDestroyed(/* activityFinishing= */ true);
 +
 +        SharedPrefsExt.CLEAR_BROWSING_DATA_ON_EXIT_FORM_DATA.put(false);
 +        ClearBrowsingDataOnExitManager.onDataTypePreferenceChanged();
@@ -1279,9 +1693,127 @@ index 0000000000000..0e0ad35420b20
 +        assertTrue(ready[0]);
 +        assertEquals(2, mClearRequests.size());
 +        assertFalse(ClearBrowsingDataOnExitManager.shouldBlockCustomTabPreloading());
-+        ClearBrowsingDataOnExitManager.onBrowsingActivityDestroyed(
-+                /* activityFinishing= */ true);
++        ClearBrowsingDataOnExitManager.onBrowsingActivityDestroyed(/* activityFinishing= */ true);
 +        assertEquals(2, mClearRequests.size());
++    }
++
++    @Test
++    public void testDeferredExitCleanupUsesUpdatedSelections() {
++        SharedPrefsExt.CLEAR_BROWSING_DATA_ON_EXIT_HISTORY.put(true);
++        boolean[] ready = {false};
++
++        ClearBrowsingDataOnExitManager.onBrowsingActivityCreated();
++        ClearBrowsingDataOnExitManager.prepareForBrowsingSession(mProfile, () -> ready[0] = true);
++        assertEquals(1, mClearRequests.size());
++
++        ClearBrowsingDataOnExitManager.onBrowsingActivityDestroyed(/* activityFinishing= */ true);
++        assertEquals(1, mClearRequests.size());
++
++        SharedPrefsExt.CLEAR_BROWSING_DATA_ON_EXIT_HISTORY.put(false);
++        SharedPrefsExt.CLEAR_BROWSING_DATA_ON_EXIT_CACHE.put(true);
++        mClearRequests.get(0).complete();
++
++        assertFalse(ready[0]);
++        assertEquals(2, mClearRequests.size());
++        assertArrayEquals(new int[] {BrowsingDataType.CACHE}, mClearRequests.get(1).mDataTypes);
++        mClearRequests.get(1).complete();
++        assertTrue(ready[0]);
++    }
++
++    @Test
++    public void testDeferredExitCleanupSkippedWhenSelectionsCleared() {
++        SharedPrefsExt.CLEAR_BROWSING_DATA_ON_EXIT_HISTORY.put(true);
++        boolean[] ready = {false};
++
++        ClearBrowsingDataOnExitManager.onBrowsingActivityCreated();
++        ClearBrowsingDataOnExitManager.prepareForBrowsingSession(mProfile, () -> ready[0] = true);
++        ClearBrowsingDataOnExitManager.onBrowsingActivityDestroyed(/* activityFinishing= */ true);
++
++        SharedPrefsExt.CLEAR_BROWSING_DATA_ON_EXIT_HISTORY.put(false);
++        mClearRequests.get(0).complete();
++
++        assertTrue(ready[0]);
++        assertEquals(1, mClearRequests.size());
++    }
++
++    @Test
++    public void testNewSessionReplacesDeferredExitCleanup() {
++        SharedPrefsExt.CLEAR_BROWSING_DATA_ON_EXIT_HISTORY.put(true);
++        boolean[] readyA = {false};
++        boolean[] readyB = {false};
++
++        ClearBrowsingDataOnExitManager.onBrowsingActivityCreated();
++        ClearBrowsingDataOnExitManager.prepareForBrowsingSession(mProfile, () -> readyA[0] = true);
++        ClearBrowsingDataOnExitManager.onBrowsingActivityDestroyed(/* activityFinishing= */ true);
++
++        ClearBrowsingDataOnExitManager.onBrowsingActivityCreated();
++        ClearBrowsingDataOnExitManager.prepareForBrowsingSession(mProfile, () -> readyB[0] = true);
++        assertEquals(1, mClearRequests.size());
++
++        mClearRequests.get(0).complete();
++        assertEquals(2, mClearRequests.size());
++        assertFalse(readyB[0]);
++
++        mClearRequests.get(1).complete();
++        assertTrue(readyB[0]);
++        assertEquals(2, mClearRequests.size());
++    }
++
++    @Test
++    public void testMultiplePendingExitsUseSingleCleanup() {
++        SharedPrefsExt.CLEAR_BROWSING_DATA_ON_EXIT_HISTORY.put(true);
++        boolean[] readyB = {false};
++        boolean[] readyC = {false};
++
++        startSessionAndCompleteStartupCleanup();
++        ClearBrowsingDataOnExitManager.onBrowsingActivityDestroyed(/* activityFinishing= */ true);
++        assertEquals(2, mClearRequests.size());
++
++        ClearBrowsingDataOnExitManager.onBrowsingActivityCreated();
++        ClearBrowsingDataOnExitManager.prepareForBrowsingSession(mProfile, () -> readyB[0] = true);
++        ClearBrowsingDataOnExitManager.onBrowsingActivityDestroyed(/* activityFinishing= */ true);
++        ClearBrowsingDataOnExitManager.onBrowsingActivityCreated();
++        ClearBrowsingDataOnExitManager.prepareForBrowsingSession(mProfile, () -> readyC[0] = true);
++        ClearBrowsingDataOnExitManager.onBrowsingActivityDestroyed(/* activityFinishing= */ true);
++        assertEquals(2, mClearRequests.size());
++
++        mClearRequests.get(1).complete();
++        assertFalse(readyB[0]);
++        assertFalse(readyC[0]);
++        assertEquals(3, mClearRequests.size());
++        assertArrayEquals(new int[] {BrowsingDataType.HISTORY}, mClearRequests.get(2).mDataTypes);
++        mClearRequests.get(2).complete();
++        assertTrue(readyB[0]);
++        assertTrue(readyC[0]);
++    }
++
++    @Test
++    public void testStartupBlockedUntilDeferredExitAndStartupCleanupFinish() {
++        SharedPrefsExt.CLEAR_BROWSING_DATA_ON_EXIT_HISTORY.put(true);
++        boolean[] readyA = {false};
++        boolean[] readyB = {false};
++
++        ClearBrowsingDataOnExitManager.onBrowsingActivityCreated();
++        ClearBrowsingDataOnExitManager.prepareForBrowsingSession(mProfile, () -> readyA[0] = true);
++        ClearBrowsingDataOnExitManager.onBrowsingActivityDestroyed(/* activityFinishing= */ true);
++
++        mClearRequests.get(0).complete();
++        assertFalse(readyA[0]);
++        assertEquals(2, mClearRequests.size());
++
++        ClearBrowsingDataOnExitManager.onBrowsingActivityCreated();
++        ClearBrowsingDataOnExitManager.prepareForBrowsingSession(mProfile, () -> readyB[0] = true);
++        assertFalse(readyB[0]);
++        assertEquals(2, mClearRequests.size());
++
++        mClearRequests.get(1).complete();
++        assertFalse(readyA[0]);
++        assertFalse(readyB[0]);
++        assertEquals(3, mClearRequests.size());
++
++        mClearRequests.get(2).complete();
++        assertTrue(readyA[0]);
++        assertTrue(readyB[0]);
 +    }
 +
 +    private void startSessionAndCompleteStartupCleanup() {
@@ -1293,6 +1825,16 @@ index 0000000000000..0e0ad35420b20
 +        assertFalse(ready[0]);
 +        mClearRequests.get(requestIndex).complete();
 +        assertTrue(ready[0]);
++    }
++
++    private static void assertSingleSelection(BoolSharedPref pref, int dataType) {
++        resetPreferences();
++        assertFalse(ClearBrowsingDataOnExitManager.isEnabled());
++        pref.put(true);
++        assertTrue(ClearBrowsingDataOnExitManager.isEnabled());
++        assertArrayEquals(
++                new int[] {dataType},
++                ClearBrowsingDataOnExitManager.getSelectedDataTypesForTesting());
 +    }
 +
 +    private void recordClearRequest(Profile profile, Runnable onComplete, int[] dataTypes) {
@@ -1307,6 +1849,277 @@ index 0000000000000..0e0ad35420b20
 +        SharedPrefsExt.CLEAR_BROWSING_DATA_ON_EXIT_PASSWORDS.putSync(false);
 +        SharedPrefsExt.CLEAR_BROWSING_DATA_ON_EXIT_FORM_DATA.putSync(false);
 +        SharedPrefsExt.CLEAR_BROWSING_DATA_ON_EXIT_SITE_SETTINGS.putSync(false);
++    }
++}
+diff --git a/vanadium/chromium_src/chrome/android/junit/src/org/chromium/chrome/browser/browsing_data/ClearBrowsingDataOnExitBridgeTest.java b/vanadium/chromium_src/chrome/android/junit/src/org/chromium/chrome/browser/browsing_data/ClearBrowsingDataOnExitBridgeTest.java
+new file mode 100644
+index 0000000000000..d853a99f04fa4
+--- /dev/null
++++ b/vanadium/chromium_src/chrome/android/junit/src/org/chromium/chrome/browser/browsing_data/ClearBrowsingDataOnExitBridgeTest.java
+@@ -0,0 +1,110 @@
++// Copyright 2026 GrapheneOS
++// Use of this source code is governed by a GPL-2.0-only style license that can be
++// found in the LICENSE file.
++
++package org.chromium.chrome.browser.browsing_data;
++
++import static org.junit.Assert.assertArrayEquals;
++import static org.junit.Assert.assertEquals;
++import static org.junit.Assert.assertTrue;
++import static org.mockito.ArgumentMatchers.any;
++import static org.mockito.ArgumentMatchers.anyInt;
++import static org.mockito.Mockito.doAnswer;
++import static org.mockito.Mockito.mock;
++import static org.mockito.Mockito.times;
++import static org.mockito.Mockito.verify;
++
++import org.junit.After;
++import org.junit.Before;
++import org.junit.Test;
++import org.junit.runner.RunWith;
++import org.mockito.ArgumentCaptor;
++import org.robolectric.annotation.Config;
++
++import org.chromium.base.shared_preferences.SharedPrefsUtils.SharedPrefsExt;
++import org.chromium.base.test.BaseRobolectricTestRunner;
++import org.chromium.chrome.browser.ClearBrowsingDataOnExitManager;
++import org.chromium.chrome.browser.profiles.Profile;
++
++import app.vanadium.test.NoSigningCertificatePackageManagerShadow;
++
++/** Tests the deletion request sent by clear-browsing-data-on-exit. */
++@RunWith(BaseRobolectricTestRunner.class)
++@Config(manifest = Config.NONE, shadows = NoSigningCertificatePackageManagerShadow.class)
++public final class ClearBrowsingDataOnExitBridgeTest {
++    private BrowsingDataBridge.Natives mBrowsingDataBridge;
++    private Profile mProfile;
++
++    @Before
++    public void setUp() {
++        resetPreferences();
++        mProfile = mock(Profile.class);
++        mBrowsingDataBridge = mock(BrowsingDataBridge.Natives.class);
++        BrowsingDataBridgeJni.setInstanceForTesting(mBrowsingDataBridge);
++        doAnswer(
++                        invocation -> {
++                            BrowsingDataBridge.OnClearBrowsingDataListener listener =
++                                    invocation.getArgument(1);
++                            listener.onBrowsingDataCleared();
++                            return null;
++                        })
++                .when(mBrowsingDataBridge)
++                .clearBrowsingData(any(), any(), any(), anyInt(), any(), any());
++    }
++
++    @After
++    public void tearDown() {
++        resetPreferences();
++    }
++
++    @Test
++    public void testSelectedDataTypesAreClearedForAllTime() {
++        SharedPrefsExt.CLEAR_BROWSING_DATA_ON_EXIT_HISTORY.putSync(true);
++        SharedPrefsExt.CLEAR_BROWSING_DATA_ON_EXIT_CACHE.putSync(true);
++        SharedPrefsExt.CLEAR_BROWSING_DATA_ON_EXIT_SITE_SETTINGS.putSync(true);
++        boolean[] ready = {false};
++
++        ClearBrowsingDataOnExitManager.onBrowsingActivityCreated();
++        ClearBrowsingDataOnExitManager.prepareForBrowsingSession(mProfile, () -> ready[0] = true);
++        assertTrue(ready[0]);
++        ClearBrowsingDataOnExitManager.onBrowsingActivityDestroyed(/* activityFinishing= */ true);
++
++        ArgumentCaptor<int[]> dataTypes = ArgumentCaptor.forClass(int[].class);
++        ArgumentCaptor<Integer> timePeriod = ArgumentCaptor.forClass(Integer.class);
++        ArgumentCaptor<String[]> excludedDomains = ArgumentCaptor.forClass(String[].class);
++        ArgumentCaptor<String[]> ignoredDomains = ArgumentCaptor.forClass(String[].class);
++        verify(mBrowsingDataBridge, times(2))
++                .clearBrowsingData(
++                        any(),
++                        any(),
++                        dataTypes.capture(),
++                        timePeriod.capture(),
++                        excludedDomains.capture(),
++                        ignoredDomains.capture());
++
++        int[] expectedDataTypes = {
++            BrowsingDataType.HISTORY, BrowsingDataType.CACHE, BrowsingDataType.SITE_SETTINGS
++        };
++        for (int[] actualDataTypes : dataTypes.getAllValues()) {
++            assertArrayEquals(expectedDataTypes, actualDataTypes);
++        }
++        for (int actualTimePeriod : timePeriod.getAllValues()) {
++            assertEquals(TimePeriod.ALL_TIME, actualTimePeriod);
++        }
++        for (String[] actualExcludedDomains : excludedDomains.getAllValues()) {
++            assertArrayEquals(new String[0], actualExcludedDomains);
++        }
++        for (String[] actualIgnoredDomains : ignoredDomains.getAllValues()) {
++            assertArrayEquals(new String[0], actualIgnoredDomains);
++        }
++    }
++
++    private static void resetPreferences() {
++        SharedPrefsExt.CLEAR_BROWSING_DATA_ON_EXIT_HISTORY.putSync(false);
++        SharedPrefsExt.CLEAR_BROWSING_DATA_ON_EXIT_COOKIES.putSync(false);
++        SharedPrefsExt.CLEAR_BROWSING_DATA_ON_EXIT_CACHE.putSync(false);
++        SharedPrefsExt.CLEAR_BROWSING_DATA_ON_EXIT_PASSWORDS.putSync(false);
++        SharedPrefsExt.CLEAR_BROWSING_DATA_ON_EXIT_FORM_DATA.putSync(false);
++        SharedPrefsExt.CLEAR_BROWSING_DATA_ON_EXIT_SITE_SETTINGS.putSync(false);
++    }
++}
+diff --git a/vanadium/chromium_src/chrome/android/junit/src/org/chromium/chrome/browser/privacy/settings/ClearBrowsingDataOnExitSettingsTest.java b/vanadium/chromium_src/chrome/android/junit/src/org/chromium/chrome/browser/privacy/settings/ClearBrowsingDataOnExitSettingsTest.java
+new file mode 100644
+index 0000000000000..3db024c3b93d6
+--- /dev/null
++++ b/vanadium/chromium_src/chrome/android/junit/src/org/chromium/chrome/browser/privacy/settings/ClearBrowsingDataOnExitSettingsTest.java
+@@ -0,0 +1,149 @@
++// Copyright 2026 GrapheneOS
++// Use of this source code is governed by a GPL-2.0-only style license that can be
++// found in the LICENSE file.
++
++package org.chromium.chrome.browser.privacy.settings;
++
++import static org.junit.Assert.assertEquals;
++import static org.junit.Assert.assertFalse;
++import static org.junit.Assert.assertNotNull;
++import static org.junit.Assert.assertTrue;
++import static org.mockito.ArgumentMatchers.any;
++import static org.mockito.Mockito.mock;
++import static org.mockito.Mockito.when;
++
++import android.os.Bundle;
++
++import androidx.fragment.app.testing.FragmentScenario;
++import androidx.preference.Preference;
++import androidx.preference.PreferenceFragmentCompat;
++
++import org.junit.After;
++import org.junit.Before;
++import org.junit.Test;
++import org.junit.runner.RunWith;
++import org.robolectric.annotation.Config;
++
++import org.chromium.base.shared_preferences.SharedPrefsUtils.BoolSharedPref;
++import org.chromium.base.shared_preferences.SharedPrefsUtils.SharedPrefsExt;
++import org.chromium.base.test.BaseRobolectricTestRunner;
++import org.chromium.chrome.R;
++import org.chromium.chrome.browser.WarmupManager;
++import org.chromium.chrome.browser.profiles.Profile;
++import org.chromium.components.browser_ui.settings.ChromeSwitchPreference;
++import org.chromium.components.prefs.PrefService;
++import org.chromium.components.user_prefs.UserPrefs;
++import org.chromium.components.user_prefs.UserPrefsJni;
++
++import app.vanadium.test.NoSigningCertificatePackageManagerShadow;
++
++/** Tests for {@link ClearBrowsingDataOnExitSettings}. */
++@RunWith(BaseRobolectricTestRunner.class)
++@Config(shadows = NoSigningCertificatePackageManagerShadow.class)
++public final class ClearBrowsingDataOnExitSettingsTest {
++    private static final String CLEAR_BROWSING_DATA_ON_EXIT = "clear_browsing_data_on_exit";
++    private static final BoolSharedPref[] DATA_TYPE_PREFERENCES = {
++        SharedPrefsExt.CLEAR_BROWSING_DATA_ON_EXIT_HISTORY,
++        SharedPrefsExt.CLEAR_BROWSING_DATA_ON_EXIT_COOKIES,
++        SharedPrefsExt.CLEAR_BROWSING_DATA_ON_EXIT_CACHE,
++        SharedPrefsExt.CLEAR_BROWSING_DATA_ON_EXIT_PASSWORDS,
++        SharedPrefsExt.CLEAR_BROWSING_DATA_ON_EXIT_FORM_DATA,
++        SharedPrefsExt.CLEAR_BROWSING_DATA_ON_EXIT_SITE_SETTINGS,
++    };
++
++    private FragmentScenario<ClearBrowsingDataOnExitSettings> mSettingsScenario;
++    private FragmentScenario<TestPrivacySettingsFragment> mPrivacyScenario;
++
++    @Before
++    public void setUp() {
++        resetPreferences();
++        WarmupManager.setInstanceForTesting(mock(WarmupManager.class));
++        UserPrefs.Natives userPrefsJni = mock(UserPrefs.Natives.class);
++        when(userPrefsJni.get(any())).thenReturn(mock(PrefService.class));
++        UserPrefsJni.setInstanceForTesting(userPrefsJni);
++    }
++
++    @After
++    public void tearDown() {
++        if (mSettingsScenario != null) mSettingsScenario.close();
++        if (mPrivacyScenario != null) mPrivacyScenario.close();
++        resetPreferences();
++    }
++
++    @Test
++    public void testAllSwitchesSaveAndRestoreTheirValues() {
++        launchSettings();
++        mSettingsScenario.onFragment(
++                fragment -> {
++                    for (BoolSharedPref sharedPref : DATA_TYPE_PREFERENCES) {
++                        ChromeSwitchPreference preference =
++                                fragment.findPreference(sharedPref.getKey());
++                        assertNotNull(preference);
++                        assertFalse(preference.isChecked());
++
++                        preference.performClick();
++
++                        assertTrue(preference.isChecked());
++                        assertTrue(sharedPref.get());
++                    }
++                });
++
++        mSettingsScenario.recreate();
++
++        mSettingsScenario.onFragment(
++                fragment -> {
++                    for (BoolSharedPref sharedPref : DATA_TYPE_PREFERENCES) {
++                        ChromeSwitchPreference preference =
++                                fragment.findPreference(sharedPref.getKey());
++                        assertNotNull(preference);
++                        assertTrue(preference.isChecked());
++
++                        preference.performClick();
++
++                        assertFalse(preference.isChecked());
++                        assertFalse(sharedPref.get());
++                    }
++                });
++    }
++
++    @Test
++    public void testPrivacySettingsEntryOpensClearOnExitSettings() {
++        mPrivacyScenario =
++                FragmentScenario.launchInContainer(
++                        TestPrivacySettingsFragment.class,
++                        Bundle.EMPTY,
++                        R.style.Theme_Chromium_Settings);
++
++        mPrivacyScenario.onFragment(
++                fragment -> {
++                    Preference preference = fragment.findPreference(CLEAR_BROWSING_DATA_ON_EXIT);
++                    assertNotNull(preference);
++                    assertEquals(
++                            ClearBrowsingDataOnExitSettings.class.getName(),
++                            preference.getFragment());
++                    assertEquals(6, preference.getOrder());
++                });
++    }
++
++    private void launchSettings() {
++        mSettingsScenario =
++                FragmentScenario.launchInContainer(
++                        ClearBrowsingDataOnExitSettings.class,
++                        Bundle.EMPTY,
++                        R.style.Theme_Chromium_Settings);
++    }
++
++    private static void resetPreferences() {
++        for (BoolSharedPref preference : DATA_TYPE_PREFERENCES) {
++            preference.putSync(false);
++        }
++    }
++
++    public static final class TestPrivacySettingsFragment extends PreferenceFragmentCompat {
++        @Override
++        public void onCreatePreferences(Bundle savedInstanceState, String rootKey) {
++            setPreferenceScreen(getPreferenceManager().createPreferenceScreen(requireContext()));
++            PrivacySettingsExt.initializePreferences(this, mock(Profile.class));
++        }
 +    }
 +}
 diff --git a/vanadium/chromium_src/chrome/browser/ui/android/strings/android_chrome_ext_strings.grdp b/vanadium/chromium_src/chrome/browser/ui/android/strings/android_chrome_ext_strings.grdp


### PR DESCRIPTION
Closes #966

Adds independent automatic cleanup options for browsing history, site data, cache, passwords, form data, and site settings.

The selected data is cleared when the last browser activity finishes and before browsing can begin the next time Vanadium is opened. The startup cleanup covers cases where Android terminated the previous process before exit cleanup could run. Only one cleanup runs at a time. Custom Tab page preloading remains blocked while any cleanup option is selected or a cleanup is still running, preventing preloaded pages from overlapping cleanup.

To be clear, pressing Home or switching apps does not count as closing Vanadium