### PR TITLE
temporarily disable javaless renderers due to original-package not handling manifest properties

### DIFF
--- a/args.gn
+++ b/args.gn
@@ -49,8 +49,8 @@ trichrome_library_package = "app.vanadium.trichromelibrary"
 
 config_apk_package = "app.vanadium.config"
 config_apk_certdigest = "c6adb8b83c6d4c17d292afde56fd488a51d316ff8f2c11c5410223bff8a7dbb3"
-config_apk_version_name = "191"
-config_apk_version_code = "191"
+config_apk_version_name = "192"
+config_apk_version_code = "192"
 config_apk_is_debug = false
 
 # Explicitly disable static analysis as intended for official builds.

--- a/patches/0285-tmp-Disable-javaless-browser-renderers.patch
+++ b/patches/0285-tmp-Disable-javaless-browser-renderers.patch
@@ -1,0 +1,29 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: inthewaves <inthewaves@pm.me>
+Date: Sat, 18 Jul 2026 13:48:25 -0700
+Subject: [PATCH] [tmp] Disable javaless browser renderers
+
+Vanadium installations migrated through original-package use org.chromium.chrome as their effective
+package name, while native service manifest properties remain under app.vanadium.browser. Native
+renderer startup then fails to find PROPERTY_NATIVE_SERVICE_LIBRARY_NAME and falls back to
+libmain.so.
+
+Force javaless-renderers off for browser processes. A future GrapheneOS version needs to fix
+original-package handling for manifest properties before this can be enabled again.
+---
+ .../java/src/app/vanadium/config/host/ConfigGeneratorImpl.kt    | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/vanadium/android_config/proto/host/java/src/app/vanadium/config/host/ConfigGeneratorImpl.kt b/vanadium/android_config/proto/host/java/src/app/vanadium/config/host/ConfigGeneratorImpl.kt
+index 2c27242573dac..06dfa8fba6a1f 100644
+--- a/vanadium/android_config/proto/host/java/src/app/vanadium/config/host/ConfigGeneratorImpl.kt
++++ b/vanadium/android_config/proto/host/java/src/app/vanadium/config/host/ConfigGeneratorImpl.kt
+@@ -391,7 +391,7 @@ private fun configs(): Configs {
+         addAllFlags(flags(
+             flag {
+                 setFlagName("javaless-renderers")
+-                addFlagValue("enable")
++                addFlagValue("disable")
+                 setFlagType(FlagType.ENABLED_SWITCH)
+             },
+         ))


### PR DESCRIPTION
Vanadium installations migrated through original-package use org.chromium.chrome as their effective
package name, while native service manifest properties remain under app.vanadium.browser. Native
renderer startup then fails to find PROPERTY_NATIVE_SERVICE_LIBRARY_NAME and falls back to
libmain.so.

Force javaless-renderers off for browser processes. A future GrapheneOS version needs to fix
original-package handling for manifest properties before this can be enabled again (https://github.com/GrapheneOS/platform_frameworks_base/pull/411). Then the config
update to restore it should required that version as a minimum.